### PR TITLE
Crypto.randomBytes returns a Buffer

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -15,6 +15,7 @@ use rquickjs::{
 };
 
 use crate::{
+    buffer::Buffer,
     encoding::encoder::{bytes_to_b64_string, bytes_to_hex_string},
     module::export_default,
     utils::{
@@ -58,9 +59,7 @@ pub fn random_byte_array(length: usize) -> Vec<u8> {
 
 fn get_random_bytes(ctx: Ctx, length: usize) -> Result<Value> {
     let random_bytes = random_byte_array(length);
-
-    let array_buffer = TypedArray::new(ctx.clone(), random_bytes)?;
-    array_buffer.into_js(&ctx)
+    Buffer(random_bytes).into_js(&ctx)
 }
 
 fn random_fill<'js>(ctx: Ctx<'js>, obj: Object<'js>, args: Rest<Value<'js>>) -> Result<()> {

--- a/tests/crypto.test.ts
+++ b/tests/crypto.test.ts
@@ -77,4 +77,10 @@ describe("random", () => {
       /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
     assert.match(uuid, uuidRegex);
   });
+
+  it("should generate a random bytes buffer using randomBytes", () => {
+    const buffer = crypto.randomBytes(16);
+    assert(buffer instanceof Buffer);
+    assert.strictEqual(buffer.length, 16);
+  });
 });


### PR DESCRIPTION
*Issue #, if available:*
closes #177 

*Description of changes:*
I just stumbled upon this issue so let me try fix this 🙏 

I'm still not sure how should I validate the entire build, but at least I confirmed `crypto.randomBytes` returns a buffer locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
