### PR TITLE
Add rustfmt.toml to mantain format consistency

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2021"
+fn_params_layout = "Tall"
+match_block_trailing_comma = true

--- a/src/child_process.rs
+++ b/src/child_process.rs
@@ -250,7 +250,7 @@ impl<'js> ChildProcess<'js> {
 
                     Ok(())
                 })?;
-            }
+            },
             Err(err) => {
                 let ctx3 = ctx.clone();
 
@@ -271,7 +271,7 @@ impl<'js> ChildProcess<'js> {
                     )?;
                     Ok(())
                 })?;
-            }
+            },
         }
         Ok(instance)
     }
@@ -446,7 +446,7 @@ fn spawn<'js>(
                         2 => stderr = stdio,
                         _ => {
                             break;
-                        }
+                        },
                     }
                 }
             }

--- a/src/console.rs
+++ b/src/console.rs
@@ -171,11 +171,11 @@ fn stringify_primitive<'js>(
             let big_int = value.as_big_int().unwrap();
             result.push_str(buffer.format(big_int.clone().to_i64()?));
             result.push('n');
-        }
+        },
         Type::Int => {
             let mut buffer = itoa::Buffer::new();
             result.push_str(buffer.format(value.as_int().unwrap()))
-        }
+        },
         Type::Float => {
             let mut buffer = ryu::Buffer::new();
             result.push_str(
@@ -184,7 +184,7 @@ fn stringify_primitive<'js>(
                     Err(v) => v,
                 },
             )
-        }
+        },
         Type::String => result.push_str(&value.as_string().unwrap().to_string()?),
         Type::Symbol => {
             let description = value.as_symbol().unwrap().description()?;
@@ -194,8 +194,8 @@ fn stringify_primitive<'js>(
                 result.push_str(&description);
             }
             result.push(')');
-        }
-        _ => {}
+        },
+        _ => {},
     }
     if has_color {
         result.push_str(COLOR_RESET);
@@ -389,17 +389,17 @@ fn stringify_value<'js>(
                                     if tty {
                                         result.push_str(COLOR_RESET);
                                     }
-                                }
+                                },
                                 Some("Promise") => {
                                     result.push_str("Promise {}");
-                                }
+                                },
                                 None | Some("") | Some("Object") => {
                                     is_object_like = true;
-                                }
+                                },
                                 _ => {
                                     class_name = cl;
                                     is_object_like = true;
-                                }
+                                },
                             }
                         } else {
                             is_object_like = true;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -42,12 +42,12 @@ fn encoded_bytes<'js>(ctx: Ctx<'js>, bytes: &[u8], encoding: &str) -> Result<Val
             let hex = bytes_to_hex_string(bytes);
             let hex = rquickjs::String::from_str(ctx, &hex)?;
             Ok(Value::from_string(hex))
-        }
+        },
         "base64" => {
             let b64 = bytes_to_b64_string(bytes);
             let b64 = rquickjs::String::from_str(ctx, &b64)?;
             Ok(Value::from_string(b64))
-        }
+        },
         _ => bytes_to_typed_array(ctx, bytes),
     }
 }

--- a/src/crypto/sha_hash.rs
+++ b/src/crypto/sha_hash.rs
@@ -33,7 +33,7 @@ impl Hmac {
                     &ctx,
                     &format!("Algorithm \"{}\" not supported", &algorithm),
                 ))
-            }
+            },
         };
 
         Ok(Self {
@@ -91,7 +91,7 @@ impl Hash {
                     &ctx,
                     &format!("Algorithm \"{}\" not supported", &algorithm),
                 ))
-            }
+            },
         };
 
         Ok(Self {
@@ -176,7 +176,7 @@ impl ShaHash {
             Some(secret) => {
                 let bytes = get_bytes(&ctx, secret)?;
                 Some(bytes)
-            }
+            },
             None => None,
         };
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -248,7 +248,7 @@ where
                 is_new = true;
                 events.push((key.clone(), new_items));
                 &mut events.last_mut().unwrap().1
-            }
+            },
         };
 
         let item = EventItem {

--- a/src/fs/read_dir.rs
+++ b/src/fs/read_dir.rs
@@ -193,7 +193,7 @@ fn process_options_and_create_directory_walker(
                     path.insert_str(0, CURRENT_DIR_STR);
                 }
                 path.len() + 1
-            }
+            },
         }
     };
 

