### PR TITLE
typo: Correction of artifact name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Choose `Custom Runtime on Amazon Linux 2023` and package the LLRT `bootstrap` bi
 
 ### Option 2: Use a layer
 
-Choose `Custom Runtime on Amazon Linux 2023`, upload `llrt-lambda-arm64.zip` or `llrt-lambda-x86.zip` as a layer and add to your function
+Choose `Custom Runtime on Amazon Linux 2023`, upload `llrt-lambda-arm64.zip` or `llrt-lambda-x64.zip` as a layer and add to your function
 
 ### Option 3: Package LLRT in a container image
 
@@ -308,7 +308,7 @@ Optionally build for your local machine (Mac or Linux)
 
     make release
 
-You should now have a `llrt-lambda-arm64.zip` or `llrt-lambda-x86.zip`. You can manually upload this as a Lambda layer or use it via your Infrastructure-as-code pipeline
+You should now have a `llrt-lambda-arm64.zip` or `llrt-lambda-x64.zip`. You can manually upload this as a Lambda layer or use it via your Infrastructure-as-code pipeline
 
 ## Running Lambda emulator
 


### PR DESCRIPTION
### Description of changes

in README.md

- Correction of artifact name `llrt-lambda-x86.zip` -> `llrt-lambda-x64.zip`

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
