### PR TITLE
Fix Buffer.from base64 when padding is missing

### DIFF
--- a/src/encoding/encoder.rs
+++ b/src/encoding/encoder.rs
@@ -97,9 +97,7 @@ pub fn bytes_to_b64_string(bytes: &[u8]) -> String {
 }
 
 pub fn bytes_from_b64(bytes: &[u8]) -> Result<Vec<u8>, String> {
-    base64_simd::STANDARD
-        .decode_to_vec(bytes)
-        .map_err(|e| e.to_string())
+    base64_simd::forgiving_decode_to_vec(bytes).map_err(|e| e.to_string())
 }
 
 pub fn bytes_to_b64(bytes: &[u8]) -> Vec<u8> {

--- a/tests/buffer.test.ts
+++ b/tests/buffer.test.ts
@@ -87,13 +87,7 @@ describe("Buffer.from", () => {
     const input2 = "SGVsbG8sIHdvcmxkIQ";
     const buffer2 = Buffer.from(input2, "base64");
     assert.strictEqual(buffer2.toString(), "Hello, world!");
-
-    const input3 = "SGVsbG8sIHdvcmxkIQ=";
-    const buffer3 = Buffer.from(input3, "base64");
-    assert.strictEqual(buffer3.toString(), "Hello, world!");
   });
-
-  it("should create a buffer from a string with forgiving base64 encoding", () => {});
 
   it("should create a buffer from a string with hex encoding", () => {
     const input = "48656c6c6f2c20776f726c6421";

--- a/tests/buffer.test.ts
+++ b/tests/buffer.test.ts
@@ -83,7 +83,17 @@ describe("Buffer.from", () => {
     const buffer = Buffer.from(input, "base64");
 
     assert.strictEqual(buffer.toString(), "Hello, world!");
+
+    const input2 = "SGVsbG8sIHdvcmxkIQ";
+    const buffer2 = Buffer.from(input2, "base64");
+    assert.strictEqual(buffer2.toString(), "Hello, world!");
+
+    const input3 = "SGVsbG8sIHdvcmxkIQ=";
+    const buffer3 = Buffer.from(input3, "base64");
+    assert.strictEqual(buffer3.toString(), "Hello, world!");
   });
+
+  it("should create a buffer from a string with forgiving base64 encoding", () => {});
 
   it("should create a buffer from a string with hex encoding", () => {
     const input = "48656c6c6f2c20776f726c6421";


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/llrt/issues/116

*Description of changes:*
Changes b64 decoding to forgiving mode that ignores missing padding.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
