### PR TITLE
feat: implement globalThis.performance API

### DIFF
--- a/API.md
+++ b/API.md
@@ -157,6 +157,7 @@ _Also available globally_
 [clearTimeout](https://nodejs.org/api/timers.html#cleartimeouttimeout)
 
 ## url
+
 ```typescript
 export class URL {
   constructor(input: string, base?: string | URL);
@@ -174,7 +175,7 @@ export class URL {
   searchParams: URLSearchParams;
   username: string;
 
-  canParse(input: string, base?: string): boolean; 
+  canParse(input: string, base?: string): boolean;
   toString(): string;
 }
 ```
@@ -200,9 +201,12 @@ export function urlToHttpOptions(url: URL): {
 ```
 
 ## URLSearchParams
+
 ```typescript
 export class URLSearchParams {
-  constructor(init?: string | string[][] | Record<string, string> | URLSearchParams);
+  constructor(
+    init?: string | string[][] | Record<string, string> | URLSearchParams
+  );
 
   // Methods
   append(name: string, value: string): void;
@@ -220,7 +224,6 @@ export class URLSearchParams {
   toString(): string;
 }
 ```
-
 
 ### TODO, URLSearchParams see tracking [ticket](https://github.com/awslabs/llrt/issues/307):
 
@@ -305,3 +308,7 @@ export class XMLParser(options?: XmlParserOptions){
 [atob](https://developer.mozilla.org/en-US/docs/Web/API/atob)
 
 [navigator.userAgent](https://nodejs.org/api/globals.html#navigatoruseragent)
+
+[performance.timeOrigin](https://nodejs.org/api/perf_hooks.html#performancetimeorigin)
+
+[performance.now](https://nodejs.org/api/perf_hooks.html#performancenow)

--- a/build.mjs
+++ b/build.mjs
@@ -70,6 +70,7 @@ const ES_BUILD_OPTIONS = {
     "net",
     "navigator",
     "url",
+    "performance",
   ],
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,6 @@ use rquickjs::{AsyncContext, Module};
 use std::{
     env,
     error::Error,
-    mem::MaybeUninit,
     path::{Path, PathBuf},
     process::exit,
     sync::atomic::Ordering,
@@ -70,13 +69,9 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
-pub static mut STARTED: MaybeUninit<Instant> = MaybeUninit::uninit();
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let now = Instant::now();
-
-    unsafe { STARTED.write(Instant::now()) };
 
     MinimalTracer::register()?;
     trace!("Started runtime");

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod net;
 mod number;
 mod os;
 mod path;
+mod performance;
 mod process;
 mod security;
 mod stream;

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -10,11 +10,7 @@ use crate::module::export_default;
 
 use crate::STARTED;
 
-use once_cell::sync::Lazy;
-
-use chrono::Utc;
-
-static TIME_ORIGIN: Lazy<f64> = Lazy::new(|| (Utc::now().timestamp_micros() as f64) / 1e3);
+use crate::vm::TIME_ORIGIN;
 
 fn get_time_origin() -> f64 {
     *TIME_ORIGIN

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use rquickjs::{
+    module::{Declarations, Exports, ModuleDef},
+    prelude::Func,
+    Ctx, Object, Result, Value,
+};
+
+use crate::module::export_default;
+
+use crate::STARTED;
+
+use once_cell::sync::Lazy;
+
+use chrono::Utc;
+
+static TIME_ORIGIN: Lazy<f64> = Lazy::new(|| (Utc::now().timestamp_micros() as f64) / 1e3);
+
+fn get_time_origin() -> f64 {
+    *TIME_ORIGIN
+}
+
+fn now() -> f64 {
+    let started = unsafe { STARTED.assume_init() };
+    let elapsed = started.elapsed();
+
+    elapsed.as_secs_f64() + (elapsed.as_micros() as f64) / 1e3
+}
+
+pub fn init(ctx: &Ctx<'_>) -> Result<()> {
+    let globals = ctx.globals();
+
+    let performance = Object::new(ctx.clone())?;
+
+    performance.set("timeOrigin", get_time_origin())?;
+    performance.set("now", Func::from(now))?;
+
+    globals.set("performance", performance)?;
+
+    Ok(())
+}
+
+pub struct PerformanceModule;
+
+impl ModuleDef for PerformanceModule {
+    fn declare(declare: &mut Declarations) -> Result<()> {
+        declare.declare("timeOrigin")?;
+        declare.declare("now")?;
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &mut Exports<'js>) -> Result<()> {
+        let globals = ctx.globals();
+        let performance: Object = globals.get("performance")?;
+
+        export_default(ctx, exports, |default| {
+            for name in performance.keys::<String>() {
+                let name = name?;
+                let value: Value = performance.get(&name)?;
+                default.set(name, value)?;
+            }
+
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -8,12 +8,10 @@ use rquickjs::{
 
 use crate::module::export_default;
 
-use crate::STARTED;
-
-use crate::vm::TIME_ORIGIN;
+use crate::vm::{STARTED, TIME_ORIGIN};
 
 fn get_time_origin() -> f64 {
-    *TIME_ORIGIN
+    unsafe { TIME_ORIGIN.assume_init() }
 }
 
 fn now() -> f64 {

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -24,7 +24,7 @@ fn now() -> f64 {
     let started = unsafe { STARTED.assume_init() };
     let elapsed = started.elapsed();
 
-    elapsed.as_secs_f64() + (elapsed.as_micros() as f64) / 1e3
+    elapsed.as_micros() as f64 / 1e3
 }
 
 pub fn init(ctx: &Ctx<'_>) -> Result<()> {

--- a/src/process.rs
+++ b/src/process.rs
@@ -14,7 +14,9 @@ use rquickjs::{
 
 use crate::module::export_default;
 
-use crate::{STARTED, VERSION};
+use crate::VERSION;
+
+use crate::vm::STARTED;
 
 fn cwd() -> String {
     env::current_dir().unwrap().to_string_lossy().to_string()

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::{collections::HashMap, env};
+use std::{collections::HashMap, env, sync::atomic::Ordering};
 
 use rquickjs::{
     atom::PredefinedAtom,
@@ -12,11 +12,13 @@ use rquickjs::{
     Array, BigInt, Ctx, Function, IntoJs, Object, Result, Value,
 };
 
+use chrono::Utc;
+
 use crate::module::export_default;
 
 use crate::VERSION;
 
-use crate::vm::STARTED;
+use crate::vm::TIME_ORIGIN;
 
 fn cwd() -> String {
     env::current_dir().unwrap().to_string_lossy().to_string()
@@ -44,15 +46,18 @@ pub fn get_platform() -> &'static str {
 }
 
 fn hr_time_big_int(ctx: Ctx<'_>) -> Result<BigInt> {
-    let started = unsafe { STARTED.assume_init() };
-    let elapsed = started.elapsed().as_nanos() as u64;
+    let now = Utc::now().timestamp_nanos_opt().unwrap_or_default() as u64;
+    let started = TIME_ORIGIN.load(Ordering::Relaxed) as u64;
+
+    let elapsed = now - started;
 
     BigInt::from_u64(ctx, elapsed)
 }
 
 fn hr_time(ctx: Ctx<'_>) -> Result<Array<'_>> {
-    let started = unsafe { STARTED.assume_init() };
-    let elapsed = started.elapsed().as_nanos() as u64;
+    let now = Utc::now().timestamp_nanos_opt().unwrap_or_default() as u64;
+    let started = TIME_ORIGIN.load(Ordering::Relaxed) as u64;
+    let elapsed = now - started;
 
     let seconds = elapsed / 1_000_000_000;
     let remaining_nanos = elapsed % 1_000_000_000;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -15,6 +15,7 @@ use std::{
 
 use once_cell::sync::Lazy;
 
+use chrono::Utc;
 use ring::rand::SecureRandom;
 use rquickjs::{
     atom::PredefinedAtom,
@@ -67,6 +68,8 @@ use crate::{
     uuid::UuidModule,
     xml::XmlModule,
 };
+
+pub static TIME_ORIGIN: Lazy<f64> = Lazy::new(|| (Utc::now().timestamp_micros() as f64) / 1e3);
 
 macro_rules! create_modules {
     ($($name:expr => $module:expr),*) => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -53,6 +53,7 @@ use crate::{
     number::number_to_string,
     os::OsModule,
     path::{dirname, join_path, resolve_path, PathModule},
+    performance::PerformanceModule,
     process::ProcessModule,
     timers::TimersModule,
     url::UrlModule,
@@ -132,7 +133,8 @@ create_modules!(
     "uuid" => UuidModule,
     "process" => ProcessModule,
     "navigator" => NavigatorModule,
-    "url" => UrlModule
+    "url" => UrlModule,
+    "performance" => PerformanceModule
 );
 
 struct ModuleInfo<T: ModuleDef> {
@@ -483,6 +485,7 @@ impl Vm {
             crate::events::init(&ctx)?;
             crate::buffer::init(&ctx)?;
             crate::navigator::init(&ctx)?;
+            crate::performance::init(&ctx)?;
             init(&ctx, module_names)?;
             Ok::<_, Error>(())
         })

--- a/tests/unit/performance.test.ts
+++ b/tests/unit/performance.test.ts
@@ -1,0 +1,27 @@
+import defaultImport from "performance";
+import * as namedImport from "performance";
+
+describe("performance.timeOrigin", () => {
+  it("should have a performance timeOrigin", () => {
+    expect(defaultImport.timeOrigin).toEqual(performance.timeOrigin);
+    expect(namedImport.timeOrigin).toEqual(performance.timeOrigin);
+  });
+  it("should have a positive value", () => {
+    expect(Number(performance.timeOrigin)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("performance.now()", () => {
+  it("should have a performance now", () => {
+    expect(defaultImport.now()).toBeDefined();
+    expect(namedImport.now()).toBeDefined();
+  });
+  it("should have a positive value", () => {
+    expect(Number(performance.now())).toBeGreaterThanOrEqual(0);
+  });
+  it("should be a monotonic clock", () => {
+    const before = performance.now();
+    const after = performance.now();
+    expect(Number(after)).toBeGreaterThanOrEqual(Number(before));
+  });
+});


### PR DESCRIPTION
### Description of changes

[The Minimum Common Web Platform API](https://common-min-api.proposal.wintercg.org/) is being considered at WinterCG.
I have implemented the following several APIs.
- globalThis.performance.timeOrigin
- globalThis.performance.now()

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
