### PR TITLE
docs: Clarify instructions for running emulator locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,13 @@ You should now have a `llrt-lambda-arm64.zip` or `llrt-lambda-x64.zip`. You can 
 
 ## Running Lambda emulator
 
-Please note that in order to run the example you will need:
+Please note that in order to run the example you will need to run the following from the repo root:
+
+- A root to locate the example `index.mjs`
+
+```bash
+export LAMBDA_TASK_ROOT=$(pwd)
+```
 
 - Valid AWS credentials via a `~/.aws/credentials` or via environment variables.
 
@@ -323,8 +329,13 @@ export AWS_SECRET_ACCESS_KEY=YYY
 export AWS_REGION=us-east-1
 ```
 
-- A DynamoDB table (with `id` as the partition key) on `us-east-1`
-- The `dynamodb:PutItem` IAM permission on this table. You can use this policy (don't forget to modify <YOUR_ACCOUNT_ID>):
+- A DynamoDB table (with `id` as the partition key) in the same region as above such as `us-east-1
+
+```bash
+export TABLE_NAME=quickjs-table
+```
+
+- The `dynamodb:PutItem` IAM permission on this table. You can use this policy (don't forget to modify `<YOUR_ACCOUNT_ID>` and `<TABLE_NAME>`, and change the region if you're not using `us-east-1`):
 
 ```json
 {
@@ -334,7 +345,7 @@ export AWS_REGION=us-east-1
       "Sid": "putItem",
       "Effect": "Allow",
       "Action": "dynamodb:PutItem",
-      "Resource": "arn:aws:dynamodb:us-east-1:<YOUR_ACCOUNT_ID>:table/quickjs-table"
+      "Resource": "arn:aws:dynamodb:us-east-1:<YOUR_ACCOUNT_ID>:table/<TABLE_NAME>"
     }
   ]
 }


### PR DESCRIPTION
### Description of changes

Without explicitly setting `LAMBDA_TASK_ROOT`, `make run` fails to find `index` by looking it one level higher than it should (`ReferenceError: Error resolving module '/Users/nppinski/workspace/index' from ''` -> meanwhile, my working directory is `workspace/llrt`) due to this recently added parent directory hop: https://github.com/awslabs/llrt/commit/0ba28cd990ccf4d8b83ebf3c066b28ccc5cc77b8#diff-fb2489504fc47c00a43d4af72367d6cf617ec7caf0b7726062029c29366867a7R471

@KaanMol, I couldn't quite tell what the reason why the task root had to be moved one level higher, but to at least unblock the emulator, I just added an explicit instruction to set the task root. 

If you think this is revealing a different problem, I'm happy to get some suggestions on how we can make sure this can work correctly when called from the root too

### Checklist

- [ x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ x] Ran `make fix` to format JS and apply Clippy auto fixes
- [ x] Made sure my code didn't add any additional warnings: `make check`
- [x ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
