### PR TITLE
feat: implement Console object with import node:console or console

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,6 +21,9 @@ Everything else inherited from [Uint8Array](https://developer.mozilla.org/en-US/
 
 [spawn](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options)
 
+## console
+[Console](https://nodejs.org/api/console.html#class-console)
+
 ## crypto
 
 [createHash](https://nodejs.org/api/crypto.html#cryptocreatehashalgorithm-options)

--- a/build.mjs
+++ b/build.mjs
@@ -52,6 +52,8 @@ const ES_BUILD_OPTIONS = {
   platform: "browser",
   format: "esm",
   external: [
+    "node:console",
+    "console",
     "crypto",
     "uuid",
     "hex",

--- a/tests/unit/console.test.ts
+++ b/tests/unit/console.test.ts
@@ -1,4 +1,6 @@
 import * as timers from "timers";
+import { Console as NodeConsole } from "node:console";
+import { Console } from "console";
 
 function log(...args: any[]) {
   return (console as any).__formatPlain(...args);
@@ -24,6 +26,41 @@ it("should log module", () => {
 }
 `.trim()
   );
+});
+it("should log using console object", () => {
+  const consoleObj = new Console({
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
+
+  // we check if the log does not throw an exception when called
+  consoleObj.log("log");
+  consoleObj.debug("debug");
+  consoleObj.info("info");
+  consoleObj.assert(false, "text for assertion should display");
+  consoleObj.assert(true, "This text should not be seen");
+
+  consoleObj.warn("warn");
+  consoleObj.error("error");
+  consoleObj.trace("trace");
+});
+
+it("should log using node:console object", () => {
+  const consoleObj = new NodeConsole({
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
+
+  // we check if the log does not throw an exception when called
+  consoleObj.log("log");
+  consoleObj.debug("debug");
+  consoleObj.info("info");
+  consoleObj.assert(false, "text for assertion should display");
+  consoleObj.assert(true, "This text should not be seen");
+
+  consoleObj.warn("warn");
+  consoleObj.error("error");
+  consoleObj.trace("trace");
 });
 
 it("should log complex object", () => {


### PR DESCRIPTION
### Issue #130

### Description of changes

Added the possibility to create a Console object (but does not support custom steams for now)

### Checklist

- [X] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [X] Ran `make fix` to format JS and apply Clippy auto fixes
- [X] Made sure my code didn't add any additional warnings: `make check`
- [X] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
