### PR TITLE
switch hrtime bigint to use as_nanos instead of as_micros

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -37,11 +37,11 @@ pub fn get_platform() -> &'static str {
     platform
 }
 
-fn current_time_micros() -> u64 {
+fn current_time_nanos() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_micros() as u64
+        .as_nanos() as u64
 }
 
 fn exit(code: i32) {
@@ -68,7 +68,7 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     release.prop("name", Property::from("llrt").enumerable())?;
 
     let hr_time = Object::new(ctx.clone())?;
-    hr_time.set("bigint", Func::from(current_time_micros))?;
+    hr_time.set("bigint", Func::from(current_time_nanos))?;
 
     let env_map: HashMap<String, String> = env::vars().collect();
     let mut args: Vec<String> = env::args().collect();


### PR DESCRIPTION


*Issue #, if available:*
#150
*Description of changes:*
Switches hrtime to use nanoseconds instead of microseconds
refactor function signature to reflect changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
