### PR TITLE
feat: implement readdirSync

### DIFF
--- a/API.md
+++ b/API.md
@@ -53,6 +53,10 @@ Available globally
 > * `response.body` returns `null`. Use `response.text()`, `response.json()` etc
 > * `mode`, `credentials`,  `referrerPolicy`, `priority`, `cache` is not available/applicable
 
+## fs
+[mkdirsync](https://nodejs.org/api/fs.html#fsmkdirsyncpath-options)
+[readdirSync](https://nodejs.org/api/fs.html#fsreaddirsyncpath-options)
+
 ## fs/promises
 
 [readdir](https://nodejs.org/api/fs.html#fspromisesreaddirpath-options)

--- a/src/fs/mkdir.rs
+++ b/src/fs/mkdir.rs
@@ -25,7 +25,7 @@ pub async fn mkdir<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) 
     Ok(path)
 }
 
-pub fn mkdirsync<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<String> {
+pub fn mkdir_sync<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<String> {
     let (recursive, mode) = get_mkdir_params(options);
 
     if recursive {

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -17,12 +17,12 @@ use rquickjs::{Class, Ctx, Object, Result};
 use crate::module::export_default;
 
 use self::access::access;
-use self::read_dir::{read_dir, Dirent};
+use self::read_dir::{read_dir, read_dir_sync, Dirent};
 use self::read_file::read_file;
 use self::rm::{rmdir, rmfile};
 use self::stats::{stat_fn, Stat};
 use self::write_file::write_file;
-use crate::fs::mkdir::{mkdir, mkdirsync, mkdtemp};
+use crate::fs::mkdir::{mkdir, mkdir_sync, mkdtemp};
 
 pub const CONSTANT_F_OK: u32 = 0;
 pub const CONSTANT_R_OK: u32 = 4;
@@ -71,6 +71,7 @@ impl ModuleDef for FsModule {
     fn declare(declare: &mut Declarations) -> Result<()> {
         declare.declare("promises")?;
         declare.declare("mkdirSync")?;
+        declare.declare("readdirSync")?;
 
         declare.declare("default")?;
 
@@ -86,7 +87,8 @@ impl ModuleDef for FsModule {
             export_promises(ctx, &promises)?;
 
             default.set("promises", promises)?;
-            default.set("mkdirSync", Func::from(mkdirsync))?;
+            default.set("mkdirSync", Func::from(mkdir_sync))?;
+            default.set("readdirSync", Func::from(read_dir_sync))?;
 
             Ok(())
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,8 +274,7 @@ async fn run_tests(ctx: &AsyncContext, args: &[std::string::String]) -> Result<(
 
     trace!("Scanning directory \"{}\"", root);
 
-    let mut directory_walker = DirectoryWalker::new(PathBuf::from(root), |entry| {
-        let name = entry.file_name().to_string_lossy().to_string();
+    let mut directory_walker = DirectoryWalker::new(PathBuf::from(root), |name| {
         name != "node_modules" || !name.starts_with('.')
     });
 

--- a/tests/unit/fs.test.ts
+++ b/tests/unit/fs.test.ts
@@ -33,6 +33,35 @@ describe("readdir", () => {
   });
 });
 
+describe("readdirSync", () => {
+  it("should read a directory synchronously", () => {
+    const dir = defaultFsImport.readdirSync(".cargo");
+    assert.deepEqual(dir, ["config.toml"]);
+  });
+
+  it("should read a directory with types synchronously", () => {
+    const dir = defaultFsImport.readdirSync(".cargo", {withFileTypes: true});
+    assert.deepEqual(dir, [{name: "config.toml"}]);
+    assert.equal(dir[0].isFile(), true);
+  });
+
+  it("should read a directory using default import synchronously", () => {
+    const dir = defaultFsImport.readdirSync(".cargo");
+    assert.deepEqual(dir, ["config.toml"]);
+  });
+
+  it("should read a directory using named import synchronously", () => {
+    const dir = namedFsImport.readdirSync(".cargo");
+    assert.deepEqual(dir, ["config.toml"]);
+  });
+
+  it('should read a directory with recursive synchronously', () => {
+    const dir = defaultFsImport.readdirSync('fixtures/fs/readdir', {recursive: true});
+    const compare = (a: string | Buffer, b: string | Buffer): number => a >= b ? 1 : -1;
+    assert.deepEqual(dir.sort(compare), ['recursive/readdir.js', 'recursive', 'readdir.js'].sort(compare));
+  });
+});
+
 describe("readfile", () => {
   it("should read a file", async () => {
     const buf = await fs.readFile("fixtures/hello.txt");
@@ -98,7 +127,7 @@ describe("mkdirSync", () => {
     //non recursive should reject
     expect(()=>defaultFsImport.mkdirSync(dirPath)).toThrow(/[fF]ile.*exists/);
 
-    await fs.mkdir(dirPath, { recursive: true });
+    defaultFsImport.mkdirSync(dirPath, { recursive: true });
 
     // Check that the directory exists
     const dirExists = await fs


### PR DESCRIPTION
### Description of changes

Implemented readdirSync (https://nodejs.org/api/fs.html#fsreaddirsyncpath-options)

### Checklist

- [X] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [X] Ran `make fix` to format and apply Clippy auto fixes
- [X] Made sure my code didn't add any additional warnings: `make check`
- [N/A] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*