### PR TITLE
feat: Improved compliance of Response Object

### DIFF
--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -244,11 +244,7 @@ impl<'js> Response<'js> {
             }
         }
 
-        let headers = if let Some(headers) = headers {
-            Class::instance(ctx.clone(), headers)
-        } else {
-            Class::instance(ctx.clone(), Headers::default())
-        }?;
+        let headers = Class::instance(ctx.clone(), headers.unwrap_or_default())?;
 
         let body = body.0.and_then(|body| {
             if body.is_null() || body.is_undefined() {
@@ -425,11 +421,7 @@ impl<'js> Response<'js> {
             }
         }
 
-        let headers = if let Some(headers) = headers {
-            Class::instance(ctx.clone(), headers)
-        } else {
-            Class::instance(ctx.clone(), Headers::default())
-        }?;
+        let headers = Class::instance(ctx.clone(), headers.unwrap_or_default())?;
 
         let body = Some(BodyVariant::Provided(body));
 

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -136,7 +136,7 @@ describe("Request class", () => {
     const request = new Request("https://example.com");
     expect(request.bodyUsed).toBeFalsy();
   });
-  
+
   it("should set the method to the provided value", () => {
     const method = "POST";
     const request = new Request("https://example.com", { method });
@@ -323,6 +323,52 @@ describe("Response class", () => {
   it("should create a Response object with not-ok status for status codes outside the range 200-299", () => {
     const response = new Response("Error", { status: 404 });
     expect(!response.ok).toBeTruthy();
+  });
+
+  it("should be returned specified values in error static function", () => {
+    const response = Response.error();
+    expect(response.status).toEqual(0);
+    expect(response.statusText).toEqual("");
+    expect(response.headers instanceof Headers).toBeTruthy();
+    expect(response.body).toEqual(null);
+    expect(response.type).toEqual("error");
+  });
+
+  it("should be returned specified values in redirect static function called single param", () => {
+    const redirectUrl = "http://localhost/";
+    const response = Response.redirect(redirectUrl);
+    expect(response.status).toEqual(302);
+    expect(response.headers.get("location")).toEqual(redirectUrl);
+  });
+
+  it("should be returned specified values in redirect static function called double param", () => {
+    const redirectUrl = "http://localhost/";
+    const response = Response.redirect(redirectUrl, 301);
+    expect(response.status).toEqual(301);
+    expect(response.headers.get("location")).toEqual(redirectUrl);
+  });
+
+  it("should be returned specified values in json static function called single param", () => {
+    const jsonBody = { some: "data", more: "information" };
+    const response = Response.json(JSON.stringify(jsonBody));
+    expect(response.status).toEqual(200);
+    response.json().then((parsedJson) => {
+      expect(parsedJson).toStrictEqual(jsonBody);
+    });
+  });
+
+  it("should be returned specified values in json static function called double param", () => {
+    const jsonBody = { some: "data", more: "information" };
+    const response = Response.json(JSON.stringify(jsonBody), {
+      status: 200,
+      statusText: "SuperSmashingGreat!",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(response.status).toEqual(200);
+    expect(response.statusText).toEqual("SuperSmashingGreat!");
+    response.json().then((parsedJson) => {
+      expect(parsedJson).toStrictEqual(jsonBody);
+    });
   });
 });
 


### PR DESCRIPTION
### Description of changes

Add the following methods to improve the compliance of `Response` Object.
- Response.error() static method
- Response.json() static method
- Response.redirect() static method

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
