### PR TITLE
fix an issue where require would not work in LLRT when the `node:` prefix was used

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -663,6 +663,10 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
         "require",
         Func::from(move |ctx, specifier: String| -> Result<Value> {
             let LifetimeArgs(ctx) = LifetimeArgs(ctx);
+            let specifier: String = specifier
+                .strip_prefix("node:")
+                .unwrap_or(specifier.as_str())
+                .into();
             let import_name = if module_names.contains(specifier.as_str())
                 || BYTECODE_CACHE.contains_key(&specifier)
                 || specifier.starts_with('/')

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -5,7 +5,7 @@ const CWD = process.cwd();
 it("should require a file", () => {
   const { hello } = _require(`${CWD}/fixtures/hello.js`);
 
-  expect(hello).toEqual("hello world!")
+  expect(hello).toEqual("hello world!");
 });
 
 it("should return same module when require multiple files", () => {
@@ -13,19 +13,38 @@ it("should return same module when require multiple files", () => {
   const { hello: hello2 } = _require(`${CWD}/fixtures/hello.js`);
   const { hello: hello3 } = _require(`${CWD}/fixtures/hello.js`);
 
-  expect(hello1).toEqual(hello2)
-  expect(hello1).toEqual(hello3)
+  expect(hello1).toEqual(hello2);
+  expect(hello1).toEqual(hello3);
 });
 
 it("should handle cyclic requires", () => {
   const a = _require(`${CWD}/fixtures/a.js`);
   const b = _require(`${CWD}/fixtures/b.js`);
 
-  expect(a.done).toEqual(b.done)
+  expect(a.done).toEqual(b.done);
 });
 
 it("should handle cjs requires", () => {
   const a = _require(`${CWD}/fixtures/import.cjs`);
 
-  expect(a.c).toEqual("c")
+  expect(a.c).toEqual("c");
+});
+
+it("should be able to use node module with prefix `node:` with require", () => {
+  let { Console } = require("node:console");
+  const consoleObj = new Console({
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
+
+  // we check if the log does not throw an exception when called
+  consoleObj.log("log");
+  consoleObj.debug("debug");
+  consoleObj.info("info");
+  consoleObj.assert(false, "text for assertion should display");
+  consoleObj.assert(true, "This text should not be seen");
+
+  consoleObj.warn("warn");
+  consoleObj.error("error");
+  consoleObj.trace("trace");
 });


### PR DESCRIPTION
### Issue #309

### Description of changes

Fix an issue where require would not work in LLRT when the `node:` prefix was used

### Checklist

- [X] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [X] Ran `make fix` to format JS and apply Clippy auto fixes
- [X] Made sure my code didn't add any additional warnings: `make check`
- [N/A] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
