### PR TITLE
feat: Implement globalThis.performance.toJSON()

### DIFF
--- a/src/performance.rs
+++ b/src/performance.rs
@@ -27,6 +27,14 @@ fn now() -> f64 {
     (now - started) / 1e6
 }
 
+fn to_json(ctx: Ctx<'_>) -> Result<Object<'_>> {
+    let obj = Object::new(ctx.clone())?;
+
+    obj.set("timeOrigin", get_time_origin())?;
+
+    Ok(obj)
+}
+
 pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     let globals = ctx.globals();
 
@@ -34,6 +42,7 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
 
     performance.set("timeOrigin", get_time_origin())?;
     performance.set("now", Func::from(now))?;
+    performance.set("toJSON", Func::from(to_json))?;
 
     globals.set("performance", performance)?;
 
@@ -46,6 +55,7 @@ impl ModuleDef for PerformanceModule {
     fn declare(declare: &mut Declarations) -> Result<()> {
         declare.declare("timeOrigin")?;
         declare.declare("now")?;
+        declare.declare("toJSON")?;
         declare.declare("default")?;
         Ok(())
     }

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -3,6 +3,7 @@
 use std::sync::atomic::Ordering;
 
 use rquickjs::{
+    atom::PredefinedAtom,
     module::{Declarations, Exports, ModuleDef},
     prelude::Func,
     Ctx, Object, Result, Value,
@@ -42,7 +43,7 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
 
     performance.set("timeOrigin", get_time_origin())?;
     performance.set("now", Func::from(now))?;
-    performance.set("toJSON", Func::from(to_json))?;
+    performance.set(PredefinedAtom::ToJSON, Func::from(to_json))?;
 
     globals.set("performance", performance)?;
 

--- a/tests/unit/performance.test.ts
+++ b/tests/unit/performance.test.ts
@@ -24,4 +24,17 @@ describe("performance.now()", () => {
     const after = performance.now();
     expect(Number(after)).toBeGreaterThanOrEqual(Number(before));
   });
+
+  describe("performance.toJSON()", () => {
+    it("should have a performance toJSON", () => {
+      expect(defaultImport.toJSON()).toBeDefined();
+      expect(namedImport.toJSON()).toBeDefined();
+    });
+    it("performance.toJSON().timeOrigin should have a positive value", () => {
+      expect(Number(performance.toJSON().timeOrigin)).toBeGreaterThanOrEqual(0);
+    });
+    it("performance.toJSON().timeOrigin should match performance.timeOrigin", () => {
+      expect(performance.toJSON().timeOrigin).toEqual(performance.timeOrigin);
+    });
+  });
 });


### PR DESCRIPTION
### Description of changes

[The Minimum Common Web Platform API](https://common-min-api.proposal.wintercg.org/) is being considered at WinterCG.
In this context, the performance API is being studied in the [High Resolution Time](https://www.w3.org/TR/hr-time-3/) Team.
We believe that implementing toJSON() will also be compliant with this draft.

- globalThis.performance.toJSON()

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
