### PR TITLE
Update README.md - Add dependencies of Windows WSL2 in Building from source section

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ Install dependencies
     sudo apt -y install make zstd
     sudo snap install zig --classic --beta
 
+    # Windows WSL2
+    sudo apt -y install cmake g++ gcc make zip zstd
+    sudo snap install zig --classic --beta
+
+    # Windows WSL2 (If Node.js is not yet installed)
+    sudo curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
+    nvm install --lts
+
 Install Node.js packages
 
     corepack enable

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ That's it 🎉
 > Even though LLRT supports [ES2020](https://262.ecma-international.org/11.0/) it's **NOT** a drop in replacement for Node.js. Consult [Compatibility matrix](#compatibility-matrix) and [API](API.md) for more details.
 > All dependencies should be bundled for a `browser` platform and mark included `@aws-sdk` packages as external.
 
-### Option 3: AWS SAM
+### Option 4: AWS SAM
 
 The following [example project](example/llrt-sam/) sets up a lambda
 instrumented with a layer containing the llrt runtime.
 
-### Option 4: AWS CDK
+### Option 5: AWS CDK
 
 You can use [`cdk-lambda-llrt` construct library](https://github.com/tmokmss/cdk-lambda-llrt) to deploy LLRT Lambda functions with AWS CDK.
 


### PR DESCRIPTION
### Description of changes

- Add dependencies of Windows WSL2 in Building from source section

result of `make release-x64` and example of `llrt-container-x64` execution:

![image](https://github.com/awslabs/llrt/assets/7500514/ef1c895c-7d26-4ca9-bd24-646a43b6894b)

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
