### PR TITLE
Add AbortController implementation

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -445,6 +445,12 @@ impl<'js> AbortSignal<'js> {
         self.aborted
     }
 
+    #[qjs(get)]
+    pub fn reason(&self) -> Option<Value<'js>> {
+        self.reason.clone()
+    }
+
+
     #[qjs(skip)]
     pub fn set_reason(&mut self, reason: Opt<Value<'js>>) -> Result<Option<Value<'js>>> {
         if let Some(new_reason) = reason.0 {

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::mutable_key_type, clippy::for_kv_map)]
 
-use std::{mem, sync::{Arc, RwLock}};
+use std::{
+    mem,
+    sync::{Arc, RwLock},
+};
 
 use rquickjs::{
     class::{JsClass, OwnedBorrow, Trace, Tracer},
     module::{Declarations, Exports, ModuleDef},
-    prelude::{Func, Rest, This, Opt},
+    prelude::{Func, Opt, Rest, This},
     CatchResultExt, Class, Ctx, Function, Object, Result, String as JsString, Symbol, Value,
 };
 
@@ -375,7 +378,7 @@ impl<'js> EventEmitter<'js> {
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace)]
 pub struct AbortController<'js> {
-    signal: Class<'js, AbortSignal<'js>>
+    signal: Class<'js, AbortSignal<'js>>,
 }
 
 #[rquickjs::methods]
@@ -383,10 +386,13 @@ impl<'js> AbortController<'js> {
     #[qjs(constructor)]
     pub fn new(ctx: Ctx<'js>) -> Result<Self> {
         let abort_controller = Self {
-            signal: Class::instance(ctx, AbortSignal {
-                aborted: false,
-                reason: None
-            })?
+            signal: Class::instance(
+                ctx,
+                AbortSignal {
+                    aborted: false,
+                    reason: None,
+                },
+            )?,
         };
         Ok(abort_controller)
     }
@@ -396,14 +402,17 @@ impl<'js> AbortController<'js> {
         self.signal.clone()
     }
 
-    pub fn abort(this: This<Class<'js, Self>>, reason: Opt<Value<'js>>) -> Result<Class<'js, Self>> {
+    pub fn abort(
+        this: This<Class<'js, Self>>,
+        reason: Opt<Value<'js>>,
+    ) -> Result<Class<'js, Self>> {
         if reason.0.is_some() {
             this.0.borrow_mut().signal.borrow_mut().set_reason(reason)?;
         } else {
             // TODO store DOMException as reason
             this.0.borrow_mut().signal.borrow_mut().set_reason(reason)?;
         }
-   
+
         Ok(this.0)
     }
 }
@@ -412,13 +421,13 @@ impl<'js> AbortController<'js> {
 #[rquickjs::class]
 pub struct AbortSignal<'js> {
     aborted: bool,
-    reason: Option<Value<'js>>
+    reason: Option<Value<'js>>,
 }
 
 impl<'js> Trace<'js> for AbortSignal<'js> {
     fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
         if let Some(reason) = &self.reason {
-            tracer.mark(&reason);
+            tracer.mark(reason);
         }
     }
 }
@@ -429,7 +438,7 @@ impl<'js> AbortSignal<'js> {
     pub fn new() -> Self {
         Self {
             aborted: false,
-            reason: None
+            reason: None,
         }
     }
 
@@ -447,7 +456,7 @@ impl<'js> AbortSignal<'js> {
     pub fn abort(reason: Opt<Value<'js>>) -> AbortSignal {
         AbortSignal {
             aborted: true,
-            reason: reason.0
+            reason: reason.0,
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -487,7 +487,7 @@ impl<'js> AbortSignal<'js> {
 
     #[qjs(static)]
     pub fn timeout(ctx: Ctx<'js>, milliseconds: u64) -> Result<Class<'js, Self>> {
-        let timeout_exception = Exception::from_value("TimeoutError".into_js(&ctx.clone())?)?; // TODO: Timeout DOMException
+        let timeout_exception = Exception::from_value("TimeoutError".into_js(&ctx)?)?; // TODO: Timeout DOMException
         let signal = AbortSignal {
             aborted: false,
             reason: None,

--- a/src/events.rs
+++ b/src/events.rs
@@ -447,6 +447,7 @@ impl<'js> AbortSignal<'js> {
         self.aborted
     }
 
+    #[qjs(skip)]
     pub fn set_reason(&mut self, reason: Opt<Value<'js>>) -> Result<Option<Value<'js>>> {
         let new_reason = mem::replace(&mut self.reason, reason.0);
         Ok(new_reason)

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -14,8 +14,8 @@ it("should use custom EventEmitter", () => {
   const myEmitter2 = new MyEmitter();
 
   myEmitter.once("event", function (a, b) {
-    expect(a).toEqual("a")
-    expect(b).toEqual("b")
+    expect(a).toEqual("a");
+    expect(b).toEqual("b");
     // @ts-ignore
     expect(this instanceof MyEmitter).toBeTruthy();
     // @ts-ignore
@@ -34,8 +34,8 @@ it("should use custom EventEmitter", () => {
   myEmitter.emit(symbolB);
   myEmitter.emit(symbolC);
 
-  expect(called).toEqual(4)
-  expect(myEmitter.eventNames()).toEqual([symbolA, symbolB, symbolC])
+  expect(called).toEqual(4);
+  expect(myEmitter.eventNames()).toEqual([symbolA, symbolB, symbolC]);
 
   myEmitter.off(symbolB, callback);
 
@@ -44,8 +44,8 @@ it("should use custom EventEmitter", () => {
   myEmitter.emit(symbolB);
   myEmitter.emit(symbolC);
 
-  expect(called).toEqual(6)
-  expect(myEmitter.eventNames()).toEqual([symbolA, symbolC])
+  expect(called).toEqual(6);
+  expect(myEmitter.eventNames()).toEqual([symbolA, symbolC]);
 });
 
 it("should prepend event listeners", async () => {
@@ -106,6 +106,6 @@ it("should set abort reason on AbortSignal", () => {
 
   abortController.abort("cancelled");
 
-  assert.equal(signal.aborted, true);
-  assert.equal(signal.reason, "cancelled");  
+  expect(signal.aborted).toEqual(true);
+  expect(signal.reason).toEqual("cancelled");
 });

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -99,3 +99,12 @@ it("should handle events emitted recursively", (done) => {
 
   ee.emit("test");
 });
+
+it("should set abort reason on AbortSignal", () => {
+  const abortController = new AbortController();
+  const signal = abortController.signal;
+
+  abortController.abort("cancelled");
+
+  assert.equal(signal.reason, "cancelled");  
+});

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -106,5 +106,6 @@ it("should set abort reason on AbortSignal", () => {
 
   abortController.abort("cancelled");
 
+  assert.equal(signal.aborted, true);
   assert.equal(signal.reason, "cancelled");  
 });


### PR DESCRIPTION
### Issue # (if available)

https://github.com/awslabs/llrt/issues/248

### Description of changes

Adds an implementation for `AbortController` with stubbed methods for `AbortSignal` which would have the actual event aborting implementation.  This implementation attempts to follow the specification found here https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-abortcontroller%E2%91%A0

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
