### PR TITLE
fix: wrong response.url in fetch()

### DIFF
--- a/llrt_core/src/modules/http/fetch.rs
+++ b/llrt_core/src/modules/http/fetch.rs
@@ -524,7 +524,6 @@ mod tests {
                 // Method: GET, Redirect Pattern: 301 -> 200
                 options.set("method", "GET")?;
                 let url = format!("http://{}/expect/301/", mock_server.address().clone());
-                assert_eq!(response.url(), format!("http://{}/expect/200/", mock_server.address().clone()));
 
                 let response_promise: Promise<Value> = fetch.call((url, options.clone()))?;
                 let response = response_promise.await?;

--- a/llrt_core/src/modules/http/fetch.rs
+++ b/llrt_core/src/modules/http/fetch.rs
@@ -519,6 +519,7 @@ mod tests {
                 let response = response.borrow();
 
                 assert_eq!(response.status(), 200);
+                assert_eq!(response.url(), format!("http://{}/expect/200/", mock_server.address().clone()));
 
                 // Method: GET, Redirect Pattern: 301 -> 200
                 options.set("method", "GET")?;


### PR DESCRIPTION
### Description of changes

- Fixed a failure to return the last url in `response.url` after being redirected by `fetch`. (See also. [Fetch Standard#responses](https://fetch.spec.whatwg.org/#responses))

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
