### PR TITLE
Feat/implement mkdirSync

### DIFF
--- a/src/fs/mkdir.rs
+++ b/src/fs/mkdir.rs
@@ -9,13 +9,7 @@ use tokio::fs;
 use crate::utils::result::ResultExt;
 
 pub async fn mkdir<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<String> {
-    let mut recursive = false;
-    let mut mode = 0o777;
-
-    if let Some(options) = options.0 {
-        recursive = options.get("recursive").unwrap_or_default();
-        mode = options.get("mode").unwrap_or(0o777);
-    }
+    let (recursive, mode) = get_mkdir_params(options);
 
     if recursive {
         fs::create_dir_all(&path).await
@@ -29,6 +23,33 @@ pub async fn mkdir<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) 
         .or_throw_msg(&ctx, &format!("Can't set permissions of \"{}\"", &path))?;
 
     Ok(path)
+}
+
+pub fn mkdirsync<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<String> {
+    let (recursive, mode) = get_mkdir_params(options);
+
+    if recursive {
+        std::fs::create_dir_all(&path)
+    } else {
+        std::fs::create_dir(&path)
+    }
+    .or_throw_msg(&ctx, &format!("Can't create dir \"{}\"", &path))?;
+
+    std::fs::set_permissions(&path, PermissionsExt::from_mode(mode))
+        .or_throw_msg(&ctx, &format!("Can't set permissions of \"{}\"", &path))?;
+
+    Ok(path)
+}
+
+fn get_mkdir_params(options: Opt<Object>) -> (bool, u32) {
+    let mut recursive = false;
+    let mut mode = 0o777;
+
+    if let Some(options) = options.0 {
+        recursive = options.get("recursive").unwrap_or_default();
+        mode = options.get("mode").unwrap_or(0o777);
+    }
+    (recursive, mode)
 }
 
 const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -22,7 +22,7 @@ use self::read_file::read_file;
 use self::rm::{rmdir, rmfile};
 use self::stats::{stat_fn, Stat};
 use self::write_file::write_file;
-use crate::fs::mkdir::{mkdir, mkdtemp};
+use crate::fs::mkdir::{mkdir, mkdirsync, mkdtemp};
 
 pub const CONSTANT_F_OK: u32 = 0;
 pub const CONSTANT_R_OK: u32 = 4;
@@ -33,7 +33,22 @@ pub struct FsPromisesModule;
 
 impl ModuleDef for FsPromisesModule {
     fn declare(declare: &mut Declarations) -> Result<()> {
-        delarations(declare)?;
+        declare.declare("access")?;
+        declare.declare("open")?;
+        declare.declare("readFile")?;
+        declare.declare("writeFile")?;
+        declare.declare("appendFile")?;
+        declare.declare("copyFile")?;
+        declare.declare("rename")?;
+        declare.declare("readdir")?;
+        declare.declare("mkdir")?;
+        declare.declare("mkdtemp")?;
+        declare.declare("rm")?;
+        declare.declare("rmdir")?;
+        declare.declare("stat")?;
+        declare.declare("constants")?;
+
+        declare.declare("default")?;
 
         Ok(())
     }
@@ -55,6 +70,8 @@ pub struct FsModule;
 impl ModuleDef for FsModule {
     fn declare(declare: &mut Declarations) -> Result<()> {
         declare.declare("promises")?;
+        declare.declare("mkdirSync")?;
+
         declare.declare("default")?;
 
         Ok(())
@@ -66,34 +83,14 @@ impl ModuleDef for FsModule {
 
         export_default(ctx, exports, |default| {
             let promises = Object::new(ctx.clone())?;
-
             export_promises(ctx, &promises)?;
 
             default.set("promises", promises)?;
+            default.set("mkdirSync", Func::from(mkdirsync))?;
 
             Ok(())
         })
     }
-}
-
-fn delarations(declare: &mut Declarations) -> Result<()> {
-    declare.declare("access")?;
-    declare.declare("open")?;
-    declare.declare("readFile")?;
-    declare.declare("writeFile")?;
-    declare.declare("appendFile")?;
-    declare.declare("copyFile")?;
-    declare.declare("rename")?;
-    declare.declare("readdir")?;
-    declare.declare("mkdir")?;
-    declare.declare("mkdtemp")?;
-    declare.declare("rm")?;
-    declare.declare("rmdir")?;
-    declare.declare("stat")?;
-    declare.declare("constants")?;
-
-    declare.declare("default")?;
-    Ok(())
 }
 
 fn export_promises<'js>(ctx: &Ctx<'js>, exports: &Object<'js>) -> Result<()> {

--- a/tests/unit/fs.test.ts
+++ b/tests/unit/fs.test.ts
@@ -69,7 +69,28 @@ describe("mkdir", () => {
     const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), "test/test-"));
 
     //non recursive should reject
-    assert.rejects(fs.mkdir(dirPath));
+    expect(fs.mkdir(dirPath)).rejects.toThrow("EEXIST: file already exists, mkdir");
+
+    await fs.mkdir(dirPath, { recursive: true });
+
+    // Check that the directory exists
+    const dirExists = await fs
+      .stat(dirPath)
+      .then(() => true)
+      .catch(() => false);
+    assert.ok(dirExists);
+
+    // Clean up the directory
+    await fs.rmdir(dirPath, { recursive: true });
+  });
+});
+
+describe("mkdirSync", () => {
+  it("should create a directory with the given path synchronously", async () => {
+    const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), "test/test-"));
+
+    //non recursive should reject
+    expect(()=>defaultFsImport.mkdirSync(dirPath)).toThrow(/[fF]ile.*exists/);
 
     await fs.mkdir(dirPath, { recursive: true });
 

--- a/tests/unit/jest-expect.test.ts
+++ b/tests/unit/jest-expect.test.ts
@@ -23,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
+// Extracted and modified from Vitest:  https://github.com/vitest-dev/vitest/blob/7a31a1ae4223aed3adf260e63ac3b3f7fab3c9d7/test/core/test/jest-expect.test.ts
+
 class TestError extends Error {}
 
 describe('jest-expect', () => {
@@ -95,7 +97,9 @@ describe('jest-expect', () => {
     }).toThrow(err)
     expect(() => {
       throw new Error('message')
-    }).toThrowError()
+    }).toThrow(expect.objectContaining({
+      message: expect.stringContaining('mes'),
+    }))
     expect([1, 2, 3]).toHaveLength(3)
     expect('abc').toHaveLength(3)
     expect('').not.toHaveLength(5)


### PR DESCRIPTION
*Description of changes:*
Implement mkdir sync, fix an issue when using expect(...).rejects.toThrow in unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
