### PR TITLE
Fix fs readdir for symlinks

### DIFF
--- a/src/fs/stats.rs
+++ b/src/fs/stats.rs
@@ -138,21 +138,49 @@ impl Stat {
         self.metadata.is_symlink()
     }
 
+    #[qjs(rename = "isFIFO")]
     pub fn is_fifo(&self) -> bool {
-        self.metadata.file_type().is_fifo()
+        #[cfg(unix)]
+        {
+            self.metadata.file_type().is_fifo()
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
     }
 
     pub fn is_block_device(&self) -> bool {
-        self.metadata.file_type().is_block_device()
+        #[cfg(unix)]
+        {
+            self.metadata.file_type().is_block_device()
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
     }
 
     pub fn is_character_device(&self) -> bool {
-        self.metadata.file_type().is_char_device()
+        #[cfg(unix)]
+        {
+            self.metadata.file_type().is_char_device()
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
     }
 
-    #[cfg(unix)]
     pub fn is_socket(&self) -> bool {
-        self.metadata.file_type().is_socket()
+        #[cfg(unix)]
+        {
+            self.metadata.file_type().is_socket()
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
     }
 }
 

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -108,6 +108,7 @@ where
 
     async fn append_stack(&mut self, dir: &PathBuf) -> io::Result<()> {
         let mut stream = fs::read_dir(dir).await?;
+
         while let Some(entry) = stream.next_entry().await? {
             let entry_path = entry.path();
 
@@ -116,7 +117,8 @@ where
                 continue;
             }
 
-            let metadata = fs::metadata(&entry_path).await?;
+            let metadata = fs::symlink_metadata(&entry_path).await?;
+
             self.stack.push((entry_path, Some(metadata)));
         }
         Ok(())
@@ -131,7 +133,7 @@ where
                 continue;
             }
             let entry_path = entry.path();
-            let metadata = entry.metadata()?;
+            let metadata = entry_path.symlink_metadata()?;
             self.stack.push((entry_path, Some(metadata)))
         }
 

--- a/tests/unit/fs.test.ts
+++ b/tests/unit/fs.test.ts
@@ -7,52 +7,54 @@ import os from "os";
 describe("readdir", () => {
   it("should read a directory", async () => {
     const dir = await fs.readdir(".cargo");
-    expect(dir).toEqual(["config.toml"])
+    expect(dir).toEqual(["config.toml"]);
   });
 
   it("should read a directory with types", async () => {
     const dir = await fs.readdir(".cargo", { withFileTypes: true });
-    expect(dir).toEqual([{ name: "config.toml" }])
+    expect(dir).toEqual([{ name: "config.toml", parentPath: "./.cargo" }]);
     expect(dir[0].isFile()).toBeTruthy();
   });
 
   it("should read a directory using default import", async () => {
     const dir = await defaultFsImport.promises.readdir(".cargo");
-    expect(dir).toEqual(["config.toml"])
+    expect(dir).toEqual(["config.toml"]);
   });
 
   it("should read a directory using named import", async () => {
     const dir = await namedFsImport.promises.readdir(".cargo");
-    expect(dir).toEqual(["config.toml"])
+    expect(dir).toEqual(["config.toml"]);
   });
 
   it("should read a directory with recursive", async () => {
     const dir = await fs.readdir("fixtures/fs/readdir", { recursive: true });
     const compare = (a: string, b: string) => (a >= b ? 1 : -1);
-    expect(dir.sort(compare)).toEqual(["recursive/readdir.js", "recursive", "readdir.js"].sort(compare));
+    expect(dir.sort(compare)).toEqual(
+      ["recursive/readdir.js", "recursive", "readdir.js"].sort(compare)
+    );
   });
 });
 
 describe("readdirSync", () => {
   it("should read a directory synchronously", () => {
     const dir = defaultFsImport.readdirSync(".cargo");
-    expect(dir).toEqual(["config.toml"])
+    expect(dir).toEqual(["config.toml"]);
   });
 
   it("should read a directory with types synchronously", () => {
     const dir = defaultFsImport.readdirSync(".cargo", { withFileTypes: true });
-    expect(dir).toEqual([{ name: "config.toml" }])
+    expect(dir).toEqual([{ name: "config.toml", parentPath: "./.cargo" }]);
     expect(dir[0].isFile()).toBeTruthy();
   });
 
   it("should read a directory using default import synchronously", () => {
     const dir = defaultFsImport.readdirSync(".cargo");
-    expect(dir).toEqual(["config.toml"])
+    expect(dir).toEqual(["config.toml"]);
   });
 
   it("should read a directory using named import synchronously", () => {
     const dir = namedFsImport.readdirSync(".cargo");
-    expect(dir).toEqual(["config.toml"])
+    expect(dir).toEqual(["config.toml"]);
   });
 
   it("should read a directory with recursive synchronously", () => {
@@ -61,7 +63,9 @@ describe("readdirSync", () => {
     });
     const compare = (a: string | Buffer, b: string | Buffer): number =>
       a >= b ? 1 : -1;
-    expect(dir.sort(compare)).toEqual(["recursive/readdir.js", "recursive", "readdir.js"].sort(compare));
+    expect(dir.sort(compare)).toEqual(
+      ["recursive/readdir.js", "recursive", "readdir.js"].sort(compare)
+    );
   });
 });
 
@@ -158,13 +162,13 @@ describe("mkdtemp", () => {
 });
 
 describe("mkdtempSync", () => {
-  it("should create a temporary directory with a given prefix synchronously",  () => {
+  it("should create a temporary directory with a given prefix synchronously", () => {
     // Create a temporary directory with the given prefix
     const prefix = "test-";
     const dirPath = defaultFsImport.mkdtempSync(path.join(os.tmpdir(), prefix));
 
     // Check that the directory exists
-    const dirExists =  defaultFsImport.statSync(dirPath)
+    const dirExists = defaultFsImport.statSync(dirPath);
     expect(dirExists).toBeTruthy();
 
     // Check that the directory has the correct prefix
@@ -209,7 +213,7 @@ describe("mkdirSync", () => {
     defaultFsImport.mkdirSync(dirPath, { recursive: true });
 
     // Check that the directory exists
-    const dirExists = defaultFsImport.statSync(dirPath)
+    const dirExists = defaultFsImport.statSync(dirPath);
     expect(dirExists).toBeTruthy();
 
     // Clean up the directory


### PR DESCRIPTION
### Description of changes

Symlinks may cause errors when reading dir and should not be followed. This PR fixes `readdir` call

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
