### PR TITLE
Add username and password to URL and add canParse util static method.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,8 +190,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crc32c"
-version = "0.6.4"
-source = "git+https://github.com/zowens/crc32c.git?rev=8799754e2d0da5eeffe1f85f6152afe3f5c65469#8799754e2d0da5eeffe1f85f6152afe3f5c65469"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
 dependencies = [
  "rustc_version",
 ]
@@ -740,7 +741,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "llrt"
-version = "0.1.8-beta"
+version = "0.1.9-beta"
 dependencies = [
  "async-trait",
  "base64-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llrt"
-version = "0.1.8-beta"
+version = "0.1.9-beta"
 edition = "2021"
 license-file = "LICENSE"
 
@@ -13,7 +13,7 @@ macro = ["rquickjs/macro"]
 [dependencies]
 chrono = { version = "0.4.34", default-features = false, features = ["std"] }
 quick-xml = "0.31.0"
-crc32c = { rev = "8799754e2d0da5eeffe1f85f6152afe3f5c65469", git = "https://github.com/zowens/crc32c.git" }
+crc32c = "0.6.5"
 crc32fast = "1.4.0"
 phf = "0.11.2"
 md-5 = { version = "0.10.6", features = ["asm"] }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ That's it 🎉
 The following [example project](example/llrt-sam/) sets up a lambda
 instrumented with a layer containing the llrt runtime.
 
+### Option 4: AWS CDK
+
+You can use [`cdk-lambda-llrt` construct library](https://github.com/tmokmss/cdk-lambda-llrt) to deploy LLRT Lambda functions with AWS CDK.
+
+```ts
+import { LlrtFunction } from 'cdk-lambda-llrt';
+
+const handler = new LlrtFunction(this, 'Handler', {
+    entry: 'lambda/index.ts',
+});
+```
+
+See [Construct Hub](https://constructs.dev/packages/cdk-lambda-llrt/) and [its examples](https://github.com/tmokmss/cdk-lambda-llrt/tree/main/example) for more details.
+
 ## Testing & ensuring compatibility
 
 The best way to ensure that your code is compatible with LLRT is to write tests and executing them via the built in test runner


### PR DESCRIPTION
Adds username and password properties to URL per WHATWG spec https://url.spec.whatwg.org/#url
also adds canParse utility static method.

Adds testing, testing is basic cases since the underlying rust crate url, does much of the heavy lifting.