### PR TITLE
AbortController/Signal fixes

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -494,10 +494,7 @@ impl<'js> AbortSignal<'js> {
 
     #[qjs(get, rename = "onabort")]
     pub fn get_on_abort(&self) -> Option<Function<'js>> {
-        Self::get_listeners_str(&self, "abort")
-            .iter()
-            .next()
-            .map(|e| e.clone())
+        Self::get_listeners_str(self, "abort").first().cloned()
     }
 
     #[qjs(set, rename = "onabort")]

--- a/src/events.rs
+++ b/src/events.rs
@@ -270,21 +270,22 @@ where
 
     fn has_listener_str(&self, event: &str) -> bool {
         let key = EventKey::String(String::from(event));
-        self.get_event_list()
-            .read()
-            .unwrap()
-            .iter()
-            .any(|(k, _)| k == &key)
+        has_key(self.get_event_list(), key)
     }
 
     fn has_listener(&self, ctx: Ctx<'js>, event: Value<'js>) -> Result<bool> {
         let key = EventKey::from_value(&ctx, event)?;
-        Ok(self
-            .get_event_list()
-            .read()
-            .unwrap()
-            .iter()
-            .any(|(k, _)| k == &key))
+        Ok(has_key(self.get_event_list(), key))
+    }
+
+    fn get_listeners(&self, ctx: &Ctx<'js>, event: Value<'js>) -> Result<Vec<Function<'js>>> {
+        let key = EventKey::from_value(ctx, event)?;
+        Ok(find_all_listeners(self.get_event_list(), key))
+    }
+
+    fn get_listeners_str(&self, event: &str) -> Vec<Function<'js>> {
+        let key = EventKey::String(String::from(event));
+        find_all_listeners(self.get_event_list(), key)
     }
 
     fn do_emit(
@@ -365,6 +366,23 @@ where
     }
 }
 
+fn find_all_listeners<'js>(
+    events: Arc<RwLock<EventList<'js>>>,
+    key: EventKey<'js>,
+) -> Vec<Function<'js>> {
+    let events = events.read().unwrap();
+    let items = events.iter().find(|(k, _)| k == &key);
+    if let Some((_, callbacks)) = items {
+        callbacks.iter().map(|item| item.callback.clone()).collect()
+    } else {
+        vec![]
+    }
+}
+
+fn has_key<'js>(event_list: Arc<RwLock<EventList<'js>>>, key: EventKey<'js>) -> bool {
+    event_list.read().unwrap().iter().any(|(k, _)| k == &key)
+}
+
 fn to_event<'js>(ctx: &Ctx<'js>, event: &str) -> Result<Value<'js>> {
     let event = JsString::from_str(ctx.clone(), event)?;
     Ok(event.into_value())
@@ -412,6 +430,10 @@ impl<'js> AbortController<'js> {
         let instance = this.0.borrow();
         let signal = instance.signal.clone();
         let mut signal_borrow = signal.borrow_mut();
+        if signal_borrow.aborted {
+            //only once
+            return Ok(());
+        }
         signal_borrow.set_reason(reason);
         drop(signal_borrow);
         AbortSignal::send_aborted(This(signal), ctx)?;
@@ -468,6 +490,24 @@ impl<'js> AbortSignal<'js> {
             reason: None,
             sender,
         }
+    }
+
+    #[qjs(get, rename = "onabort")]
+    pub fn get_on_abort(&self) -> Option<Function<'js>> {
+        Self::get_listeners_str(&self, "abort")
+            .iter()
+            .next()
+            .map(|e| e.clone())
+    }
+
+    #[qjs(set, rename = "onabort")]
+    pub fn set_on_abort(
+        this: This<Class<'js, Self>>,
+        ctx: Ctx<'js>,
+        listener: Function<'js>,
+    ) -> Result<()> {
+        Self::add_event_listener_str(this, &ctx, "abort", listener, false, true)?;
+        Ok(())
     }
 
     pub fn throw_if_aborted(&self, ctx: Ctx<'js>) -> Result<()> {

--- a/src/events.rs
+++ b/src/events.rs
@@ -506,7 +506,7 @@ impl<'js> AbortSignal<'js> {
         ctx: Ctx<'js>,
         listener: Function<'js>,
     ) -> Result<()> {
-        Self::add_event_listener_str(this, &ctx, "abort", listener, false, true)?;
+        Self::add_event_listener_str(this, &ctx, "abort", listener, false, false)?;
         Ok(())
     }
 

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -140,4 +140,17 @@ describe("AbortSignal & AbortController", () => {
       done();
     }, 100);
   });
+
+  it("should only emit aborted once", () => {
+    let ctrl = new AbortController();
+    let count = 0;
+    ctrl.signal.onabort = () => {
+      count++;
+    };
+    expect(ctrl.signal.onabort).toEqual(expect.any(Function));
+    ctrl.abort();
+    ctrl.abort();
+    ctrl.abort();
+    expect(count).toBe(1);
+  });
 });

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -149,6 +149,7 @@ describe("AbortSignal & AbortController", () => {
     };
     expect(ctrl.signal.onabort).toEqual(expect.any(Function));
     ctrl.abort();
+    expect(ctrl.signal.onabort).toEqual(expect.any(Function)); //keep listener
     ctrl.abort();
     ctrl.abort();
     expect(count).toBe(1);


### PR DESCRIPTION
### Description of changes

Add `onabort` and only fire event once (if aborted)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
