### PR TITLE
Fix url search params for non-existing keys

### DIFF
--- a/llrt_core/src/modules/http/url_search_params.rs
+++ b/llrt_core/src/modules/http/url_search_params.rs
@@ -95,7 +95,7 @@ impl URLSearchParams {
     pub fn set(&mut self, key: String, value: String) {
         let mut modified = false;
         let mut same = false;
-        self.params.retain_mut(move |(k, v)| {
+        self.params.retain_mut(|(k, v)| {
             same = k == &key;
             if !modified && same {
                 modified = true;
@@ -105,6 +105,10 @@ impl URLSearchParams {
 
             !same
         });
+
+        if !modified {
+            self.params.push((key, value));
+        }
     }
 
     pub fn delete(&mut self, key: String) {

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -491,14 +491,6 @@ describe("URL class", () => {
   it("canParse works for relative urls", () => {
     expect(URL.canParse("/foo", "https://example.org/")).toEqual(true);
   });
-  it("should return the URL as a string", () => {
-    const url = new URL(
-      "https://developer.mozilla.org/ja/docs/Web/API/URL/toString"
-    );
-    expect(url.toJSON()).toEqual(
-      "https://developer.mozilla.org/ja/docs/Web/API/URL/toString"
-    );
-  });
 });
 
 describe("URLSearchParams class", () => {
@@ -591,6 +583,12 @@ describe("URLSearchParams class", () => {
     const searchParams = new URLSearchParams(paramsString);
     searchParams.set("topic", "More webdev");
     expect(searchParams.toString()).toEqual("topic=More+webdev&a=1&a=2&a=3");
+  });
+
+  it("should set value even if not existing", () => {
+    const searchParams = new URLSearchParams("?bar=baz");
+    searchParams.set("foo", "bar");
+    expect(searchParams.toString()).toEqual("bar=baz&foo=bar");
   });
 
   it("should remove the parameter from the query string", () => {


### PR DESCRIPTION
### Issue # (if available)

https://github.com/awslabs/llrt/issues/396

### Description of changes

Append value if not present

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
