### PR TITLE
Change speling to is_directory

### DIFF
--- a/src/fs/read_dir.rs
+++ b/src/fs/read_dir.rs
@@ -21,7 +21,7 @@ impl Dirent {
     pub fn is_file(&self) -> bool {
         self.metadata.is_file()
     }
-    pub fn is_dir(&self) -> bool {
+    pub fn is_directory(&self) -> bool {
         self.metadata.is_dir()
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/awslabs/llrt/issues/198

*Description of changes:*
Should be named `isDirectory`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
