### PR TITLE
Fix custom toJSON object JSON serialization.

### DIFF
--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -55,7 +55,7 @@ mod tests {
     #[tokio::test]
     async fn json_stringify_objects() {
         with_runtime(|ctx| {
-            let date: Value = ctx.eval("new Date(0)")?;
+            let date: Value = ctx.eval("let obj = { date: new Date(0) };obj;")?;
             let stringified = json_stringify(&ctx, date.clone())?.unwrap();
             let stringified_2 = ctx.json_stringify(date)?.unwrap().to_string()?;
             assert_eq!(stringified, stringified_2);

--- a/src/json/stringify.rs
+++ b/src/json/stringify.rs
@@ -125,7 +125,7 @@ fn run_to_json<'js>(
             value: &val,
             depth: context.depth,
             indentation: context.indentation,
-            key: context.key,
+            key: None,
             index: None,
             parent: Some(js_object),
             ancestors: context.ancestors,


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/awslabs/llrt/issues/183

*Description of changes:*
JSON serialization was switched from QuickJS built in to a custom implementation in 0.1.4. This yielded a 2x performance gain. A bug caused the key of any object with a `toJSON()` method to be written twice when present in a parent object.
This PR fixes the issue by removing the parent key from the serialization context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
