### PR TITLE
chore: remove `assert` support to make sure jest/chai is used instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For more information about the E2E Tests and how to run them, see [here](tests/e
 
 ### Test runner
 
-Test runner uses a lightweight Jest-like API and supports Jest/Chai assertions and the [assert module](https://nodejs.org/api/assert.html) from Node.js for test assertions. For examples on how to implement tests for LLRT see the `/tests` folder of this repository.
+Test runner uses a lightweight Jest-like API and supports Jest/Chai assertions. For examples on how to implement tests for LLRT see the `/tests` folder of this repository.
 
 To run tests, execute the `llrt test` command. LLRT scans the current directory and sub-directories for files that ends with `*.test.js` or `*.test.mjs`. You can also provide a specific test directory to scan by using the `llrt test -d <directory>` option.
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/jest": "29.5.12",
     "@types/readable-stream": "4.0.10",
     "@types/uuid": "9.0.8",
-    "assert": "2.1.0",
     "esbuild": "0.20.1",
     "esbuild-plugins-node-modules-polyfill": "1.6.3",
     "prettier": "3.2.5",

--- a/src/js/@llrt/test.ts
+++ b/src/js/@llrt/test.ts
@@ -1,12 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import assert from "assert";
 import * as chai from "chai";
 import { JestChaiExpect } from "./expect/jest-expect";
 import { JestAsymmetricMatchers } from "./expect/jest-asymmetric-matchers";
 
 const GLOBAL = globalThis as any;
-GLOBAL.assert = assert;
 const START = Date.now();
 const SUITE_LOAD_PROMISES: (() => Promise<void>)[] = [];
 const DEFAULT_TIMEOUT_MS = 5000;


### PR DESCRIPTION
Refs: #240

### Issue #240 

### Description of changes

As discussed, removed `assert` support to make sure jest/chai assertions are used instead (using vitest)

### Checklist

- [N/A] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [X] Ran `make fix` to format JS and apply Clippy auto fixes
- [X] Made sure my code didn't add any additional warnings: `make check`
- [X] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
