### PR TITLE
feat: implement accessSync

### DIFF
--- a/API.md
+++ b/API.md
@@ -54,7 +54,8 @@ Available globally
 > * `mode`, `credentials`,  `referrerPolicy`, `priority`, `cache` is not available/applicable
 
 ## fs
-[mkdirsync](https://nodejs.org/api/fs.html#fsmkdirsyncpath-options)
+[accessSync](https://nodejs.org/api/fs.html#fsaccesssyncpath-mode)
+[mkdirSync](https://nodejs.org/api/fs.html#fsmkdirsyncpath-options)
 [readdirSync](https://nodejs.org/api/fs.html#fsreaddirsyncpath-options)
 
 ## fs/promises

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -8,6 +8,7 @@ mod rm;
 mod stats;
 mod write_file;
 
+use crate::fs::access::access_sync;
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
     prelude::{Async, Func},
@@ -70,6 +71,7 @@ pub struct FsModule;
 impl ModuleDef for FsModule {
     fn declare(declare: &mut Declarations) -> Result<()> {
         declare.declare("promises")?;
+        declare.declare("accessSync")?;
         declare.declare("mkdirSync")?;
         declare.declare("readdirSync")?;
 
@@ -87,6 +89,7 @@ impl ModuleDef for FsModule {
             export_promises(ctx, &promises)?;
 
             default.set("promises", promises)?;
+            default.set("accessSync", Func::from(access_sync))?;
             default.set("mkdirSync", Func::from(mkdir_sync))?;
             default.set("readdirSync", Func::from(read_dir_sync))?;
 

--- a/tests/unit/fs.test.ts
+++ b/tests/unit/fs.test.ts
@@ -182,3 +182,20 @@ describe("access", () => {
     await namedFsImport.promises.access(filePath);
   });
 });
+
+describe("accessSync", () => {
+  it("should access a file synchronously", () => {
+    const filePath = "fixtures/hello.txt";
+    defaultFsImport.accessSync(filePath);
+  });
+
+  it("should throw if not proper permissions synchronously", () => {
+    const filePath = "fixtures/hello.txt";
+    expect(()=>defaultFsImport.accessSync(filePath, fs.constants.X_OK)).toThrow(/[pP]ermission denied/);
+  });
+
+  it("should throw if not exists synchronously", () => {
+    const filePath = "fixtures/nothing";
+    expect(()=>defaultFsImport.accessSync(filePath)).toThrow(/[Nn]o such file or directory/);
+  });
+});


### PR DESCRIPTION
### Description of changes

Implement [accessSync](https://nodejs.org/api/fs.html#fsaccesssyncpath-mode)

### Checklist

- [X] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [X] Ran `make fix` to format and apply Clippy auto fixes
- [X] Made sure my code didn't add any additional warnings: `make check`
- [X] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*