### PR TITLE
Optimize timer removal

### DIFF
--- a/src/timers.rs
+++ b/src/timers.rs
@@ -65,8 +65,10 @@ fn set_timeout_interval<'js>(
 
 fn clear_timeout_interval(timeouts: &Arc<Mutex<Vec<Timeout>>>, id: usize) {
     let mut timeouts = timeouts.lock().unwrap();
-    if let Some(index) = timeouts.iter().position(|t| t.id == id) {
-        timeouts.remove(index);
+    if let Some(timeout) = timeouts.iter_mut().find(|t| t.id == id) {
+        timeout.cb.take();
+        timeout.timeout = 0;
+        timeout.repeating = false;
     }
 }
 


### PR DESCRIPTION
### Description of changes

Avoids copying elements in list by instead taking callback reference and set timeout to 0 for scheduled removal on next timer tick

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*