### PR TITLE
fix doc for arm64 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Install generate libs and setup rust targets & toolchains
 
 Build release
 
-    make release-arm
+    make release-arm64
     # or for x86, use
     make release-x86
 


### PR DESCRIPTION
*Description of changes:*
One-liner change in the README.md as the `release-arm` is not a valid target in the current `Makefile`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
