### PR TITLE
feat: Implement DOMException()

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -71,6 +71,7 @@ const ES_BUILD_OPTIONS = {
     "navigator",
     "url",
     "performance",
+    "DOMException",
   ],
 };
 

--- a/build.mjs
+++ b/build.mjs
@@ -71,7 +71,6 @@ const ES_BUILD_OPTIONS = {
     "navigator",
     "url",
     "performance",
-    "DOMException",
   ],
 };
 

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,15 +1,31 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use rquickjs::{function::Opt, Class, Ctx, Result};
+use std::error::Error;
+use std::fmt::{self, Display};
 
-use rquickjs::{atom::PredefinedAtom, function::Opt, Class, Ctx, Result};
-
-#[derive(Clone, Default)]
+#[derive(Debug, Default)]
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace)]
 pub struct DOMException {
     message: String,
     name: String,
 }
+
+impl Display for DOMException {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        todo!()
+        /*
+        if self.message.is_empty() {
+            return self.name.clone();
+        }
+
+        format!("{}: {}", &self.name, &self.message)
+        */
+    }
+}
+
+impl Error for DOMException {}
 
 #[rquickjs::methods]
 impl<'js> DOMException {
@@ -29,15 +45,6 @@ impl<'js> DOMException {
     #[qjs(get, rename = "name")]
     pub fn get_name(&self) -> String {
         self.name.clone()
-    }
-
-    #[qjs(rename = PredefinedAtom::ToString)]
-    pub fn to_string(&self) -> String {
-        if self.message.is_empty() {
-            return self.name.clone();
-        }
-
-        format!("{}: {}", &self.name, &self.message)
     }
 }
 

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,57 +1,69 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use rquickjs::{function::Opt, Class, Ctx, Result};
-use std::error::Error;
-use std::fmt::{self, Display};
+use rquickjs::{
+    atom::PredefinedAtom,
+    function::Constructor,
+    prelude::{Func, This},
+    Ctx, IntoJs, Object, Result, Value,
+};
 
-#[derive(Debug, Default)]
-#[rquickjs::class]
-#[derive(rquickjs::class::Trace)]
 pub struct DOMException {
     message: String,
     name: String,
+    stack: Result<String>,
 }
 
