### PR TITLE
feat: add recursive option for readdir

### DIFF
--- a/fixtures/fs/readdir/readdir.js
+++ b/fixtures/fs/readdir/readdir.js
@@ -1,0 +1,5 @@
+import fs from 'fs/promises';
+
+fs.readdir('./', { recursive: true }).then(res => {
+    console.log(res);
+});

--- a/fixtures/fs/readdir/readdir.js
+++ b/fixtures/fs/readdir/readdir.js
@@ -1,5 +1,3 @@
 import fs from 'fs/promises';
 
-fs.readdir('./', { recursive: true }).then(res => {
-    console.log(res);
-});
+fs.readdir('./', { recursive: true }).then(res => {});

--- a/fixtures/fs/readdir/recursive/readdir.js
+++ b/fixtures/fs/readdir/recursive/readdir.js
@@ -1,0 +1,5 @@
+import fs from 'fs/promises';
+
+fs.readdir('./', { recursive: true }).then(res => {
+    console.log(res);
+});

--- a/fixtures/fs/readdir/recursive/readdir.js
+++ b/fixtures/fs/readdir/recursive/readdir.js
@@ -1,5 +1,3 @@
 import fs from 'fs/promises';
 
-fs.readdir('./', { recursive: true }).then(res => {
-    console.log(res);
-});
+fs.readdir('./', { recursive: true }).then(res => {});

--- a/src/path.rs
+++ b/src/path.rs
@@ -216,7 +216,7 @@ fn normalize(path: String) -> String {
     join_path(parts)
 }
 
-fn is_absolute(path: String) -> bool {
+pub fn is_absolute(path: String) -> bool {
     PathBuf::from(path).is_absolute()
 }
 

--- a/tests/unit/fs.test.ts
+++ b/tests/unit/fs.test.ts
@@ -25,6 +25,12 @@ describe("readdir", () => {
     const dir = await namedFsImport.promises.readdir(".cargo");
     assert.deepEqual(dir, ["config.toml"]);
   });
+
+  it('should read a directory with recursive', async () => {
+    const dir = await fs.readdir('fixtures/fs/readdir', { recursive: true });
+    const compare = (a: string, b: string) => a >= b ? 1 : -1;
+    assert.deepEqual(dir.sort(compare), ['recursive/readdir.js', 'recursive', 'readdir.js'].sort(compare));
+  });
 });
 
 describe("readfile", () => {


### PR DESCRIPTION
Issue fix #197


*Description of changes:*

add recursive option for readdir

```js
fs.readdir('example', { recursive: true })
    .then(res => {
        console.log(res);
    });

```
