### PR TITLE
feat: implement globalThis.navigator.userAgent

### DIFF
--- a/API.md
+++ b/API.md
@@ -22,6 +22,7 @@ Everything else inherited from [Uint8Array](https://developer.mozilla.org/en-US/
 [spawn](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options)
 
 ## console
+
 [Console](https://nodejs.org/api/console.html#class-console)
 
 ## crypto
@@ -225,6 +226,8 @@ export class XMLParser(options?: XmlParserOptions){
 
 [structuredClone](https://nodejs.org/api/globals.html#structuredclonevalue-options)
 
-[atoa](https://developer.mozilla.org/en-US/docs/Web/API/btoa)
+[btoa](https://developer.mozilla.org/en-US/docs/Web/API/btoa)
 
 [atob](https://developer.mozilla.org/en-US/docs/Web/API/atob)
+
+[navigator.userAgent](https://nodejs.org/api/globals.html#navigatoruseragent)

--- a/build.mjs
+++ b/build.mjs
@@ -68,6 +68,7 @@ const ES_BUILD_OPTIONS = {
     "buffer",
     "xml",
     "net",
+    "navigator",
   ],
 };
 

--- a/src/http/fetch.rs
+++ b/src/http/fetch.rs
@@ -160,7 +160,7 @@ pub(crate) fn init(ctx: &Ctx<'_>, globals: &Object) -> Result<()> {
                 let mut req = Request::builder()
                     .method(method)
                     .uri(uri)
-                    .header("user-agent", format!("llrt {}", VERSION))
+                    .header("user-agent", format!("llrt/{}", VERSION))
                     .header("accept", "*/*");
 
                 if let Some(headers) = headers {

--- a/src/http/fetch.rs
+++ b/src/http/fetch.rs
@@ -160,7 +160,7 @@ pub(crate) fn init(ctx: &Ctx<'_>, globals: &Object) -> Result<()> {
                 let mut req = Request::builder()
                     .method(method)
                     .uri(uri)
-                    .header("user-agent", format!("llrt/{}", VERSION))
+                    .header("user-agent", format!("llrt {}", VERSION))
                     .header("accept", "*/*");
 
                 if let Some(headers) = headers {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod http;
 mod json;
 mod minimal_tracer;
 mod module;
+mod navigator;
 mod net;
 mod number;
 mod os;

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use rquickjs::{
+    module::{Declarations, Exports, ModuleDef},
+    Ctx, Object, Result, Value,
+};
+
+use crate::module::export_default;
+
+use crate::VERSION;
+
+fn get_user_agent() -> String {
+    format!("llrt/{}", VERSION)
+}
+
+pub fn init(ctx: &Ctx<'_>) -> Result<()> {
+    let globals = ctx.globals();
+
+    let navigator = Object::new(ctx.clone())?;
+
+    navigator.set("userAgent", get_user_agent())?;
+
+    globals.set("navigator", navigator)?;
+
+    Ok(())
+}
+
+pub struct NavigatorModule;
+
+impl ModuleDef for NavigatorModule {
+    fn declare(declare: &mut Declarations) -> Result<()> {
+        declare.declare("userAgent")?;
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &mut Exports<'js>) -> Result<()> {
+        let globals = ctx.globals();
+        let navigator: Object = globals.get("navigator")?;
+
+        export_default(ctx, exports, |default| {
+            for name in navigator.keys::<String>() {
+                let name = name?;
+                let value: Value = navigator.get(&name)?;
+                default.set(name, value)?;
+            }
+
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -10,7 +10,7 @@ use crate::module::export_default;
 use crate::VERSION;
 
 fn get_user_agent() -> String {
-    format!("llrt/{}", VERSION)
+    format!("llrt {}", VERSION)
 }
 
 pub fn init(ctx: &Ctx<'_>) -> Result<()> {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -48,6 +48,7 @@ use crate::{
     fs::{FsModule, FsPromisesModule},
     json::{parse::json_parse, stringify::json_stringify_replacer_space},
     module::ModuleModule,
+    navigator::NavigatorModule,
     net::NetModule,
     number::number_to_string,
     os::OsModule,
@@ -128,7 +129,8 @@ create_modules!(
     "child_process" => ChildProcessModule,
     "util" => UtilModule,
     "uuid" => UuidModule,
-    "process" => ProcessModule
+    "process" => ProcessModule,
+    "navigator" => NavigatorModule
 );
 
 struct ModuleInfo<T: ModuleDef> {
@@ -478,6 +480,7 @@ impl Vm {
             crate::process::init(&ctx)?;
             crate::events::init(&ctx)?;
             crate::buffer::init(&ctx)?;
+            crate::navigator::init(&ctx)?;
             init(&ctx, module_names)?;
             Ok::<_, Error>(())
         })

--- a/tests/unit/navigator.test.ts
+++ b/tests/unit/navigator.test.ts
@@ -6,7 +6,7 @@ describe("navigator.userAgent", () => {
     expect(defaultImport.userAgent).toEqual(navigator.userAgent);
     expect(namedImport.userAgent).toEqual(navigator.userAgent);
   });
-  it("should start with \"llrt/\"", () => {
-    expect(navigator.userAgent.startsWith("llrt/")).toBeTruthy();
+  it("should start with \"llrt \"", () => {
+    expect(navigator.userAgent.startsWith("llrt ")).toBeTruthy();
   });
 });

--- a/tests/unit/navigator.test.ts
+++ b/tests/unit/navigator.test.ts
@@ -6,4 +6,7 @@ describe("navigator.userAgent", () => {
     expect(defaultImport.userAgent).toEqual(navigator.userAgent);
     expect(namedImport.userAgent).toEqual(navigator.userAgent);
   });
+  it("should start with \"llrt/\"", () => {
+    expect(navigator.userAgent.startsWith("llrt/")).toBeTruthy();
+  });
 });

--- a/tests/unit/navigator.test.ts
+++ b/tests/unit/navigator.test.ts
@@ -1,0 +1,9 @@
+import defaultImport from "navigator";
+import * as namedImport from "navigator";
+
+describe("navigator.userAgent", () => {
+  it("should have a navigator userAgent", () => {
+    expect(defaultImport.userAgent).toEqual(navigator.userAgent);
+    expect(namedImport.userAgent).toEqual(navigator.userAgent);
+  });
+});


### PR DESCRIPTION
### Description of changes

[The Minimum Common Web Platform API](https://common-min-api.proposal.wintercg.org/) is being considered at WinterCG.
I implemented one of the APIs, `globalThis.navigator.userAgent`.

This is my first time coding in the rust language, so I will promote it as a draft version.
Please point out if it does not follow `llrt` or `rust` conventions.

### Local execution results

![image](https://github.com/awslabs/llrt/assets/7500514/ec85a149-de74-4006-8954-470fe0a45262)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
