### PR TITLE
Fix S3 object read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,1 @@
-* JSON.stringify bugfix for custom objects with `toJSON()` method
-* Increase WHATWG/WinterCG `Fetch` compatibility:
-  * Add `Blob`
-  * Make `Request` and `Response` instantiable from global scope
-  * Add missing properties
-* Update dependencies
-* Minor bugfixes
+* Fix S3 Object Read

--- a/shims/sdk-stream-mixin.js
+++ b/shims/sdk-stream-mixin.js
@@ -20,10 +20,9 @@ async function transformToString(encoding) {
   return toUtf8(typedArray);
 }
 
-export const sdkStreamMixin = (stream) => {
-  return Object.assign(stream, {
+export const sdkStreamMixin = (stream) =>
+  Object.assign(stream, {
     transformToByteArray,
     transformToString,
     transformToWebStream,
   });
-};

--- a/shims/sdk-stream-mixin.js
+++ b/shims/sdk-stream-mixin.js
@@ -7,21 +7,23 @@ const transformToWebStream = () => {
 };
 
 async function transformToByteArray() {
-  return this;
+  return await this.typedArray();
 }
 
 async function transformToString(encoding) {
+  const typedArray = await this.typedArray();
   if (encoding === "base64") {
-    return toBase64(this);
+    return toBase64(typedArray);
   } else if (encoding === "hex") {
-    return toHex(this);
+    return toHex(typedArray);
   }
-  return toUtf8(this);
+  return toUtf8(typedArray);
 }
 
-export const sdkStreamMixin = (stream) =>
-  Object.assign(stream, {
+export const sdkStreamMixin = (stream) => {
+  return Object.assign(stream, {
     transformToByteArray,
     transformToString,
     transformToWebStream,
   });
+};


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/awslabs/llrt/issues/191

*Description of changes:*
Regression in S3 was introduced when returning fetch body as an object. This PR fixes that by returning `typedArray` from body

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
