### PR TITLE
Fix process hr-time-res

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -132,6 +132,7 @@ fn stringify_primitive<'js>(
             Type::Undefined => result.push_str(COLOR_BLACK),
             Type::Int | Type::Float | Type::Bool => result.push_str(COLOR_YELLOW),
             Type::Symbol => result.push_str(COLOR_GREEN),
+            Type::BigInt => result.push_str(COLOR_YELLOW),
             _ => has_color = false,
         }
     }
@@ -144,6 +145,12 @@ fn stringify_primitive<'js>(
         } else {
             "false"
         }),
+        Type::BigInt => {
+            let mut buffer = itoa::Buffer::new();
+            let big_int = value.as_big_int().unwrap();
+            result.push_str(buffer.format(big_int.clone().to_i64()?));
+            result.push('n');
+        }
         Type::Int => {
             let mut buffer = itoa::Buffer::new();
             result.push_str(buffer.format(value.as_int().unwrap()))
@@ -194,6 +201,7 @@ fn is_primitive_like_or_void(typeof_value: Type) -> bool {
             | Type::Int
             | Type::Float
             | Type::String
+            | Type::BigInt
             | Type::Symbol
             | Type::Unknown
     )

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -143,7 +143,7 @@ impl StringBuilder {
     }
 }
 
-pub fn atob<'js>(ctx: Ctx<'js>, encoded_value: String) -> Result<String> {
+pub fn atob(ctx: Ctx<'_>, encoded_value: String) -> Result<String> {
     let vec = bytes_from_b64(encoded_value.as_bytes()).or_throw(&ctx)?;
     Ok(unsafe { String::from_utf8_unchecked(vec) })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,9 @@ mod xml;
 use minimal_tracer::MinimalTracer;
 use rquickjs::{AsyncContext, Module};
 use std::{
-    env::{self},
+    env,
     error::Error,
+    mem::MaybeUninit,
     path::{Path, PathBuf},
     process::exit,
     sync::atomic::Ordering,
@@ -59,12 +60,16 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
+pub static mut STARTED: MaybeUninit<Instant> = MaybeUninit::uninit();
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let now = Instant::now();
+
+    unsafe { STARTED.write(Instant::now()) };
+
     MinimalTracer::register()?;
     trace!("Started runtime");
-
-    let now = Instant::now();
 
     let vm = Vm::new().await?;
     trace!("Initialized VM in {}ms", now.elapsed().as_millis());


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/llrt/issues/150

*Description of changes:*
This will return higher resolution to the `process.hrtime.bigint()`. The "time basis" from node is slightly different where node uses an offset from a previous value (that seems to be inited from uptime) where as LLRT uses an start offset from startup time of the program. This change does not effect the behavior of timers as they are not based from unix epoch and should have nanosecond precision.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
