### PR TITLE
feat: Implementation of decompression in fetch()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotlic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f552f56f302af0006c32b50bfa2bdb4696fd6ba33c3ab9f6225fefdb1efdc680"
+dependencies = [
+ "brotlic-sys",
+]
+
+[[package]]
+name = "brotlic-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdec5c62bc97b56349053cf66ba503af5c2448591be61c3ad70a5f11b57e574"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +389,17 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "libz-ng-sys",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -842,6 +871,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "llrt"
 version = "0.1.12-beta"
 dependencies = [
@@ -859,10 +898,12 @@ version = "0.1.12-beta"
 dependencies = [
  "async-trait",
  "base64-simd",
+ "brotlic",
  "bytes",
  "chrono",
  "crc32c",
  "crc32fast",
+ "flate2",
  "fxhash",
  "hex-simd",
  "http-body-util",

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -73,6 +73,8 @@ tokio-rustls = { version = "0.26.0", features = [
 ring = "0.17.8"
 rand = "0.8.5"
 uname = "0.1.1"
+flate2 = { version = "1.0.30", features = ["zlib-ng"], default-features = false }
+brotlic = "0.8.2"
 
 [build-dependencies]
 rquickjs = { version = "0.5.1", features = [

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -167,12 +167,12 @@ impl<'js> Response<'js> {
                 };
 
                 if let Some(content_encoding) = &self.body_attributes.content_encoding {
-                    let mut data: Vec<u8> = Vec::new();
+                    let mut data: Vec<u8> = Vec::with_capacity(bytes.len());
                     match content_encoding.as_str() {
+                        "zstd" => ZstdDecoder::new(&bytes[..])?.read_to_end(&mut data)?,
+                        "br" => BrotliDecoder::new(&bytes[..]).read_to_end(&mut data)?,
                         "gzip" => GzDecoder::new(&bytes[..]).read_to_end(&mut data)?,
                         "deflate" => ZlibDecoder::new(&bytes[..]).read_to_end(&mut data)?,
-                        "br" => BrotliDecoder::new(&bytes[..]).read_to_end(&mut data)?,
-                        "zstd" => ZstdDecoder::new(&bytes[..])?.read_to_end(&mut data)?,
                         _ => return Err(Exception::throw_message(ctx, "Unsupported encoding")),
                     };
                     data

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -304,7 +304,7 @@ impl<'js> Response<'js> {
         self.headers.clone()
     }
 
-    async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
+    pub async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             return Ok(String::from_utf8_lossy(&bytes).to_string());
         }


### PR DESCRIPTION
### Issue #355 (if available)

### Description of changes

- Implementation of decompression in fetch()
Supported Encodings: gzip, deflate, br, zstd

### Execution Sample
content-encoding.js:
```javascript
const main = async () => {
  try {
    const response = await fetch('https://www.meta.com/', {headers: {"accept-encoding": process.argv[2]}});
    console.log(response.headers.get('content-encoding'));
    const responseText = await response.text();
    console.log('vvv');
    console.log(responseText.substring(0, 100));
    console.log('^^^');
  } catch(e) {
    console.log(e);
  }
}

main();
```

1. accept-encoding: `zstd`
```
shinya@MBA2022M2 llrt-test % ./llrt content-encoding.js zstd   
zstd
vvv
<!DOCTYPE html><html id="facebook" class="_a4ch _aber" lang="ja" dir="ltr"><head><link data-default-
^^^
```
2. accept-encoding: `br`
```
shinya@MBA2022M2 llrt-test % ./llrt content-encoding.js br  
br
vvv
<!DOCTYPE html><html id="facebook" class="_a4ch _aber" lang="ja" dir="ltr"><head><link data-default-
^^^
```
3. accept-encoding: `gzip`
```
shinya@MBA2022M2 llrt-test % ./llrt content-encoding.js gzip
gzip
vvv
<!DOCTYPE html><html id="facebook" class="_a4ch _aber" lang="ja" dir="ltr"><head><link data-default-
^^^
```
4. accept-encoding: `deflate`
```
shinya@MBA2022M2 llrt-test % ./llrt content-encoding.js deflate
undefined       // NOTE: This website does not support deflate.
vvv
<!DOCTYPE html><html id="facebook" class="_a4ch _aber" lang="ja" dir="ltr"><head><link data-default-
^^^
```
5. accept-encoding: `gzip, deflate, br, zstd`
```
shinya@MBA2022M2 llrt-test % ./llrt content-encoding.js "gzip, deflate, br, zstd"
zstd            // NOTE: The encoding is determined on the server side.
vvv
<!DOCTYPE html><html id="facebook" class="_a4ch _aber" lang="ja" dir="ltr"><head><link data-default-
^^^
```

### ToDo

- [x] Add test code. (`Response.text()` or `response.json()` does not work well in Mock Server testing...)
- ~~[ ] Verify `deflate` decompression on the actual website. (I would like to know if anyone has found it anywhere. :)~~
- [x] Default setting for `accept-encoding`. (Is there a specification that cannot be overridden by a `header` method when `Request::builder()` is executed? Also, what about the encoding priority order?)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