--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -150,7 +150,7 @@ impl<'js> Body<'js> {
                     .ok_or(Exception::throw_type(ctx, "Already read"))?;
                 let bytes = body.body_mut().collect().await.or_throw(ctx)?.to_bytes();
                 bytes.to_vec()
-            }
+            },
             BodyVariant::Provided(provided) => {
                 if let Some(blob) = get_class::<Blob>(provided)? {
                     let blob = blob.borrow();
@@ -158,7 +158,7 @@ impl<'js> Body<'js> {
                 } else {
                     get_bytes(ctx, provided.clone())?
                 }
-            }
+            },
         };
         Ok(bytes)
     }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -138,7 +138,7 @@ impl<'js> Response<'js> {
                 let bytes = body.body_mut().collect().await.or_throw(ctx)?.to_bytes();
 
                 bytes.to_vec()
-            }
+            },
             Some(BodyVariant::Provided(provided)) => {
                 if let Some(blob) = get_class::<Blob>(provided)? {
                     let blob = blob.borrow();
@@ -146,7 +146,7 @@ impl<'js> Response<'js> {
                 } else {
                     get_bytes(ctx, provided.clone())?
                 }
-            }
+            },
             None => return Ok(None),
         };
 

--- a/src/json/parse.rs
+++ b/src/json/parse.rs
@@ -67,9 +67,9 @@ pub fn json_parse<'js>(ctx: &Ctx<'js>, mut json: Vec<u8>) -> Result<Value<'js>> 
     match first {
         Node::String(value) => {
             return value.into_js(ctx);
-        }
+        },
         Node::Static(node) => return static_node_to_value(ctx, *node),
-        _ => {}
+        _ => {},
     };
 
     let mut path_data = Vec::<PathItem>::with_capacity(10);
@@ -103,13 +103,13 @@ pub fn json_parse<'js>(ctx: &Ctx<'js>, mut json: Vec<u8>) -> Result<Value<'js>> 
                             current_obj.index += 1;
                             last_is_string = false
                         }
-                    }
+                    },
                     ValueItem::Array(array) => {
                         array.set(current_obj.index, value)?;
                         current_obj.index += 1;
-                    }
+                    },
                 }
-            }
+            },
             Node::Object { len, count: _ } => {
                 let js_object = Object::new(ctx.clone())?;
                 let item = if let Some(current_obj) = path_data.last_mut() {
@@ -129,7 +129,7 @@ pub fn json_parse<'js>(ctx: &Ctx<'js>, mut json: Vec<u8>) -> Result<Value<'js>> 
 
                 path_data.push(item);
                 last_is_string = false;
-            }
+            },
             Node::Array { len, count: _ } => {
                 let js_array = Array::new(ctx.clone())?;
                 let item = if let Some(current_obj) = path_data.last_mut() {
@@ -148,7 +148,7 @@ pub fn json_parse<'js>(ctx: &Ctx<'js>, mut json: Vec<u8>) -> Result<Value<'js>> 
                 };
                 path_data.push(item);
                 last_is_string = false;
-            }
+            },
             Node::Static(node) => {
                 last_is_string = false;
                 current_obj = path_data.last_mut().unwrap();
@@ -158,7 +158,7 @@ pub fn json_parse<'js>(ctx: &Ctx<'js>, mut json: Vec<u8>) -> Result<Value<'js>> 
                     ValueItem::Array(arr) => arr.set(current_obj.index, value)?,
                 }
                 current_obj.index += 1;
-            }
+            },
         }
 
         current_obj = path_data.last_mut().unwrap();

