### PR TITLE
Fix 'make release' in Windows WSL2 environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ endif
 
 ifeq ($(ARCH),aarch64)
 	ARCH = arm64
+else ifeq ($(ARCH),x86_64)
+	ARCH = x64
 endif
 
 CURRENT_TARGET ?= $(TARGET_$(DETECTED_OS)_$(ARCH))

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,6 @@ endif
 
 ifeq ($(ARCH),aarch64)
 	ARCH = arm64
-else ifeq ($(ARCH),x86_64)
-	ARCH = x64
 endif
 
 CURRENT_TARGET ?= $(TARGET_$(DETECTED_OS)_$(ARCH))
@@ -67,6 +65,8 @@ llrt-linux-x64.zip: | clean-js js
 llrt-linux-arm64.zip: | clean-js js
 	cargo $(BUILD_ARG) --target $(TARGET_linux_arm64)
 	zip -j $@ target/$(TARGET_linux_arm64)/release/llrt
+
+llrt-linux-x86_64.zip: llrt-linux-x64.zip
 
 define release_template
 release-${1}: | clean-js js


### PR DESCRIPTION
### Issue  #274 

### Description of changes

- Fix `make release` in Windows WSL2 environment

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
