### PR TITLE
feat: Improved compliance of URLSearchParams

### DIFF
--- a/API.md
+++ b/API.md
@@ -220,6 +220,9 @@ export class URLSearchParams {
     init?: string | string[][] | Record<string, string> | URLSearchParams
   );
 
+  // properties
+  size: number;
+ 
   // Methods
   append(name: string, value: string): void;
   delete(name: string): void;
@@ -231,6 +234,8 @@ export class URLSearchParams {
 
   [Symbol.iterator](): IterableIterator<[string, string]>;
   entries(): IterableIterator<[string, string]>;
+  forEach(): IterableIterator<[string, string]>;
+  keys(): IterableIterator<string>;
   values(): IterableIterator<string>;
 
   toString(): string;

--- a/llrt_core/src/modules/http/url_search_params.rs
+++ b/llrt_core/src/modules/http/url_search_params.rs
@@ -59,6 +59,11 @@ impl URLSearchParams {
         Ok(URLSearchParams { params: Vec::new() })
     }
 
+    #[qjs(get)]
+    pub fn size(&mut self) -> usize {
+        self.params.len()
+    }
+
     pub fn append(&mut self, key: String, value: String) {
         self.params.push((key, value));
     }
@@ -137,6 +142,10 @@ impl URLSearchParams {
         string
     }
 
+    pub fn keys(&mut self) -> Vec<String> {
+        self.params.iter().map(|(k, _)| k.clone()).collect()
+    }
+
     pub fn values(&mut self) -> Vec<String> {
         self.params.iter().map(|(_, v)| v.clone()).collect()
     }
@@ -148,6 +157,13 @@ impl URLSearchParams {
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
     pub fn iterator<'js>(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         self.js_iterator(ctx)
+    }
+
+    pub fn for_each(&self, callback: Function<'_>) -> Result<()> {
+        for param in self.params.iter() {
+            callback.call((param.1.clone(), param.0.clone()))?
+        }
+        Ok(())
     }
 }
 

--- a/llrt_core/src/modules/http/url_search_params.rs
+++ b/llrt_core/src/modules/http/url_search_params.rs
@@ -60,7 +60,7 @@ impl URLSearchParams {
     }
 
     #[qjs(get)]
-    pub fn size(&mut self) -> usize {
+    pub fn size(&self) -> usize {
         self.params.len()
     }
 

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -39,14 +39,18 @@ describe("URL module import", () => {
     it("supports URLSearchParams basic API", () => {
       const paramsString = "topic=api&a=1&a=2&a=3";
       const searchParams = new urlModule.URLSearchParams(paramsString);
+      expect(searchParams.size).toEqual(4);
       searchParams.append("foo", "bar");
+      expect(searchParams.size).toEqual(5);
       expect(searchParams.has("topic")).toBeTruthy();
       expect(searchParams.has("foo")).toBeTruthy();
       searchParams.delete("foo");
+      expect(searchParams.size).toEqual(4);
       expect(searchParams.has("foo")).toBeFalsy();
       expect(searchParams.get("topic")).toEqual("api");
       expect(searchParams.getAll("a")).toEqual(["1", "2", "3"]);
       searchParams.set("topic", "node");
+      expect(searchParams.size).toEqual(4);
       expect(searchParams.get("topic")).toEqual("node");
     });
   });
@@ -479,6 +483,41 @@ describe("URLSearchParams class", () => {
       ["a", "2"],
       ["a", "3"],
     ]);
+  });
+
+  it("should for_each all parameters in the query string", () => {
+    const paramsString = "topic=api&a=1&a=2&a=3";
+    const searchParams = new URLSearchParams(paramsString);
+    let arr: [string, string][] = [];
+    searchParams.forEach((value, key) => {
+      arr.push([key, value]);
+    });
+    expect(arr).toEqual([
+      ["topic", "api"],
+      ["a", "1"],
+      ["a", "2"],
+      ["a", "3"],
+    ]);
+  });
+
+  it("should get key parameters in the query string", () => {
+    const paramsString = "key1=value1&key2=value2";
+    const searchParams = new URLSearchParams(paramsString);
+    let keys = "";
+    for (const key of searchParams.keys()) {
+      keys = keys + key;
+    }
+    expect(keys).toEqual("key1key2");
+  });
+
+  it("should get value parameters in the query string", () => {
+    const paramsString = "key1=value1&key2=value2";
+    const searchParams = new URLSearchParams(paramsString);
+    let values = "";
+    for (const value of searchParams.values()) {
+      values = values + value;
+    }
+    expect(values).toEqual("value1value2");
   });
 });
 


### PR DESCRIPTION
### Description of changes

Add the following methods/properties to improve the compliance of URLSearchParams.
- URLSearchParams.size
- URLSearchParams.keys()
- URLSearchParams.forEach()

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
