### PR TITLE
Fix JSON.stringify of undefined values

### DIFF
--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -8,7 +8,7 @@ pub mod stringify;
 mod tests {
     use std::time::Instant;
 
-    use rquickjs::{Array, CatchResultExt, Null, Object, Value};
+    use rquickjs::{Array, CatchResultExt, IntoJs, Null, Object, Undefined, Value};
 
     use crate::{
         json::{
@@ -46,6 +46,30 @@ mod tests {
                 println!("{}", new_json);
                 assert_eq!(new_json, builtin_json);
             }
+
+            Ok(())
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn json_stringify_undefined() {
+        with_runtime(|ctx| {
+            let stringified = json_stringify(&ctx, Undefined.into_js(&ctx)?)?;
+            let stringified_2 = ctx
+                .json_stringify(Undefined)?
+                .map(|v| v.to_string().unwrap());
+            assert_eq!(stringified, stringified_2);
+
+            let obj: Value = ctx.eval(
+                r#"let obj = { value: undefined, array: [undefined, null, 1, true, "hello", { [Symbol("sym")]: 1, [undefined]: 2}] };obj;"#,
+            )?;
+
+            let stringified = json_stringify(&ctx, obj.clone())?;
+            let stringified_2 = ctx
+                .json_stringify(obj)?
+                .map(|v| v.to_string().unwrap());
+            assert_eq!(stringified, stringified_2);
 
             Ok(())
         })
@@ -179,6 +203,8 @@ mod tests {
             generate_json(&json, 10),
             generate_json(&json, 100),
             generate_json(&json, 1000),
+            generate_json(&json, 10000),
+            generate_json(&json, 100000),
         ];
 
         with_runtime(|ctx| {

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -203,8 +203,6 @@ mod tests {
             generate_json(&json, 10),
             generate_json(&json, 100),
             generate_json(&json, 1000),
-            generate_json(&json, 10000),
-            generate_json(&json, 100000),
         ];
 
         with_runtime(|ctx| {

--- a/src/json/stringify.rs
+++ b/src/json/stringify.rs
@@ -445,7 +445,7 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                     },
                     add_comma,
                 )?;
-                value_written = value_written || !value_written && add_comma;
+                value_written = value_written || add_comma;
             }
 
             if value_written {
@@ -487,7 +487,7 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                     },
                     add_comma,
                 )?;
-                value_written = value_written || !value_written && add_comma;
+                value_written = value_written || add_comma;
             }
             if value_written {
                 write_indentation(context.result, indentation, depth);

--- a/src/json/stringify.rs
+++ b/src/json/stringify.rs
@@ -91,8 +91,14 @@ pub fn json_stringify_replacer_space<'js>(
         include_keys_replacer,
     };
 
-    if write_primitive(&mut context, false)? {
-        return Ok(Some(result));
+    match write_primitive(&mut context, false)? {
+        PrimitiveStatus::Written => {
+            return Ok(Some(result));
+        }
+        PrimitiveStatus::Ignored => {
+            return Ok(None);
+        }
+        _ => {}
     }
 
     context.depth += 1;
@@ -137,13 +143,20 @@ fn run_to_json<'js>(
     Ok(())
 }
 
+#[derive(PartialEq)]
+enum PrimitiveStatus {
+    Written,
+    Ignored,
+    Iterate,
+}
+
 #[inline(always)]
 #[cold]
 fn run_replacer<'js>(
     context: &mut IterationContext<'_, 'js>,
     replacer_fn: &Function<'js>,
     add_comma: bool,
-) -> Result<bool> {
+) -> Result<PrimitiveStatus> {
     let parent = context.parent;
     let ctx = context.ctx;
     let value = context.value;
@@ -176,7 +189,7 @@ fn run_replacer<'js>(
 }
 
 #[inline(always)]
-fn write_primitive(context: &mut IterationContext, add_comma: bool) -> Result<bool> {
+fn write_primitive(context: &mut IterationContext, add_comma: bool) -> Result<PrimitiveStatus> {
     if let Some(replacer_fn) = context.replacer_fn {
         return run_replacer(context, replacer_fn, add_comma);
     }
@@ -190,14 +203,14 @@ fn write_primitive(context: &mut IterationContext, add_comma: bool) -> Result<bo
 
     let type_of = value.type_of();
 
-    if matches!(type_of, Type::Symbol | Type::Undefined) {
-        return Ok(true);
+    if matches!(type_of, Type::Symbol | Type::Undefined) && context.index.is_none() {
+        return Ok(PrimitiveStatus::Ignored);
     }
 
     if let Some(include_keys_replacer) = include_keys_replacer {
         let key = get_key_or_index(key, index);
         if !include_keys_replacer.contains(&key) {
-            return Ok(true);
+            return Ok(PrimitiveStatus::Ignored);
         }
     };
 
@@ -211,7 +224,7 @@ fn write_primitive(context: &mut IterationContext, add_comma: bool) -> Result<bo
     }
 
     match type_of {
-        Type::Null => context.result.push_str("null"),
+        Type::Null | Type::Undefined => context.result.push_str("null"),
         Type::Bool => context.result.push_str(match value.as_bool().unwrap() {
             true => "true",
             false => "false",
@@ -244,9 +257,9 @@ fn write_primitive(context: &mut IterationContext, add_comma: bool) -> Result<bo
             }
         }
         Type::String => write_string(context.result, &value.as_string().unwrap().to_string()?),
-        _ => return Ok(false),
+        _ => return Ok(PrimitiveStatus::Iterate),
     }
-    Ok(true)
+    Ok(PrimitiveStatus::Written)
 }
 
 #[inline(always)]
@@ -325,13 +338,16 @@ fn detect_circular_reference(
 }
 
 #[inline(always)]
-fn append_value(context: &mut IterationContext<'_, '_>, add_comma: bool) -> Result<()> {
-    if !write_primitive(context, add_comma)? {
-        context.depth += 1;
-        iterate(context)?;
+fn append_value(context: &mut IterationContext<'_, '_>, add_comma: bool) -> Result<bool> {
+    match write_primitive(context, add_comma)? {
+        PrimitiveStatus::Written => Ok(true),
+        PrimitiveStatus::Ignored => Ok(false),
+        PrimitiveStatus::Iterate => {
+            context.depth += 1;
+            iterate(context)?;
+            Ok(true)
+        }
     }
-
-    Ok(())
 }
 
 #[inline(always)]
@@ -410,7 +426,7 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                 let key = key?;
                 let val = js_object.get(&key)?;
 
-                append_value(
+                add_comma = append_value(
                     &mut IterationContext {
                         ctx,
                         result: context.result,
@@ -426,7 +442,6 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                     },
                     add_comma,
                 )?;
-                add_comma = true;
             }
             if add_comma {
                 write_indentation(context.result, indentation, depth);
@@ -450,7 +465,7 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
             }
             for (i, val) in js_array.iter::<Value>().enumerate() {
                 let val = val?;
-                append_value(
+                add_comma = append_value(
                     &mut IterationContext {
                         ctx,
                         result: context.result,
@@ -466,7 +481,6 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                     },
                     add_comma,
                 )?;
-                add_comma = true;
             }
             if add_comma {
                 write_indentation(context.result, indentation, depth);

--- a/src/json/stringify.rs
+++ b/src/json/stringify.rs
@@ -396,6 +396,7 @@ fn get_key_or_index(key: Option<&str>, index: Option<usize>) -> String {
 #[inline(always)]
 fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
     let mut add_comma;
+    let mut value_written;
     let elem = context.value;
     let depth = context.depth;
     let ctx = context.ctx;
@@ -422,6 +423,8 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
             context.result.push('{');
 
             add_comma = false;
+            value_written = false;
+
             for key in js_object.keys::<String>() {
                 let key = key?;
                 let val = js_object.get(&key)?;
@@ -442,8 +445,10 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                     },
                     add_comma,
                 )?;
+                value_written = value_written || !value_written && add_comma;
             }
-            if add_comma {
+
+            if value_written {
                 write_indentation(context.result, indentation, depth);
             }
             context.result.push('}');
@@ -451,6 +456,7 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
         Type::Array => {
             context.result.push('[');
             add_comma = false;
+            value_written = false;
             let js_array = elem.as_array().unwrap();
             //only start detect circular reference at this level
             if depth > CIRCULAR_REF_DETECTION_DEPTH {
@@ -481,8 +487,9 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                     },
                     add_comma,
                 )?;
+                value_written = value_written || !value_written && add_comma;
             }
-            if add_comma {
+            if value_written {
                 write_indentation(context.result, indentation, depth);
             }
             context.result.push(']');


### PR DESCRIPTION
### Description of changes

`undefined` values where not correctly handled by json_stringify

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
