### PR TITLE
feat: Support for http/2

### DIFF
--- a/llrt_core/src/environment.rs
+++ b/llrt_core/src/environment.rs
@@ -2,6 +2,7 @@
 pub const ENV_LLRT_NET_ALLOW: &str = "LLRT_NET_ALLOW";
 pub const ENV_LLRT_NET_DENY: &str = "LLRT_NET_DENY";
 pub const ENV_LLRT_NET_POOL_IDLE_TIMEOUT: &str = "LLRT_NET_POOL_IDLE_TIMEOUT";
+pub const ENV_LLRT_HTTP_VERSION: &str = "LLRT_HTTP_VERSION";
 
 //log
 pub const ENV_LLRT_LOG: &str = "LLRT_LOG";


### PR DESCRIPTION
### Issue #338 (if available)

### Description of changes

- If the environment variable `LLRT_HTTP_VERSION` is not present, the connection is established with `http/2`. (This is the default behavior.)
- If the environment variable `LLRT_HTTP_VERSION` is set to `1.1`, the connection is established with `http/1.1`.
- If the environment variable `LLRT_HTTP_VERSION` is set to a value other than `1.1` (for example, `5`), the connection is established with `http/2`.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
