### PR TITLE
[docs] - Add benchmark methodology section to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It's built in Rust, utilizing QuickJS as JavaScript engine, ensuring efficient m
 
 <sub>Node.js 20 - [DynamoDB Put, ARM, 128MB](example/functions/src/v3-lib.mjs):<sub>
 ![DynamoDB Put Node20](./benchmarks/node20-ddb-put.png "Node20 DynamoDB Put")
+
 Benchmarks measured in **round trip time** for a cold start ([why?](#benchmark-methodology))
 
 ## Configure Lambda functions to use LLRT

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It's built in Rust, utilizing QuickJS as JavaScript engine, ensuring efficient m
 
 <sub>Node.js 20 - [DynamoDB Put, ARM, 128MB](example/functions/src/v3-lib.mjs):<sub>
 ![DynamoDB Put Node20](./benchmarks/node20-ddb-put.png "Node20 DynamoDB Put")
+Benchmarks measured in **round trip time** for a cold start ([why?](#benchmark-methodology))
 
 ## Configure Lambda functions to use LLRT
 
@@ -272,6 +273,9 @@ Start the `lambda-server.js` in a separate terminal
 Then run llrt:
 
     make run
+
+## Benchmark Methodology
+Although Init Duration [reported by Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) is commonly used to understand cold start impact on overall request latency, this metric does not include the time needed to copy code into the Lambda sandbox.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ The technical definition of Init Duration ([source](https://docs.aws.amazon.com/
 
 Measuring round-trip request duration provides a more complete picture of user facing cold-start latency.
 
+Lambda invocation results (λ-labeled row) report the sum total of Init Duration + Function Duration.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's built in Rust, utilizing QuickJS as JavaScript engine, ensuring efficient m
 <sub>Node.js 20 - [DynamoDB Put, ARM, 128MB](example/functions/src/v3-lib.mjs):<sub>
 ![DynamoDB Put Node20](./benchmarks/node20-ddb-put.png "Node20 DynamoDB Put")
 
-Benchmarks measured in **round trip time** for a cold start ([why?](#benchmark-methodology))
+HTTP benchmarks measured in **round trip time** for a cold start ([why?](#benchmark-methodology))
 
 ## Configure Lambda functions to use LLRT
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,13 @@ Then run llrt:
     make run
 
 ## Benchmark Methodology
-Although Init Duration [reported by Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) is commonly used to understand cold start impact on overall request latency, this metric does not include the time needed to copy code into the Lambda sandbox.
+Although Init Duration [reported by Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) is commonly used to understand cold start impact on overall request latency, this metric does not include the time needed to copy code into the Lambda sandbox. 
+
+The technical definition of Init Duration is:
+> For the first request served, the amount of time it took the runtime to load the function and run code outside of the handler method.
+[source](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html#node-logging-output)
+
+Measuring round-trip request duration provides a more complete picture of user facing cold-start latency.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -278,9 +278,8 @@ Then run llrt:
 ## Benchmark Methodology
 Although Init Duration [reported by Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) is commonly used to understand cold start impact on overall request latency, this metric does not include the time needed to copy code into the Lambda sandbox. 
 
-The technical definition of Init Duration is:
+The technical definition of Init Duration is ([source](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html#node-logging-output)):
 > For the first request served, the amount of time it took the runtime to load the function and run code outside of the handler method.
-[source](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html#node-logging-output)
 
 Measuring round-trip request duration provides a more complete picture of user facing cold-start latency.
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Then run llrt:
 ## Benchmark Methodology
 Although Init Duration [reported by Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) is commonly used to understand cold start impact on overall request latency, this metric does not include the time needed to copy code into the Lambda sandbox. 
 
-The technical definition of Init Duration is ([source](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html#node-logging-output)):
+The technical definition of Init Duration ([source](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html#node-logging-output)):
 > For the first request served, the amount of time it took the runtime to load the function and run code outside of the handler method.
 
 Measuring round-trip request duration provides a more complete picture of user facing cold-start latency.


### PR DESCRIPTION
*Description of changes:*
When I first received access to this project I was very pleased to see that the benchmarks measured round-trip request latency for a given cold start.

I don't believe this is common knowledge (as it surprised a number of folks when I [spoke about it at re:Invent](https://www.youtube.com/watch?t=1421&v=2EDNcPvR45w&feature=youtu.be)), so I believe a short description is helpful.

>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

I agree!