-impl Display for DOMException {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
-        todo!()
-        /*
-        if self.message.is_empty() {
-            return self.name.clone();
-        }
-
-        format!("{}: {}", &self.name, &self.message)
-        */
-    }
-}
-
-impl Error for DOMException {}
-
-#[rquickjs::methods]
-impl<'js> DOMException {
-    #[qjs(constructor)]
-    pub fn new(_ctx: Ctx<'js>, message: Opt<String>, name: Opt<String>) -> Result<Self> {
-        Ok(Self {
-            message: message.0.unwrap_or(String::from("")),
-            name: name.0.unwrap_or(String::from("Error")),
-        })
-    }
-
-    #[qjs(get, rename = "message")]
-    fn get_message(&self) -> String {
-        self.message.clone()
-    }
-
-    #[qjs(get, rename = "name")]
-    pub fn get_name(&self) -> String {
-        self.name.clone()
+impl<'js> IntoJs<'js> for DOMException {
+    fn into_js(self, ctx: &Ctx<'js>) -> Result<Value<'js>> {
+        //TODO: It seems that the parameters are not being pulled in properly from the JavaScript side.
+        let message = self.message;
+        let name = self.name;
+        let val_message = message.into_js(ctx)?;
+        let val_name = name.into_js(ctx)?;
+        let constructor: Constructor = ctx.globals().get(stringify!(DOMException))?;
+        constructor.construct((val_message, val_name))
     }
 }
 
-pub fn init(ctx: &Ctx<'_>) -> Result<()> {
-    let globals = ctx.globals();
+//impl<'js> DOMException {}
 
-    Class::<DOMException>::define(&globals)?;
+fn message<'js>(_this: This<Object<'js>>, _ctx: Ctx<'js>) -> Result<String> {
+    // TODO: I don't know how to get the message property out of this object.
+    Ok("".to_string())
+}
+
+fn name<'js>(_this: This<Object<'js>>, _ctx: Ctx<'js>) -> Result<String> {
+    // TODO: I don't know how to get the name property out of this object.
+    Ok("".to_string())
+}
+
+fn to_string(_this: This<Object<'_>>, _ctx: Ctx) -> Result<String> {
+    // TODO: I don't know how to get the message and name property out of this object.
+    Ok("".to_string())
+}
+
+fn set_prototype<'js>(ctx: &Ctx<'js>, constructor: Object<'js>) -> Result<()> {
+    let prototype: &Object = &constructor.get(PredefinedAtom::Prototype)?;
+    // TODO: It accesses struct directly with or without the next 2 lines.
+    prototype.set(PredefinedAtom::Getter, Func::from(message))?;
+    prototype.set(PredefinedAtom::Getter, Func::from(name))?;
+
+    prototype.set(PredefinedAtom::ToString, Func::from(to_string))?;
+
+    ctx.globals().set(stringify!(DOMException), constructor)?;
 
     Ok(())
+}
+
+pub fn init<'js>(ctx: &Ctx<'js>) -> Result<()> {
+    let dom_exception = ctx.eval::<Object<'js>, &str>(&format!(
+        "class {0} extends Error {{}}\n{0}",
+        stringify!(DOMException)
+    ))?;
+
+    // TODO: Trying to register with globalThis, but IntoJs conflicts with #[rquickjs::class].
+    //let globals = ctx.globals();
+    //Class::<DOMException>::define(&globals)?;
+
+    set_prototype(ctx, dom_exception)
 }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -45,6 +45,15 @@ impl DOMException {
     fn stack(&self) -> String {
         self.stack.clone()
     }
+
+    #[qjs(rename = PredefinedAtom::ToString)]
+    pub fn to_string(&self) -> String {
+        if self.message.is_empty() {
+            return self.name.clone();
+        }
+
+        format!("{}: {}", &self.name, &self.message)
+    }
 }
 
 pub fn init(ctx: &Ctx<'_>) -> Result<()> {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -45,15 +45,6 @@ impl DOMException {
     fn stack(&self) -> String {
         self.stack.clone()
     }
-
-    #[qjs(rename = PredefinedAtom::ToString)]
-    pub fn to_string(&self) -> String {
-        if self.message.is_empty() {
-            return self.name.clone();
-        }
-
-        format!("{}: {}", &self.name, &self.message)
-    }
 }
 
 pub fn init(ctx: &Ctx<'_>) -> Result<()> {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,13 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use rquickjs::{
-    atom::PredefinedAtom,
-    function::Opt,
-    module::{Declarations, Exports, ModuleDef},
-    Class, Ctx, Result,
-};
 
-use crate::module::export_default;
+use rquickjs::{atom::PredefinedAtom, function::Opt, Class, Ctx, Result};
 
 #[derive(Clone, Default)]
 #[rquickjs::class]
@@ -55,24 +49,4 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     Class::<DOMException>::define(&globals)?;
 
     Ok(())
