### PR TITLE
define process.versions

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -61,6 +61,8 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     let globals = ctx.globals();
 
     let process = Object::new(ctx.clone())?;
+    let process_versions = Object::new(ctx.clone())?;
+    process_versions.set("llrt", VERSION)?;
 
     let release = Object::new(ctx.clone())?;
     release.prop("name", Property::from("llrt").enumerable())?;
@@ -95,6 +97,7 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     process.set("hrtime", hr_time)?;
     process.set("release", release)?;
     process.set("version", VERSION)?;
+    process.set("versions", process_versions)?;
     process.set("exit", Func::from(exit))?;
 
     globals.set("process", process)?;


### PR DESCRIPTION
*Fixes #126*

*Description of changes:*
Defines process.versions on the process global. Some nodejs packages (e.g. [pg-promise](https://github.com/vitaly-t/pg-promise/blob/master/lib/index.js#L11)) rely on it for feature detection.

My first ever rust pr. I looked into how to expose the quickjs & turbo version, but I'm afraid I don't understand the ecosystem well enough.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


