### PR TITLE
Implement Request#signal.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run tests
         if: inputs.arch != 'aarch64' || inputs.platform != 'linux'
         run: |
-          make test-ci
+          make test-ci 2>&1
       - name: Run tests
         if: inputs.arch == 'aarch64' && inputs.platform == 'linux'
         env:

--- a/API.md
+++ b/API.md
@@ -311,6 +311,10 @@ export class XMLParser(options?: XmlParserOptions){
 
 ## Misc Global objects
 
+[AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+
+[AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+
 [atob](https://developer.mozilla.org/en-US/docs/Web/API/atob)
 
 [btoa](https://developer.mozilla.org/en-US/docs/Web/API/btoa)

--- a/src/events.rs
+++ b/src/events.rs
@@ -428,6 +428,7 @@ impl<'js> AbortController<'js> {
 }
 
 //TODO implement static methods abort() and timeout(miliseconds)
+#[derive(Clone, Debug, Default)]
 #[rquickjs::class]
 pub struct AbortSignal<'js> {
     aborted: bool,
@@ -446,10 +447,7 @@ impl<'js> Trace<'js> for AbortSignal<'js> {
 impl<'js> AbortSignal<'js> {
     #[qjs(constructor)]
     pub fn new() -> Self {
-        Self {
-            aborted: false,
-            reason: None,
-        }
+        Self::default()
     }
 
     #[qjs(get)]

--- a/src/events.rs
+++ b/src/events.rs
@@ -523,7 +523,7 @@ impl<'js> AbortSignal<'js> {
                     }),
                 )?,
                 false,
-                false,
+                true,
             )?;
         }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -12,8 +12,8 @@ use rquickjs::{
     function::OnceFn,
     module::{Declarations, Exports, ModuleDef},
     prelude::{Func, Opt, Rest, This},
-    Array, CatchResultExt, Class, Ctx, Exception, Function, IntoJs, Object, Result,
-    String as JsString, Symbol, Undefined, Value,
+    Array, CatchResultExt, Class, Ctx, Exception, Function, Object, Result, String as JsString,
+    Symbol, Undefined, Value,
 };
 
 use tracing::trace;

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -8,7 +8,7 @@ use rquickjs::{
 
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace)]
-struct DOMException {
+pub struct DOMException {
     message: String,
     name: String,
     stack: String,
@@ -17,16 +17,16 @@ struct DOMException {
 #[rquickjs::methods]
 impl DOMException {
     #[qjs(constructor)]
-    fn new(ctx: Ctx<'_>, message: Opt<String>, name: Opt<String>) -> Result<Self> {
+    pub fn new(ctx: Ctx<'_>, message: Opt<String>, name: Opt<String>) -> Result<Self> {
         let error_ctor: Constructor = ctx.globals().get(PredefinedAtom::Error)?;
         let new: Object = error_ctor.construct((message.clone(),))?;
 
-        let var_message = message.0.unwrap_or(String::from(""));
-        let var_name = name.0.unwrap_or(String::from("Error"));
+        let message = message.0.unwrap_or(String::from(""));
+        let name = name.0.unwrap_or(String::from("Error"));
 
         Ok(Self {
-            message: var_message,
-            name: var_name,
+            message,
+            name,
             stack: new.get::<_, String>(PredefinedAtom::Stack)?,
         })
     }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -129,13 +129,13 @@ fn assign_request<'js>(request: &mut Request<'js>, ctx: Ctx<'js>, obj: &Object<'
                 Some(signal_obj) if signal_obj.instance_of::<AbortSignal>() => {
                     let signal = AbortSignal::from_js(&ctx, signal)?;
                     request.signal = Some(Class::instance(ctx.clone(), signal)?);
-                }
+                },
                 _ => {
                     return Err(request_construct_type_error(
                         &ctx,
                         "member signal is not of type AbortSignal.",
                     ));
-                }
+                },
             }
         }
     }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -124,8 +124,15 @@ fn assign_request<'js>(request: &mut Request<'js>, ctx: Ctx<'js>, obj: &Object<'
 
     if obj.contains_key("signal").unwrap() {
         let signal: Value = obj.get("signal")?;
-        let signal = AbortSignal::from_js(&ctx, signal)?;
-        request.signal = Some(Class::instance(ctx.clone(), signal)?);
+        if !signal.is_undefined() && !signal.is_null() {
+            let signal = AbortSignal::from_js(&ctx, signal).map_err(|_| {
+                Exception::throw_type(
+                    &ctx,
+                    "Failed to construct 'Request': 'signal' property is not an AbortSignal",
+                )
+            })?;
+            request.signal = Some(Class::instance(ctx.clone(), signal)?);
+        }
     }
 
     if obj.contains_key("body").unwrap_or_default() {

--- a/src/utils/mc_oneshot.rs
+++ b/src/utils/mc_oneshot.rs
@@ -113,6 +113,6 @@ mod tests {
 
         rx3.recv().await;
 
-        join!(a, b);
+        let _ = join!(a, b);
     }
 }

--- a/src/utils/mc_oneshot.rs
+++ b/src/utils/mc_oneshot.rs
@@ -95,8 +95,6 @@ mod tests {
         let rx2 = tx.subscribe();
         let rx3 = tx.subscribe();
 
-        // tx.send(false);
-
         let a = tokio::spawn(async move {
             let val = rx1.recv().await; //wait for value to become false
             assert!(val)
@@ -109,10 +107,13 @@ mod tests {
 
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-        tx.send(false);
+        tx.send(true);
 
-        rx3.recv().await;
+        let val = rx3.recv().await;
+        assert!(val);
 
-        let _ = join!(a, b);
+        let (a, b) = join!(a, b);
+        a.unwrap();
+        b.unwrap();
     }
 }

--- a/src/utils/mc_oneshot.rs
+++ b/src/utils/mc_oneshot.rs
@@ -99,12 +99,12 @@ mod tests {
 
         let a = tokio::spawn(async move {
             let val = rx1.recv().await; //wait for value to become false
-            assert_eq!(val, true)
+            assert!(val)
         });
 
         let b = tokio::spawn(async move {
             let val = rx2.recv().await; //wait for value to become false
-            assert_eq!(val, true)
+            assert!(val)
         });
 
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/src/utils/mc_oneshot.rs
+++ b/src/utils/mc_oneshot.rs
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+    task::{Context, Poll},
+};
+
+#[derive(Clone, Debug)]
+pub struct Sender<T: Clone> {
+    is_sent: Arc<AtomicBool>,
+    value: Arc<RwLock<Option<T>>>,
+}
+
+impl<T: Clone> Sender<T> {
+    pub fn send(&self, value: T) {
+        if !self.is_sent.load(Ordering::Relaxed) {
+            self.value.write().unwrap().replace(value);
+            self.is_sent.store(true, Ordering::Relaxed);
+        }
+    }
+
+    pub fn subscribe(&self) -> Receiver<T> {
+        Receiver {
+            is_sent: self.is_sent.clone(),
+            value: self.value.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Receiver<T: Clone> {
+    is_sent: Arc<AtomicBool>,
+    value: Arc<RwLock<Option<T>>>,
+}
+
+impl<T: Clone> Receiver<T> {
+    pub fn recv(&self) -> ReceiverWaiter<T> {
+        ReceiverWaiter {
+            is_sent: self.is_sent.clone(),
+            value: self.value.clone(),
+        }
+    }
+}
+
+pub struct ReceiverWaiter<T: Clone> {
+    is_sent: Arc<AtomicBool>,
+    value: Arc<RwLock<Option<T>>>,
+}
+
+impl<T: Clone> Future for ReceiverWaiter<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.is_sent.load(Ordering::Relaxed) {
+            let a = self.get_mut().value.read().unwrap().clone().unwrap();
+            return Poll::Ready(a);
+        }
+
+        cx.waker().wake_by_ref();
+
+        Poll::Pending
+    }
+}
+
+pub fn channel<T: Clone>() -> (Sender<T>, Receiver<T>) {
+    let is_sent = Arc::new(AtomicBool::new(false));
+    let value = Arc::new(RwLock::new(None));
+
+    (
+        Sender {
+            is_sent: is_sent.clone(),
+            value: value.clone(),
+        },
+        Receiver {
+            is_sent: is_sent.clone(),
+            value: value.clone(),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::join;
+
+    #[tokio::test]
+    async fn test() {
+        let (tx, rx1) = super::channel::<bool>();
+
+        let rx2 = tx.subscribe();
+        let rx3 = tx.subscribe();
+
+        // tx.send(false);
+
+        let a = tokio::spawn(async move {
+            let val = rx1.recv().await; //wait for value to become false
+            assert_eq!(val, true)
+        });
+
+        let b = tokio::spawn(async move {
+            let val = rx2.recv().await; //wait for value to become false
+            assert_eq!(val, true)
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        tx.send(false);
+
+        rx3.recv().await;
+
+        join!(a, b);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,7 @@ use crate::module::export_default;
 pub mod class;
 pub mod clone;
 pub mod io;
+pub mod mc_oneshot;
 pub mod object;
 pub mod result;
 pub mod string;

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -1,111 +1,143 @@
 import { EventEmitter } from "events";
 
-it("should use custom EventEmitter", () => {
-  let called = 0;
-  const symbolA = Symbol();
-  const symbolB = Symbol();
-  const symbolC = Symbol();
-  const callback = () => {
-    called++;
-  };
+describe("EventEmitter", () => {
+  it("should use custom EventEmitter", () => {
+    let called = 0;
+    const symbolA = Symbol();
+    const symbolB = Symbol();
+    const symbolC = Symbol();
+    const callback = () => {
+      called++;
+    };
 
-  class MyEmitter extends EventEmitter {}
-  const myEmitter = new MyEmitter();
-  const myEmitter2 = new MyEmitter();
+    class MyEmitter extends EventEmitter {}
+    const myEmitter = new MyEmitter();
+    const myEmitter2 = new MyEmitter();
 
-  myEmitter.once("event", function (a, b) {
-    expect(a).toEqual("a");
-    expect(b).toEqual("b");
-    // @ts-ignore
-    expect(this instanceof MyEmitter).toBeTruthy();
-    // @ts-ignore
-    expect(this === myEmitter).toBeTruthy();
-    // @ts-ignore
-    expect(this !== myEmitter2).toBeTruthy();
-    called++;
+    myEmitter.once("event", function (a, b) {
+      expect(a).toEqual("a");
+      expect(b).toEqual("b");
+      // @ts-ignore
+      expect(this instanceof MyEmitter).toBeTruthy();
+      // @ts-ignore
+      expect(this === myEmitter).toBeTruthy();
+      // @ts-ignore
+      expect(this !== myEmitter2).toBeTruthy();
+      called++;
+    });
+
+    myEmitter.on(symbolA, callback);
+    myEmitter.on(symbolB, callback);
+    myEmitter.on(symbolC, callback);
+
+    myEmitter.emit("event", "a", "b");
+    myEmitter.emit(symbolA);
+    myEmitter.emit(symbolB);
+    myEmitter.emit(symbolC);
+
+    expect(called).toEqual(4);
+    expect(myEmitter.eventNames()).toEqual([symbolA, symbolB, symbolC]);
+
+    myEmitter.off(symbolB, callback);
+
+    myEmitter.emit("event", "a", "b");
+    myEmitter.emit(symbolA);
+    myEmitter.emit(symbolB);
+    myEmitter.emit(symbolC);
+
+    expect(called).toEqual(6);
+    expect(myEmitter.eventNames()).toEqual([symbolA, symbolC]);
   });
 
-  myEmitter.on(symbolA, callback);
-  myEmitter.on(symbolB, callback);
-  myEmitter.on(symbolC, callback);
+  it("should prepend event listeners", async () => {
+    const myEmitter = new EventEmitter();
 
-  myEmitter.emit("event", "a", "b");
-  myEmitter.emit(symbolA);
-  myEmitter.emit(symbolB);
-  myEmitter.emit(symbolC);
+    const eventsArray: string[] = [];
 
-  expect(called).toEqual(4);
-  expect(myEmitter.eventNames()).toEqual([symbolA, symbolB, symbolC]);
+    myEmitter.addListener("event", () => {
+      eventsArray.push("added first");
+    });
+    myEmitter.prependListener("event", () => {
+      eventsArray.push("added to beginning");
+    });
+    myEmitter.addListener("event", () => {
+      eventsArray.push("last");
+    });
+    myEmitter.prependListener("event", () => {
+      eventsArray.push("even before that");
+    });
 
-  myEmitter.off(symbolB, callback);
+    myEmitter.emit("event");
 
-  myEmitter.emit("event", "a", "b");
-  myEmitter.emit(symbolA);
-  myEmitter.emit(symbolB);
-  myEmitter.emit(symbolC);
+    expect(eventsArray).toEqual([
+      "even before that",
+      "added to beginning",
+      "added first",
+      "last",
+    ]);
+  });
 
-  expect(called).toEqual(6);
-  expect(myEmitter.eventNames()).toEqual([symbolA, symbolC]);
+  it("should handle crash in event handler", () => {
+    const emitter = new EventEmitter();
+
+    emitter.on("data", () => {
+      throw new Error("error");
+    });
+
+    expect(() => {
+      emitter.emit("data", 123);
+    }).toThrow();
+  });
+
+  it("should handle events emitted recursively", (done) => {
+    const ee = new EventEmitter();
+
+    ee.on("test", () => {
+      ee.emit("test2");
+    });
+
+    ee.on("test2", done);
+
+    ee.emit("test");
+  });
 });
 
-it("should prepend event listeners", async () => {
-  const myEmitter = new EventEmitter();
+describe("AbortSignal & AbortController", () => {
+  it("should set abort reason on AbortSignal", () => {
+    const abortController = new AbortController();
+    const signal = abortController.signal;
 
-  const eventsArray: string[] = [];
+    abortController.abort("cancelled");
 
-  myEmitter.addListener("event", () => {
-    eventsArray.push("added first");
-  });
-  myEmitter.prependListener("event", () => {
-    eventsArray.push("added to beginning");
-  });
-  myEmitter.addListener("event", () => {
-    eventsArray.push("last");
-  });
-  myEmitter.prependListener("event", () => {
-    eventsArray.push("even before that");
+    expect(signal.aborted).toEqual(true);
+    expect(signal.reason).toEqual("cancelled");
   });
 
-  myEmitter.emit("event");
-
-  expect(eventsArray).toEqual([
-    "even before that",
-    "added to beginning",
-    "added first",
-    "last",
-  ]);
-});
-
-it("should handle crash in event handler", () => {
-  const emitter = new EventEmitter();
-
-  emitter.on("data", () => {
-    throw new Error("error");
+  it("should throw DomException on timeout", (done) => {
+    let signal = AbortSignal.timeout(10);
+    setTimeout(() => {
+      expect(signal.aborted).toBe(false);
+      setTimeout(() => {
+        expect(signal.aborted).toBe(true);
+        //@ts-ignore
+        expect(signal.reason).toBeInstanceOf(DOMException);
+        expect(signal.reason.name).toBe("TimeoutError");
+        done();
+      }, 50);
+    }, 5);
   });
 
-  expect(() => {
-    emitter.emit("data", 123);
-  }).toThrow();
-});
+  it("should abort if any signal is aborted asynchronously", (done) => {
+    let signal = AbortSignal.timeout(10);
+    let ctrl = new AbortController();
+    //@ts-ignore
+    let new_signal: AbortSignal = AbortSignal.any([signal, ctrl.signal]);
 
-it("should handle events emitted recursively", (done) => {
-  const ee = new EventEmitter();
+    expect(new_signal.aborted).toBe(false);
 
-  ee.on("test", () => {
-    ee.emit("test2");
+    setTimeout(() => {
+      expect(new_signal.aborted).toBe(true);
+      done();
+    }, 15);
   });
-
-  ee.on("test2", done);
-
-  ee.emit("test");
-});
-
-it("should set abort reason on AbortSignal", () => {
-  const abortController = new AbortController();
-  const signal = abortController.signal;
-
-  abortController.abort("cancelled");
-
-  expect(signal.aborted).toEqual(true);
-  expect(signal.reason).toEqual("cancelled");
 });

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -117,25 +117,13 @@ describe("AbortSignal & AbortController", () => {
     let signal = AbortSignal.timeout(5);
     setTimeout(() => {
       expect(signal.aborted).toBe(false);
-      let time = 0;
-      const interval = setInterval(() => {
-        time++;
-        if (signal.aborted) {
-          clearInterval(interval);
-          console.log("=========================", time);
-          done();
-        }
-      }, 1);
       setTimeout(() => {
-        clearInterval(interval);
-      }, 10000);
-      // setTimeout(() => {
-      //   expect(signal.aborted).toBe(true);
-      //   //@ts-ignore
-      //   expect(signal.reason).toBeInstanceOf(DOMException);
-      //   expect(signal.reason.name).toBe("TimeoutError");
-      //   done();
-      // }, 100);
+        expect(signal.aborted).toBe(true);
+        //@ts-ignore
+        expect(signal.reason).toBeInstanceOf(DOMException);
+        expect(signal.reason.name).toBe("TimeoutError");
+        done();
+      }, 50);
     }, 0);
   });
 
@@ -150,6 +138,6 @@ describe("AbortSignal & AbortController", () => {
     setTimeout(() => {
       expect(new_signal.aborted).toBe(true);
       done();
-    }, 15);
+    }, 50);
   });
 });

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -117,13 +117,25 @@ describe("AbortSignal & AbortController", () => {
     let signal = AbortSignal.timeout(5);
     setTimeout(() => {
       expect(signal.aborted).toBe(false);
+      let time = 0;
+      const interval = setInterval(() => {
+        time++;
+        if (signal.aborted) {
+          clearInterval(interval);
+          console.log("=========================", time);
+          done();
+        }
+      }, 1);
       setTimeout(() => {
-        expect(signal.aborted).toBe(true);
-        //@ts-ignore
-        expect(signal.reason).toBeInstanceOf(DOMException);
-        expect(signal.reason.name).toBe("TimeoutError");
-        done();
-      }, 100);
+        clearInterval(interval);
+      }, 10000);
+      // setTimeout(() => {
+      //   expect(signal.aborted).toBe(true);
+      //   //@ts-ignore
+      //   expect(signal.reason).toBeInstanceOf(DOMException);
+      //   expect(signal.reason.name).toBe("TimeoutError");
+      //   done();
+      // }, 100);
     }, 0);
   });
 

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -114,7 +114,7 @@ describe("AbortSignal & AbortController", () => {
   });
 
   it("should throw DomException on timeout", (done) => {
-    let signal = AbortSignal.timeout(10);
+    let signal = AbortSignal.timeout(5);
     setTimeout(() => {
       expect(signal.aborted).toBe(false);
       setTimeout(() => {
@@ -123,8 +123,8 @@ describe("AbortSignal & AbortController", () => {
         expect(signal.reason).toBeInstanceOf(DOMException);
         expect(signal.reason.name).toBe("TimeoutError");
         done();
-      }, 50);
-    }, 5);
+      }, 100);
+    }, 0);
   });
 
   it("should abort if any signal is aborted asynchronously", (done) => {

--- a/tests/unit/fetch.test.ts
+++ b/tests/unit/fetch.test.ts
@@ -137,4 +137,25 @@ describe("fetch", () => {
     });
     proc.on("error", done);
   });
+
+  it("should be abortable using signals", async () => {
+    const abortController = new AbortController();
+    const res = fetch(url, { signal: abortController.signal });
+    abortController.abort();
+    try {
+      await res;
+    } catch (err: any) {
+      expect(err.name).toBe("AbortError");
+    }
+  });
+  it("should be abortable using request signal", async () => {
+    const abortController = new AbortController();
+    const req = new Request(url, { signal: abortController.signal });
+    abortController.abort("aborted");
+    try {
+      await fetch(req);
+    } catch (err: any) {
+      expect(abortController.signal.reason).toBe("aborted");
+    }
+  });
 });

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -174,31 +174,35 @@ describe("Request", () => {
 
   it("should accept a signal as an option", () => {
     const controller = new AbortController();
-    const request = new Request('http://localhost', { signal: controller.signal });
+    const request = new Request("http://localhost", {
+      signal: controller.signal,
+    });
     expect(request.signal).toEqual(controller.signal);
   });
 
   it("should accept null or undefined as signal options", () => {
     // @ts-ignore
-    const reqNull = new Request('http://localhost', { signal: null });
+    const reqNull = new Request("http://localhost", { signal: null });
     expect(reqNull.signal).toBeUndefined();
     // @ts-ignore
-    const reqUndef = new Request('http://localhost', { signal: undefined });
+    const reqUndef = new Request("http://localhost", { signal: undefined });
     expect(reqUndef.signal).toBeUndefined();
   });
 
   it("should fail if the signal option is not an object", () => {
     expect(() => {
       // @ts-ignore
-      new Request('http://localhost', { signal: 'type error' })
-    }).toThrow(/member signal is not of type AbortSignal/);
+      new Request("http://localhost", { signal: "type error" });
+    }).toThrow(/property is not an AbortSignal/);
   });
 
   it("should fail if the signal option is not an valid object", () => {
     expect(() => {
-      // @ts-ignore
-      new Request('http://localhost', { signal: new Request('http://localhost') })
-    }).toThrow(/member signal is not of type AbortSignal/);
+      new Request("http://localhost", {
+        // @ts-ignore
+        signal: new Request("http://localhost"),
+      });
+    }).toThrow(/property is not an AbortSignal/);
   });
 });
 

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -178,6 +178,15 @@ describe("Request", () => {
     expect(request.signal).toEqual(controller.signal);
   });
 
+  it("should accept null or undefined as signal options", () => {
+    // @ts-ignore
+    const reqNull = new Request('http://localhost', { signal: null });
+    expect(reqNull.signal).toBeUndefined();
+    // @ts-ignore
+    const reqUndef = new Request('http://localhost', { signal: undefined });
+    expect(reqUndef.signal).toBeUndefined();
+  });
+
   it("should fail if the signal option is not an object", () => {
     expect(() => {
       // @ts-ignore

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -171,6 +171,26 @@ describe("Request", () => {
     expect(newRequest.url).toEqual("https://example.com");
     expect(newRequest.headers.get("From")).toEqual("developer@example.org");
   });
+
+  it("should accept a signal as an option", () => {
+    const controller = new AbortController();
+    const request = new Request('http://localhost', { signal: controller.signal });
+    expect(request.signal).toEqual(controller.signal);
+  });
+
+  it("should fail if the signal option is not an object", () => {
+    expect(() => {
+      // @ts-ignore
+      new Request('http://localhost', { signal: 'type error' })
+    }).toThrow(/member signal is not of type AbortSignal/);
+  });
+
+  it("should fail if the signal option is not an valid object", () => {
+    expect(() => {
+      // @ts-ignore
+      new Request('http://localhost', { signal: new Request('http://localhost') })
+    }).toThrow(/member signal is not of type AbortSignal/);
+  });
 });
 
 describe("Response class", () => {


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/182

### Description of changes

Allow to pass an AbortSignal as an option to a request. Ensure that only AbortSignal types are allowed.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