-}
-
-pub struct ExceptionsModule;
-
-impl ModuleDef for ExceptionsModule {
-    fn declare(declare: &mut Declarations) -> Result<()> {
-        declare.declare("default")?;
-
-        Ok(())
-    }
-
-    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &mut Exports<'js>) -> Result<()> {
-        Class::<DOMException>::register(ctx)?;
-
-        export_default(ctx, exports, |default| {
-            Class::<DOMException>::define(default)?;
-
-            Ok(())
-        })
-    }
 }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,0 +1,78 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use rquickjs::{
+    atom::PredefinedAtom,
+    function::Opt,
+    module::{Declarations, Exports, ModuleDef},
+    Class, Ctx, Result,
+};
+
+use crate::module::export_default;
+
+#[derive(Clone, Default)]
+#[rquickjs::class]
+#[derive(rquickjs::class::Trace)]
+pub struct DOMException {
+    message: String,
+    name: String,
+}
+
+#[rquickjs::methods]
+impl<'js> DOMException {
+    #[qjs(constructor)]
+    pub fn new(_ctx: Ctx<'js>, message: Opt<String>, name: Opt<String>) -> Result<Self> {
+        Ok(Self {
+            message: message.0.unwrap_or(String::from("")),
+            name: name.0.unwrap_or(String::from("Error")),
+        })
+    }
+
+    #[qjs(get, rename = "message")]
+    fn get_message(&self) -> String {
+        self.message.clone()
+    }
+
+    #[qjs(get, rename = "name")]
+    pub fn get_name(&self) -> String {
+        self.name.clone()
+    }
+
+    #[qjs(rename = PredefinedAtom::ToString)]
+    pub fn to_string(&self) -> String {
+        let mut message = String::new();
+
+        if !self.message.is_empty() {
+            message = format!(": {}", &self.message)
+        }
+
+        format!("{}{}", &self.name, message)
+    }
+}
+
+pub fn init(ctx: &Ctx<'_>) -> Result<()> {
+    let globals = ctx.globals();
+
+    Class::<DOMException>::define(&globals)?;
+
+    Ok(())
+}
+
+pub struct ExceptionsModule;
+
+impl ModuleDef for ExceptionsModule {
+    fn declare(declare: &mut Declarations) -> Result<()> {
+        declare.declare("default")?;
+
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &mut Exports<'js>) -> Result<()> {
+        Class::<DOMException>::register(ctx)?;
+
+        export_default(ctx, exports, |default| {
+            Class::<DOMException>::define(default)?;
+
+            Ok(())
+        })
+    }
+}

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -33,13 +33,11 @@ impl<'js> DOMException {
 
     #[qjs(rename = PredefinedAtom::ToString)]
     pub fn to_string(&self) -> String {
-        let mut message = String::new();
-
-        if !self.message.is_empty() {
-            message = format!(": {}", &self.message)
+        if self.message.is_empty() {
+            return self.name.clone();
         }
 
-        format!("{}{}", &self.name, message)
+        format!("{}: {}", &self.name, &self.message)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod crypto;
 mod encoding;
 mod environment;
 mod events;
+mod exceptions;
 mod fs;
 mod http;
 mod json;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -47,6 +47,7 @@ use crate::{
     encoding::HexModule,
     environment,
     events::EventsModule,
+    exceptions::ExceptionsModule,
     fs::{FsModule, FsPromisesModule},
     json::{parse::json_parse, stringify::json_stringify_replacer_space},
     module::ModuleModule,
@@ -138,7 +139,8 @@ create_modules!(
     "process" => ProcessModule,
     "navigator" => NavigatorModule,
     "url" => UrlModule,
-    "performance" => PerformanceModule
+    "performance" => PerformanceModule,
+    "exceptions" => ExceptionsModule
 );
 
 struct ModuleInfo<T: ModuleDef> {
@@ -501,6 +503,7 @@ impl Vm {
             crate::buffer::init(&ctx)?;
             crate::navigator::init(&ctx)?;
             crate::performance::init(&ctx)?;
+            crate::exceptions::init(&ctx)?;
             init(&ctx, module_names)?;
             Ok::<_, Error>(())
         })

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -47,7 +47,6 @@ use crate::{
     encoding::HexModule,
     environment,
     events::EventsModule,
-    exceptions::ExceptionsModule,
     fs::{FsModule, FsPromisesModule},
     json::{parse::json_parse, stringify::json_stringify_replacer_space},
     module::ModuleModule,
@@ -139,8 +138,7 @@ create_modules!(
     "process" => ProcessModule,
     "navigator" => NavigatorModule,
     "url" => UrlModule,
-    "performance" => PerformanceModule,
-    "exceptions" => ExceptionsModule
+    "performance" => PerformanceModule
 );
 
 struct ModuleInfo<T: ModuleDef> {

--- a/tests/unit/exceptions.test.ts
+++ b/tests/unit/exceptions.test.ts
@@ -1,4 +1,3 @@
-/*
 describe("globalThis", () => {
   it("globalThis should have a DOMException", () => {
     expect(globalThis.DOMException()).toBeDefined();
@@ -6,44 +5,49 @@ describe("globalThis", () => {
   it("globalThis.DOMException() should have a message", () => {
     expect(globalThis.DOMException().message).toBeDefined();
   });
-  it("globalThis.DOMException() should have a message", () => {
+  it("globalThis.DOMException() should have a name", () => {
     expect(globalThis.DOMException().name).toBeDefined();
   });
+  it("globalThis.DOMException() should have a stack", () => {
+    expect(globalThis.DOMException().stack).toBeDefined();
+  });
+  it("globalThis.DOMException() should have a toString()", () => {
+    expect(globalThis.DOMException().toString()).toBeDefined();
+  });
 });
-*/
 
 describe("DOMException()", () => {
   const e = new DOMException();
 
-  it("DOMException() should have a message", () => {
+  it("should have a message", () => {
     expect(e.message).toBeDefined();
   });
-  it("message property should be the initial value", () => {
+  it("message should be the initial value", () => {
     expect(e.message).toEqual("");
   });
-  it("DOMException() should have a name", () => {
+  it("should have a name", () => {
     expect(e.name).toBeDefined();
   });
-  it("name property should be the initial value", () => {
+  it("name should be the initial value", () => {
     expect(e.name).toEqual("Error");
   });
-  it("DOMException() should have a stack", () => {
+  it("should have a stack", () => {
     expect(e.stack).toBeDefined();
   });
-  it("DOMException() should have a toString()", () => {
+  it("should have a toString()", () => {
     expect(e.toString()).toBeDefined();
   });
-  it("DOMException() should be the string 'Error'", () => {
+  it("toString() should return the string 'Error'", () => {
     expect(e.toString()).toEqual("Error");
   });
-  it("Message properties are the same for thrown and caught exceptions", () => {
+  it("message should be the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException();
     } catch (ex) {
       expect(ex.message).toEqual("");
     }
   });
-  it("Name properties are the same for thrown and caught exceptions", () => {
+  it("name should be the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException();
     } catch (ex) {
@@ -55,23 +59,23 @@ describe("DOMException()", () => {
 describe("DOMException('abc')", () => {
   const e = new DOMException("abc");
 
-  it("message property should be the string 'abc'", () => {
+  it("message should be the string 'abc'", () => {
     expect(e.message).toEqual("abc");
   });
-  it("name property should be the initial value", () => {
+  it("name should be the initial value", () => {
     expect(e.name).toEqual("Error");
   });
-  it("DOMException().toString() should be the string 'Error: abc'", () => {
+  it("toString() should return the string 'Error: abc'", () => {
     expect(e.toString()).toEqual("Error: abc");
   });
-  it("Message properties are the same for thrown and caught exceptions", () => {
+  it("message should be the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException("abc");
     } catch (ex) {
       expect(ex.message).toEqual("abc");
     }
   });
-  it("Name properties are the same for thrown and caught exceptions", () => {
+  it("name should be the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException("abc");
     } catch (ex) {
@@ -83,23 +87,23 @@ describe("DOMException('abc')", () => {
 describe("DOMException('abc', 'def')", () => {
   const e = new DOMException("abc", "def");
 
-  it("message property should be the string 'abc'", () => {
+  it("message should be the string 'abc'", () => {
     expect(e.message).toEqual("abc");
   });
-  it("name property should be the string 'def'", () => {
+  it("name should be the string 'def'", () => {
     expect(e.name).toEqual("def");
   });
-  it("DOMException().toString() should be the string 'def: abc'", () => {
+  it("toString() should return the string 'def: abc'", () => {
     expect(e.toString()).toEqual("def: abc");
   });
-  it("Message properties are the same for thrown and caught exceptions", () => {
+  it("message should be the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException("abc", "def");
     } catch (ex) {
       expect(ex.message).toEqual("abc");
     }
   });
-  it("Name properties are the same for thrown and caught exceptions", () => {
+  it("name should be the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException("abc", "def");
     } catch (ex) {

--- a/tests/unit/exceptions.test.ts
+++ b/tests/unit/exceptions.test.ts
@@ -11,6 +11,9 @@ describe("globalThis", () => {
   it("globalThis.DOMException() should have a stack", () => {
     expect(globalThis.DOMException().stack).toBeDefined();
   });
+  it("globalThis.DOMException() should have a toString()", () => {
+    expect(globalThis.DOMException().toString()).toBeDefined();
+  });
 });
 
 describe("DOMException()", () => {
@@ -30,6 +33,12 @@ describe("DOMException()", () => {
   });
   it("should have a stack", () => {
     expect(e.stack).toBeDefined();
+  });
+  it("should have a toString()", () => {
+    expect(e.toString()).toBeDefined();
+  });
+  it("toString() should return the string 'Error'", () => {
+    expect(e.toString()).toEqual("Error");
   });
   it("message should be the same for thrown and caught exceptions", () => {
     try {
@@ -56,6 +65,9 @@ describe("DOMException('abc')", () => {
   it("name should be the initial value", () => {
     expect(e.name).toEqual("Error");
   });
+  it("toString() should return the string 'Error: abc'", () => {
+    expect(e.toString()).toEqual("Error: abc");
+  });
   it("message should be the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException("abc");
@@ -80,6 +92,9 @@ describe("DOMException('abc', 'def')", () => {
   });
   it("name should be the string 'def'", () => {
     expect(e.name).toEqual("def");
+  });
+  it("toString() should return the string 'def: abc'", () => {
+    expect(e.toString()).toEqual("def: abc");
   });
   it("message should be the same for thrown and caught exceptions", () => {
     try {

--- a/tests/unit/exceptions.test.ts
+++ b/tests/unit/exceptions.test.ts
@@ -66,14 +66,14 @@ describe("DOMException('abc')", () => {
   });
   it("Message properties are the same for thrown and caught exceptions", () => {
     try {
-      throw new DOMException();
+      throw new DOMException("abc");
     } catch (ex) {
       expect(ex.message).toEqual("abc");
     }
   });
   it("Name properties are the same for thrown and caught exceptions", () => {
     try {
-      throw new DOMException();
+      throw new DOMException("abc");
     } catch (ex) {
       expect(ex.name).toEqual("Error");
     }
@@ -94,14 +94,14 @@ describe("DOMException('abc', 'def')", () => {
   });
   it("Message properties are the same for thrown and caught exceptions", () => {
     try {
-      throw new DOMException();
+      throw new DOMException("abc", "def");
     } catch (ex) {
       expect(ex.message).toEqual("abc");
     }
   });
   it("Name properties are the same for thrown and caught exceptions", () => {
     try {
-      throw new DOMException();
+      throw new DOMException("abc", "def");
     } catch (ex) {
       expect(ex.name).toEqual("def");
     }

--- a/tests/unit/exceptions.test.ts
+++ b/tests/unit/exceptions.test.ts
@@ -1,0 +1,59 @@
+describe("globalThis", () => {
+  it("globalThis should have a DOMException", () => {
+    expect(globalThis.DOMException()).toBeDefined();
+  });
+  it("globalThis.DOMException() should have a message", () => {
+    expect(globalThis.DOMException().message).toBeDefined();
+  });
+  it("globalThis.DOMException() should have a message", () => {
+    expect(globalThis.DOMException().name).toBeDefined();
+  });
+});
+
+describe("DOMException()", () => {
+  const e = new DOMException();
+
+  it("should have a message", () => {
+    expect(e.message).toBeDefined();
+  });
+  it("message property should be the initial value", () => {
+    expect(e.message).toEqual("");
+  });
+  it("should have a message", () => {
+    expect(e.name).toBeDefined();
+  });
+  it("should be the initial value", () => {
+    expect(e.name).toEqual("Error");
+  });
+  it("result of the toString method should be 'Error'", () => {
+    expect(e.toString()).toEqual("Error");
+  });
+});
+
+describe("DOMException('abc')", () => {
+  const e = new DOMException("abc");
+
+  it("message property should have the string 'abc'", () => {
+    expect(e.message).toEqual("abc");
+  });
+  it("message property should be the initial value", () => {
+    expect(e.name).toEqual("Error");
+  });
+  it("result of the toString method should be 'Error: abc'", () => {
+    expect(e.toString()).toEqual("Error: abc");
+  });
+});
+
+describe("DOMException('abc', 'def')", () => {
+  const e = new DOMException("abc", "def");
+
+  it("message property should have the string 'abc'", () => {
+    expect(e.message).toEqual("abc");
+  });
+  it("name property should have the string 'def'", () => {
+    expect(e.name).toEqual("def");
+  });
+  it("result of the toString method should be 'def: abc'", () => {
+    expect(e.toString()).toEqual("def: abc");
+  });
+});

--- a/tests/unit/exceptions.test.ts
+++ b/tests/unit/exceptions.test.ts
@@ -28,6 +28,13 @@ describe("DOMException()", () => {
   it("result of the toString method should be 'Error'", () => {
     expect(e.toString()).toEqual("Error");
   });
+  it("throwing and catching exceptions can be done", () => {
+    try {
+      throw new DOMException();
+    } catch (ex) {
+      expect(ex.toString()).toEqual(e.toString());
+    }
+  });
 });
 
 describe("DOMException('abc')", () => {
@@ -42,6 +49,13 @@ describe("DOMException('abc')", () => {
   it("result of the toString method should be 'Error: abc'", () => {
     expect(e.toString()).toEqual("Error: abc");
   });
+  it("throwing and catching exceptions can be done", () => {
+    try {
+      throw new DOMException("abc");
+    } catch (ex) {
+      expect(ex.toString()).toEqual(e.toString());
+    }
+  });
 });
 
 describe("DOMException('abc', 'def')", () => {
@@ -55,5 +69,12 @@ describe("DOMException('abc', 'def')", () => {
   });
   it("result of the toString method should be 'def: abc'", () => {
     expect(e.toString()).toEqual("def: abc");
+  });
+  it("throwing and catching exceptions can be done", () => {
+    try {
+      throw new DOMException("abc", "def");
+    } catch (ex) {
+      expect(ex.toString()).toEqual(e.toString());
+    }
   });
 });

--- a/tests/unit/exceptions.test.ts
+++ b/tests/unit/exceptions.test.ts
@@ -1,3 +1,4 @@
+/*
 describe("globalThis", () => {
   it("globalThis should have a DOMException", () => {
     expect(globalThis.DOMException()).toBeDefined();
@@ -9,30 +10,44 @@ describe("globalThis", () => {
     expect(globalThis.DOMException().name).toBeDefined();
   });
 });
+*/
 
 describe("DOMException()", () => {
   const e = new DOMException();
 
-  it("should have a message", () => {
+  it("DOMException() should have a message", () => {
     expect(e.message).toBeDefined();
   });
   it("message property should be the initial value", () => {
     expect(e.message).toEqual("");
   });
-  it("should have a message", () => {
+  it("DOMException() should have a name", () => {
     expect(e.name).toBeDefined();
   });
-  it("should be the initial value", () => {
+  it("name property should be the initial value", () => {
     expect(e.name).toEqual("Error");
   });
-  it("result of the toString method should be 'Error'", () => {
+  it("DOMException() should have a stack", () => {
+    expect(e.stack).toBeDefined();
+  });
+  it("DOMException() should have a toString()", () => {
+    expect(e.toString()).toBeDefined();
+  });
+  it("DOMException() should be the string 'Error'", () => {
     expect(e.toString()).toEqual("Error");
   });
-  it("throwing and catching exceptions can be done", () => {
+  it("Message properties are the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException();
     } catch (ex) {
-      expect(ex.toString()).toEqual(e.toString());
+      expect(ex.message).toEqual("");
+    }
+  });
+  it("Name properties are the same for thrown and caught exceptions", () => {
+    try {
+      throw new DOMException();
+    } catch (ex) {
+      expect(ex.name).toEqual("Error");
     }
   });
 });
@@ -40,20 +55,27 @@ describe("DOMException()", () => {
 describe("DOMException('abc')", () => {
   const e = new DOMException("abc");
 
-  it("message property should have the string 'abc'", () => {
+  it("message property should be the string 'abc'", () => {
     expect(e.message).toEqual("abc");
   });
-  it("message property should be the initial value", () => {
+  it("name property should be the initial value", () => {
     expect(e.name).toEqual("Error");
   });
-  it("result of the toString method should be 'Error: abc'", () => {
+  it("DOMException().toString() should be the string 'Error: abc'", () => {
     expect(e.toString()).toEqual("Error: abc");
   });
-  it("throwing and catching exceptions can be done", () => {
+  it("Message properties are the same for thrown and caught exceptions", () => {
     try {
-      throw new DOMException("abc");
+      throw new DOMException();
     } catch (ex) {
-      expect(ex.toString()).toEqual(e.toString());
+      expect(ex.message).toEqual("abc");
+    }
+  });
+  it("Name properties are the same for thrown and caught exceptions", () => {
+    try {
+      throw new DOMException();
+    } catch (ex) {
+      expect(ex.name).toEqual("Error");
     }
   });
 });
@@ -61,20 +83,27 @@ describe("DOMException('abc')", () => {
 describe("DOMException('abc', 'def')", () => {
   const e = new DOMException("abc", "def");
 
-  it("message property should have the string 'abc'", () => {
+  it("message property should be the string 'abc'", () => {
     expect(e.message).toEqual("abc");
   });
-  it("name property should have the string 'def'", () => {
+  it("name property should be the string 'def'", () => {
     expect(e.name).toEqual("def");
   });
-  it("result of the toString method should be 'def: abc'", () => {
+  it("DOMException().toString() should be the string 'def: abc'", () => {
     expect(e.toString()).toEqual("def: abc");
   });
-  it("throwing and catching exceptions can be done", () => {
+  it("Message properties are the same for thrown and caught exceptions", () => {
     try {
-      throw new DOMException("abc", "def");
+      throw new DOMException();
     } catch (ex) {
-      expect(ex.toString()).toEqual(e.toString());
+      expect(ex.message).toEqual("abc");
+    }
+  });
+  it("Name properties are the same for thrown and caught exceptions", () => {
+    try {
+      throw new DOMException();
+    } catch (ex) {
+      expect(ex.name).toEqual("def");
     }
   });
 });

--- a/tests/unit/exceptions.test.ts
+++ b/tests/unit/exceptions.test.ts
@@ -11,9 +11,6 @@ describe("globalThis", () => {
   it("globalThis.DOMException() should have a stack", () => {
     expect(globalThis.DOMException().stack).toBeDefined();
   });
-  it("globalThis.DOMException() should have a toString()", () => {
-    expect(globalThis.DOMException().toString()).toBeDefined();
-  });
 });
 
 describe("DOMException()", () => {
@@ -33,12 +30,6 @@ describe("DOMException()", () => {
   });
   it("should have a stack", () => {
     expect(e.stack).toBeDefined();
-  });
-  it("should have a toString()", () => {
-    expect(e.toString()).toBeDefined();
-  });
-  it("toString() should return the string 'Error'", () => {
-    expect(e.toString()).toEqual("Error");
   });
   it("message should be the same for thrown and caught exceptions", () => {
     try {
@@ -65,9 +56,6 @@ describe("DOMException('abc')", () => {
   it("name should be the initial value", () => {
     expect(e.name).toEqual("Error");
   });
-  it("toString() should return the string 'Error: abc'", () => {
-    expect(e.toString()).toEqual("Error: abc");
-  });
   it("message should be the same for thrown and caught exceptions", () => {
     try {
       throw new DOMException("abc");
@@ -92,9 +80,6 @@ describe("DOMException('abc', 'def')", () => {
   });
   it("name should be the string 'def'", () => {
     expect(e.name).toEqual("def");
-  });
-  it("toString() should return the string 'def: abc'", () => {
-    expect(e.toString()).toEqual("def: abc");
   });
   it("message should be the same for thrown and caught exceptions", () => {
     try {


### PR DESCRIPTION
### Issue # (if available)
Fixes #330  

### Description of changes

[The Minimum Common Web Platform API](https://common-min-api.proposal.wintercg.org/) is being considered at WinterCG.
This PR provides [DOMException()](https://developer.mozilla.org/en-US/docs/Web/API/DOMException), which is not yet implemented in `llrt`.

The unit test with javascript seems to be working well, but we have not yet implemented the return of exceptions from rust to javascript.

events.rs:
```rust
let abort_exception = Exception::from_value("AbortError".into_js(&ctx)?)?; // TODO: AbortError DOMException
```
```rust
let timeout_exception = Exception::from_value("TimeoutError".into_js(&ctx)?)?; // TODO: Timeout DOMException
```

What implementation is needed to eliminate this problem?
Any reference to implementations or sample code in already existing projects would be helpful.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
