### PR TITLE
fix: Avoid re-running build.rs on every build, even when nothing changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy
         run: | #create mock js files
-          mkdir -p bundle
+          mkdir -p bundle/js
           for i in {1..5}; do
-            echo "console.log(123);" > "bundle/test$i.js"
+            echo "console.log(123);" > "bundle/js/test$i.js"
           done
           cargo clippy --all-targets --all-features -- -D warnings
   build:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ZSTD_LIB_CC_arm64 = CC="zig cc -target aarch64-linux-musl $(ZSTD_LIB_CC_ARGS)"
 ZSTD_LIB_CC_x64 = CC="zig cc -target x86_64-linux-musl $(ZSTD_LIB_CC_ARGS)"
 
 TS_SOURCES = $(wildcard llrt_core/src/modules/js/*.ts) $(wildcard llrt_core/src/modules/js/@llrt/*.ts) $(wildcard tests/unit/*.ts)
-STD_JS_FILE = $(BUNDLE_DIR)/@llrt/std.js
+STD_JS_FILE = $(BUNDLE_DIR)/js/@llrt/std.js
 
 RELEASE_ARCH_NAME_x64 = x86_64
 RELEASE_ARCH_NAME_arm64 = arm64
@@ -108,7 +108,7 @@ clean: clean-js
 
 js: $(STD_JS_FILE)
 
-bundle/%.js: $(TS_SOURCES)
+bundle/js/%.js: $(TS_SOURCES)
 	node build.mjs
 
 fix:
@@ -150,15 +150,15 @@ run-cli: js
 
 test: export JS_MINIFY = 0
 test: js
-	cargo run -- test -d bundle/__tests__/unit
+	cargo run -- test -d bundle/js/__tests__/unit
 test-e2e: export JS_MINIFY = 0
 test-e2e: js
-	cargo run -- test -d bundle/__tests__/e2e
+	cargo run -- test -d bundle/js/__tests__/e2e
 
 test-ci: export JS_MINIFY = 0
 test-ci: clean-js | toolchain js
 	cargo $(TOOLCHAIN) -Z panic-abort-tests test --target $(CURRENT_TARGET)
-	cargo $(TOOLCHAIN) run -r --target $(CURRENT_TARGET) -- test -d bundle/__tests__/unit
+	cargo $(TOOLCHAIN) run -r --target $(CURRENT_TARGET) -- test -d bundle/js/__tests__/unit
 
 libs-arm64: lib/arm64/libzstd.a lib/zstd.h
 libs-x64: lib/x64/libzstd.a lib/zstd.h

--- a/build.mjs
+++ b/build.mjs
@@ -10,7 +10,7 @@ process.env.NODE_PATH = ".";
 const TMP_DIR = `.tmp-llrt-aws-sdk`;
 const SRC_DIR = path.join("llrt_core", "src", "modules", "js");
 const TESTS_DIR = "tests";
-const OUT_DIR = "bundle";
+const OUT_DIR = "bundle/js";
 const SHIMS = new Map();
 
 async function readFilesRecursive(dir, filePredicate) {

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -70,7 +70,7 @@ pub fn uncompressed_size(input: &[u8]) -> StdResult<(usize, &[u8]), io::Error> {
     Ok((uncompressed_size, rest))
 }
 
-pub(crate) static COMPRESSION_DICT: &[u8] = include_bytes!("../../bundle/compression.dict");
+pub(crate) static COMPRESSION_DICT: &[u8] = include_bytes!("../../bundle/lrt/compression.dict");
 
 static DECOMPRESSOR_DICT: Lazy<DecoderDictionary> =
     Lazy::new(|| DecoderDictionary::copy(COMPRESSION_DICT));

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -47,5 +47,5 @@ Certain resources need to be created to make sure the integration test has backe
    Assuming you already have a binary built for LLRT, this will run a specific integration tests (e.g.: `s3.e2e.test.ts`)
 
    ```shell
-   make bundle/%.js && target/debug/llrt  test s3.e2e.test
+   make bundle/js/%.js && target/debug/llrt  test s3.e2e.test
    ```


### PR DESCRIPTION
### Issue # (if available)

<!--  **Please post the link to the resolved issue** -->

### Description of changes

from commit message:

Because build.rs depends on the bundle/ directory, whenever it also writes into it, the directory's timestamp is updated. This leads Cargo to always consider it outdated and re-run build.rs every time.

To fix this, separate the inputs to build.rs (the JS files) into a separate directory, bundle/js/, and move the compiled .lrt files to bundle/lrt/. This will keep their timestamps separate.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
