### PR TITLE
Update Step Functions service endpoint from sfn to states

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -63,7 +63,7 @@ const SDK_DATA = {
   "client-cloudwatch-logs": ["CloudWatchLogs", "logs"],
   "client-cloudwatch-events": ["CloudWatchEvents", "events"],
   "client-eventbridge": ["EventBridge", "events"],
-  "client-sfn": ["SFN", "sfn"],
+  "client-sfn": ["SFN", "states"],
   "client-xray": ["XRay", "xray"],
   "client-cognito-identity": ["CognitoIdentity", "cognito-idp"],
 };


### PR DESCRIPTION
When importing the `SFNClient` from `@aws-sdk/client-sfn`, the runtime will throw an error: `client error (Connect)`.

This was occurring because the `addAwsSdkInitTask` function in the bootstrap was trying to connect to
`https://sfn.<region>.amazonaws.com` rather than `https://states.<region>.amazonaws.com`.

This change updates the service endpoint subdomain from `sfn` to `states`.