### PR TITLE
doc; fix make command

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ Install generate libs and setup rust targets & toolchains
 Build release for Lambda
 
     make release-arm64
-    # or for x86, use
-    make release-x86
+    # or for x86-64, use
+    make release-x64
 
 Optionally build for your local machine (Mac or Linux)
 


### PR DESCRIPTION
The command "make release-x86" does not build

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
