### PR TITLE
Add Dockerfile and docker-compose.yml for LLRT SAM application

### DIFF
--- a/example/llrt-sam/Dockerfile
+++ b/example/llrt-sam/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18 as build
+WORKDIR /llrt/example/llrt-sam
+
+# install aws sam
+RUN <<EOF
+apt-get update
+apt install wget
+wget https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip
+unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
+./sam-installation/install
+EOF
+
+COPY . .
+
+RUN <<EOF
+wget -P ../../ https://github.com/awslabs/llrt/releases/download/v0.1.6-beta/llrt-lambda-arm64.zip
+npm install -g esbuild
+sam build
+#sam deploy --guided
+EOF

--- a/example/llrt-sam/docker-compose.yml
+++ b/example/llrt-sam/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  llrm-build:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    image: llrm-image:latest
+    container_name: llrm-build-container
+    volumes:
+      - /home/tomita/.aws:/root/.aws


### PR DESCRIPTION

*Issue #, if available:*
Docker was included in the required README.md, but there was no Dockerfile, so I created a Dockerfile and docker-compose.yml to facilitate deployment to the aws lambda.

```shell
docker buildx bake
docker run -it llrm-build -it "/bin/bash"
sam deploy --guided
```

*Description of changes:*
add example/llrt-sam/Dockerfile and example/llrt-sam/docker-compose.yml


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
