### PR TITLE
Add missing apostrophe in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Choose `Custom Runtime on Amazon Linux 2023` and package the LLRT `bootstrap` bi
 
 Choose `Custom Runtime on Amazon Linux 2023`, upload `llrt-lambda-arm64.zip` or `llrt-lambda-x86.zip` as a layer and add to your function
 
-Thats it 🎉
+That's it 🎉
 
 > [!IMPORTANT]
 > Even though LLRT supports [ES2020](https://262.ecma-international.org/11.0/) it's **NOT** a drop in replacement for Node.js. Consult [Compatibility matrix](#compatibility-matrix) and [API](API.md) for more details.


### PR DESCRIPTION
*Description of changes:* I saw a missing apostrophe in the README while looking through (`llrt` looks very cool!), thought I'd open a quick PR to fix it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