--- a/src/json/stringify.rs
+++ b/src/json/stringify.rs
@@ -94,11 +94,11 @@ pub fn json_stringify_replacer_space<'js>(
     match write_primitive(&mut context, false)? {
         PrimitiveStatus::Written => {
             return Ok(Some(result));
-        }
+        },
         PrimitiveStatus::Ignored => {
             return Ok(None);
-        }
-        _ => {}
+        },
+        _ => {},
     }
 
     context.depth += 1;
@@ -234,7 +234,7 @@ fn write_primitive(context: &mut IterationContext, add_comma: bool) -> Result<Pr
             context
                 .result
                 .push_str(buffer.format(value.as_int().unwrap()))
-        }
+        },
         Type::Float => {
             let float_value = value.as_float().unwrap();
             const EXP_MASK: u64 = 0x7ff0000000000000;
@@ -255,7 +255,7 @@ fn write_primitive(context: &mut IterationContext, add_comma: bool) -> Result<Pr
                     unsafe { context.result.as_mut_vec().set_len(len - 2) }
                 }
             }
-        }
+        },
         Type::String => write_string(context.result, &value.as_string().unwrap().to_string()?),
         _ => return Ok(PrimitiveStatus::Iterate),
     }
@@ -346,7 +346,7 @@ fn append_value(context: &mut IterationContext<'_, '_>, add_comma: bool) -> Resu
             context.depth += 1;
             iterate(context)?;
             Ok(true)
-        }
+        },
     }
 }
 
@@ -451,7 +451,7 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                 write_indentation(context.result, indentation, depth);
             }
             context.result.push('}');
-        }
+        },
         Type::Array => {
             context.result.push('[');
             add_comma = false;
@@ -492,8 +492,8 @@ fn iterate(context: &mut IterationContext<'_, '_>) -> Result<()> {
                 write_indentation(context.result, indentation, depth);
             }
             context.result.push(']');
-        }
-        _ => {}
+        },
+        _ => {},
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,11 +151,11 @@ async fn start_cli(context: &AsyncContext) {
                     "-v" | "--version" => {
                         print_version();
                         return;
-                    }
+                    },
                     "-h" | "--help" => {
                         usage();
                         return;
-                    }
+                    },
                     "-e" | "--eval" => {
                         if let Some(source) = args.get(i + 1) {
                             Vm::run_and_handle_exceptions(context, |ctx| {
@@ -164,14 +164,14 @@ async fn start_cli(context: &AsyncContext) {
                             .await
                         }
                         return;
-                    }
+                    },
                     "test" => {
                         if let Err(error) = run_tests(context, &args[i + 1..]).await {
                             eprintln!("{error}");
                             exit(1);
                         }
                         return;
-                    }
+                    },
                     "compile" => {
                         #[cfg(not(feature = "lambda"))]
                         {
@@ -201,8 +201,8 @@ async fn start_cli(context: &AsyncContext) {
                             eprintln!("Not supported in \"lambda\" version.");
                             exit(1);
                         }
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
 
                 let (_, ext) = get_basename_ext_name(arg);

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -70,11 +70,11 @@ impl NetStream {
         let (readable_done, writable_done) = match self {
             NetStream::Tcp((stream, _)) => {
                 Socket::process_tcp_stream(socket, ctx, stream, allow_half_open)
-            }
+            },
             #[cfg(unix)]
             NetStream::Unix((stream, _)) => {
                 Socket::process_unix_stream(socket, ctx, stream, allow_half_open)
-            }
+            },
         }?;
         let had_error = rw_join(ctx, readable_done, writable_done).await?;
         Ok(had_error)

--- a/src/number.rs
+++ b/src/number.rs
@@ -24,7 +24,7 @@ fn i64_to_base_n(number: i64, radix: u8) -> String {
         8 => return write_formatted!("{:o}", number),
         10 => return write_formatted!("{}", number),
         16 => return write_formatted!("{:x}", number),
-        _ => {}
+        _ => {},
     }
 
     let mut positive_number = number;

--- a/src/path.rs
+++ b/src/path.rs
@@ -39,7 +39,7 @@ pub fn dirname(path: String) -> String {
             } else {
                 parent
             }
-        }
+        },
         None => ".",
     }
     .to_string()

