### PR TITLE
Add commas after ignoring undefined values in the middle of objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ bundle/%.js: $(TS_SOURCES)
 
 fix:
 	npx pretty-quick
-	cargo fix --allow-dirty
-	cargo clippy --fix --allow-dirty
+	cargo fix --allow-dirty --allow-staged
+	cargo clippy --fix --allow-dirty --allow-staged
 	cargo fmt
 
 bloat: js

--- a/src/json/stringify.rs
+++ b/src/json/stringify.rs
@@ -9,7 +9,6 @@ use rquickjs::{
 use crate::json::escape::escape_json_string;
 
 const CIRCULAR_REF_DETECTION_DEPTH: usize = 20;
-
 struct IterationContext<'a, 'js> {
     ctx: &'a Ctx<'js>,
     result: &'a mut String,
@@ -33,6 +32,10 @@ impl<'a, 'js> IterationContext<'a, 'js> {
         } else {
             false
         }
+    }
+
+    fn ignore_undefined(&self) -> bool {
+        self.is_object || self.parent.is_none()
     }
 }
 
@@ -221,7 +224,7 @@ fn write_primitive(context: &mut IterationContext, add_comma: bool) -> Result<Pr
 
     let type_of = value.type_of();
 
-    if matches!(type_of, Type::Symbol | Type::Undefined) && context.is_object {
+    if matches!(type_of, Type::Symbol | Type::Undefined) && context.ignore_undefined() {
         return Ok(PrimitiveStatus::Ignored);
     }
 

--- a/tests/unit/json.test.ts
+++ b/tests/unit/json.test.ts
@@ -20,7 +20,7 @@ describe("JSON Parsing", () => {
     const parsedData = JSON.parse(
       '{"name": "John", "age": 25, "address": {"city": "New York", "zip": "10001"}}'
     );
-    expect(parsedData).toStrictEqual({name: "John", age: 25, address: { city: "New York", zip: "10001" },})
+    expect(parsedData).toStrictEqual({ name: "John", age: 25, address: { city: "New York", zip: "10001" }, })
   });
 
   it("should parse JSON with arrays", () => {
@@ -40,12 +40,14 @@ describe("JSON Parsing", () => {
 
   it("should parse JSON with large int value", () => {
     const parsedData = JSON.parse('{"bigInt": 888888888888888888}');
-    expect(parsedData).toStrictEqual({bigInt: 888888888888888888,})});
+    expect(parsedData).toStrictEqual({ bigInt: 888888888888888888, })
+  });
 
   it("should parse JSON with special characters", () => {
     const specialChars = "!@#$%^&*()_+-={}[]|;:,.<>?/";
     const parsedData = JSON.parse(`{"specialChars": "${specialChars}"}`);
-    expect(parsedData).toStrictEqual({specialChars,})});
+    expect(parsedData).toStrictEqual({ specialChars, })
+  });
 });
 
 describe("JSON Stringified", () => {
@@ -97,7 +99,7 @@ describe("JSON Stringified", () => {
     }).toThrow();
   });
 
-  it("Should stringify an object with default spacing", () => {
+  it("should stringify an object with default spacing", () => {
     const data = {
       key: "value",
       bool: true,
@@ -129,11 +131,11 @@ describe("JSON Stringified", () => {
         }
     }
 }`;
-    expect(jsonString).toEqual(expectedJsonString)
+    expect(jsonString).toEqual(expectedJsonString);
   });
 
   // Test JSON stringifying with custom spacing as a string
-  it("Should stringify an object with default custom spacing", () => {
+  it("should stringify an object with default custom spacing", () => {
     const data = {
       key: "value",
       bool: false,
@@ -165,11 +167,11 @@ describe("JSON Stringified", () => {
       }
    }
 }`;
-    expect(jsonString).toEqual(expectedJsonString)
+    expect(jsonString).toEqual(expectedJsonString);
   });
 
   // Test JSON stringifying with replacer as a function
-  it("Should stringify an object with a replacer function", () => {
+  it("should stringify an object with a replacer function", () => {
     const data = { key: "value", secret: "hidden" };
     const replacerFunction = (key: string, value: any) =>
       key === "secret" ? undefined : value;
@@ -178,7 +180,7 @@ describe("JSON Stringified", () => {
   });
 
   // Test more complex JSON structure
-  test("Should stringify a complex object with custom spacing and replacer", () => {
+  test("should stringify a complex object with custom spacing and replacer", () => {
     const complexData = {
       key: "value",
       nested: {
@@ -207,6 +209,57 @@ describe("JSON Stringified", () => {
     }
 }`;
 
-    expect(jsonString).toEqual(expectedJsonString)
+    expect(jsonString).toEqual(expectedJsonString);
   });
+
+  test("should stringify objects with undefined values", () => {
+    const valueStart = {
+      a: undefined,
+      b: '123',
+      c: '123'
+    };
+    expect(JSON.stringify(valueStart)).toEqual(`{"b":"123","c":"123"}`);
+    const jsonStartIndented = JSON.stringify(valueStart, null, "   ");
+    const expectedJsonStartString = `{
+   "b": "123",
+   "c": "123"
+}`;
+    expect(jsonStartIndented).toEqual(expectedJsonStartString);
+
+    const valueMiddle = {
+      a: '123',
+      b: undefined,
+      c: '123'
+    };
+    expect(JSON.stringify(valueMiddle)).toEqual(`{"a":"123","c":"123"}`);
+    const jsonMiddleIndented = JSON.stringify(valueMiddle, null, "   ");
+    const expectedJsonMiddleString = `{
+   "a": "123",
+   "c": "123"
+}`;
+    expect(jsonMiddleIndented).toEqual(expectedJsonMiddleString);
+
+    const valueEnd = {
+      a: '123',
+      b: '123',
+      c: undefined
+    };
+    expect(JSON.stringify(valueEnd)).toEqual(`{"a":"123","b":"123"}`);
+    const jsonEndIndented = JSON.stringify(valueEnd, null, "   ");
+    const expectedJsonEndString = `{
+   "a": "123",
+   "b": "123"
+}`;
+    expect(jsonEndIndented).toEqual(expectedJsonEndString);
+  });
+
+  test("should stringify arrays with undefined values", () => {
+    const valueStart = [undefined, '123', '123'];
+    expect(JSON.stringify(valueStart)).toEqual(`[null,"123","123"]`);
+    const valueMiddle = ['123', undefined, '123'];
+    expect(JSON.stringify(valueMiddle)).toEqual(`["123",null,"123"]`);
+    const valueEnd = ['123', '123', undefined];
+    expect(JSON.stringify(valueEnd)).toEqual(`["123","123",null]`);
+  });
+
 });


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/314

### Description of changes

This change keeps track of indexes and object sizes to decide if we need to add a comma after ignoring an undefined value or not.

I'm not sure if there is any easier way to implement this, I'm open to alternatives.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
