### PR TITLE
feat: implement randomInt in crypto module

### DIFF
--- a/API.md
+++ b/API.md
@@ -36,6 +36,8 @@ Everything else inherited from [Uint8Array](https://developer.mozilla.org/en-US/
 
 [randomFillSync](https://nodejs.org/api/crypto.html#cryptorandomfillsyncbuffer-offset-size)
 
+[randomInt](https://nodejs.org/api/crypto.html#cryptorandomintmin-max-callback)
+
 [randomUUID](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions)
 
 ## events

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "quick-xml",
+ "rand",
  "relative-path",
  "ring",
  "rquickjs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ tokio-rustls = { version = "0.25.0", features = [
     "ring",
 ], default-features = false }
 ring = "0.17.8"
+rand = "0.8.5"
 snmalloc-rs = { version = "0.3.5", features = ["lto"] }
 uname = "0.1.1"
 

--- a/build.mjs
+++ b/build.mjs
@@ -52,8 +52,8 @@ const ES_BUILD_OPTIONS = {
   platform: "browser",
   format: "esm",
   external: [
-    "node:console",
     "console",
+    "node:console",
     "crypto",
     "uuid",
     "hex",

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -51,7 +51,7 @@ describe("random", () => {
     crypto.randomFillSync(uint8Array);
     expect(uint8Array.length).toEqual(16);
     for (const byte of uint8Array) {
-      expect(byte >= 0 && byte <= 255).toBeTruthy()
+      expect(byte >= 0 && byte <= 255).toBeTruthy();
     }
   });
 
@@ -62,7 +62,9 @@ describe("random", () => {
       expect(buffer.buffer).toEqual(dataView.buffer);
       expect(dataView.byteLength).toEqual(32);
       for (let i = 0; i < 32; i++) {
-        expect(dataView.getUint8(i) >= 0 && dataView.getUint8(i) <= 255).toBeTruthy()
+        expect(
+          dataView.getUint8(i) >= 0 && dataView.getUint8(i) <= 255
+        ).toBeTruthy();
       }
       done();
     });
@@ -80,5 +82,25 @@ describe("random", () => {
     const buffer = crypto.randomBytes(16);
     expect(buffer).toBeInstanceOf(Buffer);
     expect(buffer.length).toEqual(16);
+  });
+
+  it("should generate a random int using randomInt", () => {
+    // Do it 10 times, to make sure we respect min and max
+    for (const number of [...Array(10).keys()]) {
+      const randomInt = crypto.randomInt(
+        Number.MAX_SAFE_INTEGER - 1,
+        Number.MAX_SAFE_INTEGER
+      );
+      expect(typeof randomInt).toEqual("number");
+      expect(Number.MAX_SAFE_INTEGER - 1).toEqual(randomInt);
+      expect(typeof randomInt).toEqual("number");
+    }
+
+    // Do it 20 times to make sure we never get values outside the range
+    for (const number of [...Array(20).keys()]) {
+      const randomInt = crypto.randomInt(0, 5);
+      expect(randomInt).toBeLessThan(5);
+      expect(randomInt).toBeGreaterThanOrEqual(0);
+    }
   });
 });


### PR DESCRIPTION
### Issue #294

### Description of changes

Implement randomInt with support for min and max value only so that it can be used with powertools.

### Checklist

- [X] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [X] Ran `make fix` to format JS and apply Clippy auto fixes
- [X] Made sure my code didn't add any additional warnings: `make check`
- [X] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
