### PR TITLE
add constructor to response struct 

### DIFF
--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -7,6 +7,8 @@ use hyper::body::{Bytes, Incoming};
 use rquickjs::{
     class::{Trace, Tracer},
     Class, Ctx, Exception, IntoJs, Result, TypedArray, Value,
+    Object,
+    function::Opt
 };
 use tracing::trace;
 
@@ -72,6 +74,23 @@ pub struct Response<'js> {
 
 #[rquickjs::methods(rename_all = "camelCase")]
 impl<'js> Response<'js> {
+    #[qjs(constructor)]
+    pub fn new(ctx: Ctx<'js>, options: Opt<Object<'js>>) -> Result<Self> {
+        let response: Response<'js> = Response {
+            data: ResponseData {
+                method: "GET".to_string(),
+                url: "".to_string(),
+                start: Instant::now(),
+                status: hyper::StatusCode::OK,
+                response: None,
+                headers: Class::instance(ctx, Headers::default())?,
+            }
+        };
+
+
+        Ok(response)
+    }
+
     #[qjs(get)]
     pub fn status(&self) -> u64 {
         self.data.status.as_u16().into()


### PR DESCRIPTION
*Issue #, if available:*
#168

*Description of changes:*
Adds a simple constructor for the Response struct. I was not able to find the reference class in nodejs github. Please let me know if I need to refactor the default values or function signature. Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
