### PR TITLE
Fix SDK stream read

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ LLRT can work with any bundler of your choice. Below are some configurations for
 
 ### ESBuild
 
-    esbuild index.js --platform=node --target=es2020 --format=esm --bundle --minify --external:@aws-sdk --external:uuid
+    esbuild index.js --platform=node --target=es2020 --format=esm --bundle --minify --external:@aws-sdk --external:@smithy --external:uuid
 
 ### Rollup
 
@@ -110,7 +110,7 @@ export default {
     commonjs(),
     terser(), 
   ],
-  external: ["@aws-sdk","uuid"],
+  external: ["@aws-sdk","@smithy","uuid"],
 };
 ```
 
@@ -132,7 +132,7 @@ export default {
   resolve: {
     extensions: ['.js'],
   },
-  externals: [nodeExternals(),"@aws-sdk","uuid"],
+  externals: [nodeExternals(),"@aws-sdk","@smithy","uuid"],
   optimization: {
     minimize: true,
     minimizer: [
@@ -150,30 +150,38 @@ export default {
 ## Using AWS SDK (v3) with LLRT
 
 LLRT includes many AWS SDK clients and utils as part of the runtime, built into the executable. These SDK Clients have been specifically fine-tuned to offer best performance while not compromising on compatibility. LLRT replaces some JavaScript dependencies used by the AWS SDK by native ones such as Hash calculations and XML parsing.
-V3 SDK packages not included in the list below have to be bundled with your source code while marking the following packages as external.
+V3 SDK packages not included in the list below have to be bundled with your source code while marking the following packages as external:
 
-**Bundled AWS SDK packages:**
+| Bundled AWS SDK packages             |
+| ------------------------------------- |
+| @aws-sdk/client-dynamodb              |
+| @aws-sdk/lib-dynamodb                 |
+| @aws-sdk/client-kms                   |
+| @aws-sdk/client-lambda                |
+| @aws-sdk/client-s3                    |
+| @aws-sdk/client-secrets-manager       |
+| @aws-sdk/client-ses                   |
+| @aws-sdk/client-sns                   |
+| @aws-sdk/client-sqs                   |
+| @aws-sdk/client-sts                   |
+| @aws-sdk/client-ssm                   |
+| @aws-sdk/client-cloudwatch-logs       |
+| @aws-sdk/client-cloudwatch-events     |
+| @aws-sdk/client-eventbridge           |
+| @aws-sdk/client-sfn                   |
+| @aws-sdk/client-xray                  |
+| @aws-sdk/client-cognito-identity      |
+| @aws-sdk/util-dynamodb                |
+| @aws-sdk/credential-providers         |
+| @smithy                               |
 
-* @aws-sdk/client-dynamodb
-* @aws-sdk/lib-dynamodb
-* @aws-sdk/client-kms
-* @aws-sdk/client-lambda
-* @aws-sdk/client-s3
-* @aws-sdk/client-secrets-manager
-* @aws-sdk/client-ses
-* @aws-sdk/client-sns
-* @aws-sdk/client-sqs
-* @aws-sdk/client-sts
-* @aws-sdk/client-ssm
-* @aws-sdk/client-cloudwatch-logs
-* @aws-sdk/client-cloudwatch-events
-* @aws-sdk/client-eventbridge
-* @aws-sdk/client-sfn
-* @aws-sdk/client-xray
-* @aws-sdk/client-cognito-identity
-* @aws-sdk/util-dynamodb
-* @aws-sdk/credential-providers
-* @smithy/signature-v4
+> [!IMPORTANT] 
+> LLRT currently does not support returning streams from SDK responses. Use `response.Body.transformToString();` or `response.Body.transformToByteArray();` as shown below.
+> ```javascript
+>const response = await client.send(command);
+>// or 'transformToByteArray()'
+>const str = await response.Body.transformToString();
+>```
 
 ## Running TypeScript with LLRT
 

--- a/build.mjs
+++ b/build.mjs
@@ -90,9 +90,6 @@ Object.keys(SDK_DATA).forEach((sdk) => {
   CLIENTS_BY_SDK[sdk] = clientName;
 });
 
-const camelToSnakeCase = (str) =>
-  str.replace(/[A-Z]/g, (letter) => `_${letter}`).toUpperCase();
-
 function runtimeConfigWrapper(config) {
   if (!config.credentials) {
     config.credentials = {
@@ -433,6 +430,7 @@ async function loadShims() {
     loadShim(/@smithy\/util-base64/, "util-base64.js"),
     loadShim(/@aws-crypto/, "aws-crypto.js"),
     loadShim(/mnemonist\/lru-cache\.js/, "lru-cache.js"),
+    loadShim(/sdk-stream-mixin.browser.js/, "sdk-stream-mixin.js"),
   ]);
 }
 

--- a/shims/sdk-stream-mixin.js
+++ b/shims/sdk-stream-mixin.js
@@ -1,0 +1,27 @@
+import { toBase64 } from "@smithy/util-base64";
+import { toHex } from "@smithy/util-hex-encoding";
+import { toUtf8 } from "@smithy/util-utf8";
+
+const transformToWebStream = () => {
+  throw new Error("WebStream is not available for LLRT");
+};
+
+async function transformToByteArray() {
+  return this;
+}
+
+async function transformToString(encoding) {
+  if (encoding === "base64") {
+    return toBase64(this);
+  } else if (encoding === "hex") {
+    return toHex(this);
+  }
+  return toUtf8(this);
+}
+
+export const sdkStreamMixin = (stream) =>
+  Object.assign(stream, {
+    transformToByteArray,
+    transformToString,
+    transformToWebStream,
+  });


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/llrt/issues/142

*Description of changes:*
Blob & Readable stream interface is not (yet) available for `fetch` responses. This PR returns the underlying TypedArray directly for reads from the SDK.

> [!IMPORTANT] 
> Stream reads form the SDK have to use the helper functions `response.Body.transformToString` or `response.Body.ransformToByteArray()`
> ```javascript
>const response = await client.send(command);
>// or 'transformToByteArray()'
>const str = await response.Body.transformToString();
>```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
