### PR TITLE
Extract environment and set connection pool idle timeout to 15s

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,0 +1,10 @@
+//network
+pub const ENV_LLRT_NET_ALLOW: &str = "LLRT_NET_ALLOW";
+pub const ENV_LLRT_NET_DENY: &str = "LLRT_NET_DENY";
+pub const ENV_LLRT_NET_POOL_IDLE_TIMEOUT: &str = "LLRT_NET_POOL_IDLE_TIMEOUT";
+
+//log
+pub const ENV_LLRT_LOG: &str = "LLRT_LOG";
+
+//vm
+pub const ENV_LLRT_GC_THRESHOLD_MB: &str = "LLRT_GC_THRESHOLD_MB";

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod compiler_common;
 mod console;
 mod crypto;
 mod encoding;
+mod environment;
 mod events;
 mod fs;
 mod http;

--- a/src/minimal_tracer.rs
+++ b/src/minimal_tracer.rs
@@ -11,6 +11,8 @@ use chrono::{DateTime, Utc};
 use tracing::{field::Visit, Id, Level, Subscriber};
 use tracing_core::{span, Field};
 
+use crate::environment;
+
 pub struct StringVisitor<'a> {
     string: &'a mut String,
 }
@@ -55,7 +57,7 @@ impl MinimalTracer {
     pub fn register() -> Result<(), tracing::subscriber::SetGlobalDefaultError> {
         let mut enabled = false;
         let mut filters: Vec<LogFilter> = Vec::with_capacity(10);
-        if let Ok(env_value) = env::var("LLRT_LOG") {
+        if let Ok(env_value) = env::var(environment::ENV_LLRT_LOG) {
             enabled = true;
             for filter in env_value.split(',') {
                 let mut target = Some(filter);

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -11,6 +11,8 @@ use rquickjs::{
 use rustls::{crypto::ring, ClientConfig, RootCertStore};
 use webpki_roots::TLS_SERVER_ROOTS;
 
+pub const DEFAULT_CONNECTION_POOL_IDLE_TIMEOUT_SECONDS: u64 = 15;
+
 pub static TLS_CONFIG: Lazy<ClientConfig> = Lazy::new(|| {
     let mut root_certificates = RootCertStore::empty();
 

--- a/src/security.rs
+++ b/src/security.rs
@@ -8,8 +8,7 @@ use std::{
     result::Result as StdResult,
 };
 
-const ENV_LLRT_NET_ALLOW: &str = "LLRT_NET_ALLOW";
-const ENV_LLRT_NET_DENY: &str = "LLRT_NET_DENY";
+use crate::environment::{ENV_LLRT_NET_ALLOW, ENV_LLRT_NET_DENY};
 
 pub static NET_ALLOW_LIST: Lazy<Option<Vec<String>>> =
     Lazy::new(|| build_access_list(env::var(ENV_LLRT_NET_ALLOW)));


### PR DESCRIPTION
*Description of changes:*
Connection pool idle timeout is not configured to 15s to reduce potential issues when server closing an unused connection while in flight after to long idling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