--- a/src/runtime_client.rs
+++ b/src/runtime_client.rs
@@ -320,7 +320,7 @@ async fn invoke_response<'js>(
                 ctx,
                 &format!("Unexpected /invocation/response response: {}", res_str),
             ))
-        }
+        },
     }
 }
 

--- a/src/stream/readable.rs
+++ b/src/stream/readable.rs
@@ -70,7 +70,7 @@ impl<'js> ReadableStreamInner<'js> {
                     } else {
                         self.listener = None;
                     }
-                }
+                },
                 "readable" => {
                     if added {
                         self.state = ReadableState::Paused;
@@ -78,8 +78,8 @@ impl<'js> ReadableStreamInner<'js> {
                     } else {
                         self.listener = None;
                     }
-                }
-                _ => {}
+                },
+                _ => {},
             }
         }
         Ok(())
@@ -201,13 +201,13 @@ where
                             return Ok(());
                         }
                         vec![Buffer(buffer).into_js(ctx)?]
-                    }
+                    },
                     "readable" => {
                         vec![]
-                    }
+                    },
                     _ => {
                         vec![]
-                    }
+                    },
                 };
                 Self::emit_str(This(this), ctx, listener, args, false)?;
             }

--- a/src/utils/clone.rs
+++ b/src/utils/clone.rs
@@ -180,7 +180,7 @@ pub fn structured_clone<'js>(
                             let value = object.get(&key)?;
                             stack.push(StackItem::Value(index, value, Some(key), None));
                         }
-                    }
+                    },
                     Type::Array => {
                         if check_circular(
                             &mut tape,
@@ -213,7 +213,7 @@ pub fn structured_clone<'js>(
                                 Some(array_index),
                             ));
                         }
-                    }
+                    },
                     _ => {
                         tape.push(TapeItem {
                             parent,
@@ -221,13 +221,13 @@ pub fn structured_clone<'js>(
                             array_index,
                             value: TapeValue::Value(value),
                         });
-                    }
+                    },
                 }
                 index += 1;
-            }
+            },
             StackItem::ObjectEnd => {
                 visited.pop();
-            }
+            },
         }
     }
 
@@ -247,22 +247,22 @@ pub fn structured_clone<'js>(
         match &mut parent.value {
             TapeValue::Array(array) => {
                 array.set(array_index.unwrap(), value)?;
-            }
+            },
             TapeValue::Object(object) => {
                 let string = object_key.unwrap();
                 object.set(string, value)?;
-            }
+            },
             TapeValue::Collection(collection_value, collection_type) => {
                 match collection_type {
                     ObjectType::Set => {
                         collection_value.replace(set_ctor.construct((value,))?);
-                    }
+                    },
                     ObjectType::Map => {
                         collection_value.replace(map_ctor.construct((value,))?);
-                    }
+                    },
                 };
-            }
-            _ => {}
+            },
+            _ => {},
         };
     }
 

--- a/src/utils/object.rs
+++ b/src/utils/object.rs
@@ -152,7 +152,7 @@ pub fn obj_to_array_buffer<'js>(
             _ => {
                 let array_buffer: ArrayBuffer = obj.get("buffer")?;
                 return Ok(Some(array_buffer));
-            }
+            },
         }?;
         return Ok(Some(array_buffer));
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -198,10 +198,10 @@ impl BinaryResolver {
                     if !normalized.pop() {
                         normalized.push(component);
                     }
-                }
+                },
                 _ => {
                     normalized.push(component);
-                }
+                },
             }
         }
         if ends_with_slash {
@@ -564,12 +564,12 @@ impl Vm {
                     err_stack = stack;
                 }
                 str
-            }
+            },
             CaughtError::Value(value) => {
                 let log_msg = console::format(ctx, Rest(vec![value.clone()]))
                     .unwrap_or(String::from("{unknown value}"));
                 format!("Error: {}", &log_msg)
-            }
+            },
         };
         ErrorDetails {
             msg: error_msg,
@@ -804,7 +804,7 @@ impl<'js> ErrorExtensions<'js> for CaughtError<'js> {
         Ok(match self {
             CaughtError::Error(err) => {
                 JsString::from_str(ctx.clone(), &err.to_string())?.into_value()
-            }
+            },
             CaughtError::Exception(ex) => ex.into_value(),
             CaughtError::Value(val) => val,
         })
