### PR TITLE
Update license section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,4 +299,4 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 ## License
 
-This library is licensed under the MIT-0 License. See the  [LICENSE](LICENSE) file.
+This library is licensed under the Apache-2.0 License. See the [LICENSE](LICENSE) file.


### PR DESCRIPTION
This section still refers to MIT-0, while it seems the current license is now Apache-2.0.