### PR TITLE
keys and forEach method for Headers

### DIFF
--- a/src/http/headers.rs
+++ b/src/http/headers.rs
@@ -83,13 +83,9 @@ impl Headers {
         self.js_iterator(ctx)
     }
 
-    pub fn for_each<'js>(&self, ctx: Ctx<'js>, callback: Function<'js>) -> Result<()> {
+    pub fn for_each<'js>(&self, callback: Function<'js>) -> Result<()> {
         for header in self.headers.iter() {
-            callback.call((
-                header.1,
-                header.0,
-                Class::<Headers>::instance(ctx.clone(), self.clone()),
-            ))?
+            callback.call((header.1, header.0))?
         }
         Ok(())
     }

--- a/src/http/headers.rs
+++ b/src/http/headers.rs
@@ -4,7 +4,8 @@ use std::collections::BTreeMap;
 
 use hyper::HeaderMap;
 use rquickjs::{
-    atom::PredefinedAtom, methods, prelude::Opt, Array, Coerced, Ctx, FromJs, Result, Value,
+    atom::PredefinedAtom, methods, prelude::Opt, Array, Class, Coerced, Ctx, FromJs, Function,
+    Result, Value,
 };
 
 use crate::utils::{
@@ -21,7 +22,7 @@ pub struct Headers {
     headers: BTreeMap<String, String>,
 }
 
-#[methods]
+#[methods(rename_all = "camelCase")]
 impl Headers {
     #[qjs(constructor)]
     pub fn new<'js>(ctx: Ctx<'js>, init: Opt<Value<'js>>) -> Result<Self> {
@@ -65,6 +66,10 @@ impl Headers {
         self.headers.remove(&key.to_lowercase());
     }
 
+    pub fn keys(&mut self) -> Vec<String> {
+        self.headers.keys().cloned().collect::<Vec<String>>()
+    }
+
     pub fn values(&mut self) -> Vec<String> {
         self.headers.values().cloned().collect::<Vec<String>>()
     }
@@ -76,6 +81,17 @@ impl Headers {
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
     pub fn iterator<'js>(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         self.js_iterator(ctx)
+    }
+
+    pub fn for_each<'js>(&self, ctx: Ctx<'js>, callback: Function<'js>) -> Result<()> {
+        for header in self.headers.iter() {
+            callback.call((
+                header.1,
+                header.0,
+                Class::<Headers>::instance(ctx.clone(), self.clone()),
+            ))?
+        }
+        Ok(())
     }
 }
 

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -41,6 +41,17 @@ describe("Headers", () => {
     next = iterator.next();
     assert.deepStrictEqual(next.value, undefined);
   });
+
+  it("should iterate over the headers with forEach", () => {
+    const headers = {
+      "content-type": "application/json",
+    };
+    const h = new Headers(headers);
+    h.forEach((value, key) => {
+      assert.deepStrictEqual(key, "content-type");
+      assert.deepStrictEqual(value, "application/json");
+    });
+  });
 });
 
 describe("Request", () => {


### PR DESCRIPTION
*Issue #, if available:*
closes #186 

*Description of changes:*

I omitted [forEach's third argument `object`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/forEach) for now because i'm not sure how to efficiently pass Headers object in each loop (without cloning btreemap), and also it's rarely used anyway.

I add [`keys` method](https://developer.mozilla.org/en-US/docs/Web/API/Headers/keys) as it was also missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