@@ -837,7 +837,7 @@ impl<'js> CtxExtension<'js> for Ctx<'js> {
                 Ok(res) => {
                     //result here dosn't matter if receiver has dropped
                     let _ = join_channel_tx.send(res);
-                }
+                },
                 Err(err) => {
                     if let CaughtError::Exception(err) = err {
                         if err.stack().is_none() {
@@ -849,7 +849,7 @@ impl<'js> CtxExtension<'js> for Ctx<'js> {
                     } else {
                         Vm::print_error_and_exit(&ctx, err);
                     }
-                }
+                },
             }
         });
         Ok(join_channel_rx)

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -139,7 +139,7 @@ impl<'js> XMLParser<'js> {
                     current_obj.has_value = true;
 
                     Self::process_end(&ctx, &current_obj, obj.into_value(&ctx)?, &current_key)?;
-                }
+                },
                 Ok(Event::Start(ref tag)) => {
                     has_attributes = false;
                     current_key = Self::get_tag_name(&ctx, &reader, tag)?;
@@ -156,7 +156,7 @@ impl<'js> XMLParser<'js> {
                         &mut current_obj,
                         &mut has_attributes,
                     )?;
-                }
+                },
                 Ok(Event::End(_)) => {
                     let (parent_tag, mut parent_obj) = path.pop().unwrap();
                     parent_obj.has_value = true;
@@ -169,7 +169,7 @@ impl<'js> XMLParser<'js> {
                     current_obj = parent_obj;
 
                     Self::process_end(&ctx, &current_obj, value, &parent_tag)?;
-                }
+                },
                 Ok(Event::CData(text)) => {
                     let text = text.escape().or_throw(&ctx)?;
                     let tag_value = String::from_utf8_lossy(text.as_ref()).to_string();
@@ -181,7 +181,7 @@ impl<'js> XMLParser<'js> {
                     } else {
                         current_value = Some(tag_value)
                     }
-                }
+                },
                 Ok(Event::Text(ref text)) => {
                     let tag_value = text
                         .unescape_with(|v| self.entities.get(v).map(|x| x.as_str()))
@@ -196,10 +196,10 @@ impl<'js> XMLParser<'js> {
                     } else {
                         current_value = Some(tag_value)
                     }
-                }
+                },
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
                 Ok(Event::Eof) => break,
-                _ => {}
+                _ => {},
             }
         }
         Ok(current_obj.obj)
@@ -492,12 +492,12 @@ impl<'js> XmlNode<'js> {
                         xml_text.push_str("/>");
                     }
                     drop(borrow);
-                }
+                },
                 NodeStackEntry::End(name) => {
                     xml_text.push_str("</");
                     xml_text.push_str(&name);
                     xml_text.push('>');
-                }
+                },
             }
         }
 


### PR DESCRIPTION
Thid PR adds rustfmt.toml, currently the following rules were added: 

- ` fn_params_layout = "Tall"` : https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#fn_params_layout
- `edition = "2021"` https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=edition#edition
-  `match_block_trailing_comma = true` https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#match_block_trailing_comma

There are some rules that may be convenient to run like:
 - https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=group#imports_granularity
 - https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=group#group_imports
But they are unstable and can only be run with nightly.


I will run `make fix` when reviewers agree on the rules.