### PR TITLE
Update README.md - cmake is required for make release

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Install rust
 Install dependencies
 
     # MacOS
-    brew install zig make zstd node corepack
+    brew install zig make cmake zstd node corepack
 
     # Ubuntu
     sudo apt -y install make zstd


### PR DESCRIPTION
On m1 Mac running `make release` fails on first attempt if user does not have `cmake` installed.

```
error: failed to run custom build command for `snmalloc-sys v0.3.4`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
