### PR TITLE
Cleanup walkdir & fix warnings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 - [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
 - [ ] Ran `make fix` to format and apply Clippy auto fixes
-- [ ] Made sure my code didn't add any additional warnings
+- [ ] Made sure my code didn't add any additional warnings: `cargo clippy --all-targets --all-features -- -D warnings`
 - [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)
 
 *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: | #create mock js files
+          mkdir -p bundle
           for i in {1..5}; do
             echo "console.log(123);" > "bundle/test$i.js"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           key: ${{ runner.os }}-cargo-rust_stable-${{ hashFiles('**/Cargo.lock') }}
       - name: Format
         run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
   build:
     needs:
       - check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: | #create mock js files
+          for i in {1..5}; do
+            echo "console.log(123);" > "bundle/test$i.js"
+          cargo clippy --all-targets --all-features -- -D warnings
   build:
     needs:
       - check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: | #create mock js files
           for i in {1..5}; do
             echo "console.log(123);" > "bundle/test$i.js"
+          done
           cargo clippy --all-targets --all-features -- -D warnings
   build:
     needs:


### PR DESCRIPTION
### Description of changes

Cleanup DirectoryWalker & Remove warnings

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*