### PR TITLE
fix: [ERROR] No replacement found for "getRuntimeConfig"

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -396,6 +396,7 @@ const AWS_SDK_PLUGIN = {
       build.onLoad({ filter }, async ({ path }) => {
         let source = (await fs.readFile(path)).toString();
         let replaced = false;
+        let contents = "";
         source = source.replace(
           RegExp(`export\\s*(const\\s*${name})`),
           (_, replacement) => {
@@ -404,12 +405,13 @@ const AWS_SDK_PLUGIN = {
           }
         );
         if (!replaced) {
-          throw new Error(`No replacement found for "${name}" in ${filter}`);
+          contents += source;
+        } else {
+          const wrapperName = `${name}Wrapper`;
+          contents += `${source}\n`;
+          contents += `const ${wrapperName} = ${wrapper.toString()}\n`;
+          contents += `export {${wrapperName} as ${name}}`;
         }
-        const wrapperName = `${name}Wrapper`;
-        let contents = `${source}\n`;
-        contents += `const ${wrapperName} = ${wrapper.toString()}\n`;
-        contents += `export {${wrapperName} as ${name}}`;
 
         return {
           contents,


### PR DESCRIPTION
### Description of changes

- fix: [ERROR] No replacement found for "getRuntimeConfig" in runtimeConfig.shared.js

### Detail

There is wrapper logic in `build.mjs` that injects AWS credentials and region parameters into `runtimeConfig.shared.js` in `@aws-sdk`.

However, we found that there are `runtimeConfig.shared.js` in `@aws-sdk` that do not follow the following rules.

@aws-sdk/client-s3/dist-es/runtimeConfig.shared.js:
```javascript
// getRuntimeConfig is included in the code, so it is successfully bundled.
...
export const getRuntimeConfig = (config) => {
    return {
        apiVersion: "2006-03-01",
        base64Decoder: config?.base64Decoder ?? fromBase64,
        base64Encoder: config?.base64Encoder ?? toBase64,
        disableHostPrefix: config?.disableHostPrefix ?? false,
        endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
        extensions: config?.extensions ?? [],
        getAwsChunkedEncodingStream: config?.getAwsChunkedEncodingStream ?? getAwsChunkedEncodingStream,
        logger: config?.logger ?? new NoOpLogger(),
        sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
        serviceId: config?.serviceId ?? "S3",
        signerConstructor: config?.signerConstructor ?? SignatureV4MultiRegion,
        signingEscapePath: config?.signingEscapePath ?? false,
        urlParser: config?.urlParser ?? parseUrl,
        useArnRegion: config?.useArnRegion ?? false,
        utf8Decoder: config?.utf8Decoder ?? fromUtf8,
        utf8Encoder: config?.utf8Encoder ?? toUtf8,
    };
};
```

For example, `@aws-sdk/lib-storage` (which I hope to bundle in the future)

@aws-sdk/lib-storage/dist-es/runtimeConfig.shared.js:
```javascript
// Error during bundling because getRuntimeConfig is not included in the code.
export const ClientSharedValues = {
    lstatSync: () => { },
};
```
This PR allows for `runtimeConfig.shared.js` that do not follow the laws to be bundled as is, without making an error that the wrapper logic cannot be injected.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
