### PR TITLE
feat: Improved compliance of URL object

### DIFF
--- a/llrt_core/src/modules/http/url.rs
+++ b/llrt_core/src/modules/http/url.rs
@@ -238,6 +238,13 @@ impl<'js> URL<'js> {
         self.password.clone_from(&password);
         password
     }
+
+    #[qjs(rename = PredefinedAtom::ToJSON)]
+    fn to_json(&self) -> String {
+        // NOTE: It is not wrong to return as a string.
+        // https://developer.mozilla.org/en-US/docs/Web/API/URL/toJSON
+        self.to_string()
+    }
 }
 
 impl<'js> URL<'js> {

--- a/llrt_core/src/modules/http/url.rs
+++ b/llrt_core/src/modules/http/url.rs
@@ -241,7 +241,6 @@ impl<'js> URL<'js> {
 
     #[qjs(rename = PredefinedAtom::ToJSON)]
     fn to_json(&self) -> String {
-        // NOTE: It is not wrong to return as a string.
         // https://developer.mozilla.org/en-US/docs/Web/API/URL/toJSON
         self.to_string()
     }

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -491,6 +491,14 @@ describe("URL class", () => {
   it("canParse works for relative urls", () => {
     expect(URL.canParse("/foo", "https://example.org/")).toEqual(true);
   });
+  it("should return the URL as a string", () => {
+    const url = new URL(
+      "https://developer.mozilla.org/ja/docs/Web/API/URL/toString"
+    );
+    expect(url.toJSON()).toEqual(
+      "https://developer.mozilla.org/ja/docs/Web/API/URL/toString"
+    );
+  });
 });
 
 describe("URLSearchParams class", () => {


### PR DESCRIPTION
### Description of changes

Add the following methods to improve the compliance of `URL` Object.

- URL.toJSON()

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
