### PR TITLE
Remove duplicate module definition

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -87,7 +87,6 @@ macro_rules! create_modules {
 
 create_modules!(
     "crypto" => CryptoModule,
-    "uuid" => UuidModule,
     "hex" => HexModule,
     "fs/promises" => FsPromisesModule,
     "os" => OsModule,


### PR DESCRIPTION
I noticed duplicated `uuid` module definition

- removed the first occurrence of `uuid` module definition


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
