### PR TITLE
chore: add llrt binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ node_modules
 out.stacks
 yarn-error.log
 llrt-container-*
+llrt
+bootstrap


### PR DESCRIPTION
### Description of changes

- Adding `llrt` and `bootstrap` to `.gitignore` prevents accidental commits after unzipping a zip created with `make release` or `make release-*` and checking local behavior.

### Checklist

- [n/a] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [n/a] Ran `make fix` to format JS and apply Clippy auto fixes
- [n/a] Made sure my code didn't add any additional warnings: `make check`
- [n/a] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
