### PR TITLE
fix: wrong a url of github release at the Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See our [AWS SAM example](./example/llrt-sam-container-image) or:
 FROM --platform=arm64 busybox
 WORKDIR /var/task/
 COPY app.mjs ./
-ADD https://github.com/awslabs/llrt/releases/download/latest/llrt-container-arm64 /usr/bin/llrt
+ADD https://github.com/awslabs/llrt/releases/latest/download/llrt-container-arm64 /usr/bin/llrt
 RUN chmod +x /usr/bin/llrt
 
 ENV LAMBDA_HANDLER "app.handler"

--- a/example/llrt-sam-container-image/hello-world/Dockerfile
+++ b/example/llrt-sam-container-image/hello-world/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=arm64 busybox
 WORKDIR /var/task/
 COPY app.mjs ./
-ADD https://github.com/awslabs/llrt/releases/download/latest/llrt-container-arm64 /usr/bin/llrt
+ADD https://github.com/awslabs/llrt/releases/latest/download/llrt-container-arm64 /usr/bin/llrt
 RUN chmod +x /usr/bin/llrt
 
 ENV LAMBDA_HANDLER "app.handler"


### PR DESCRIPTION
### Issue # (if available)
Can't resolve https://github.com/awslabs/llrt/releases/download/latest/llrt-container-arm64
<!--  **Please post the link to the resolved issue** -->

### Description of changes
According to [Linking to the latest release](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases#linking-to-the-latest-release),
the correct url is below.

https://github.com/awslabs/llrt/releases/latest/download/llrt-container-arm64

In addition, it works to build docker image with this.

<!-- **Please explain what your changes does** -->

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
