### PR TITLE
feat: Improved compliance of request and response

### DIFF
--- a/llrt_core/src/modules/http/request.rs
+++ b/llrt_core/src/modules/http/request.rs
@@ -149,6 +149,13 @@ impl<'js> Request<'js> {
         ArrayBuffer::new(ctx, Vec::<u8>::new())
     }
 
+    async fn bytes(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        if let Some(bytes) = self.take_bytes(&ctx).await? {
+            return TypedArray::new(ctx, bytes).map(|m| m.into_value());
+        }
+        TypedArray::new(ctx, Vec::<u8>::new()).map(|m| m.into_value())
+    }
+
     fn clone(&mut self, ctx: Ctx<'js>) -> Result<Self> {
         let headers = if let Some(headers) = &self.headers {
             Some(Class::<Headers>::instance(

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -11,7 +11,7 @@ use hyper::{body::Incoming, header::HeaderName};
 use rquickjs::{
     class::{Trace, Tracer},
     function::Opt,
-    ArrayBuffer, Class, Coerced, Ctx, Exception, Null, Object, Result, Value,
+    ArrayBuffer, Class, Coerced, Ctx, Exception, Null, Object, Result, TypedArray, Value,
 };
 use tokio::{runtime::Handle, select};
 
@@ -347,6 +347,13 @@ impl<'js> Response<'js> {
             return ArrayBuffer::new(ctx, bytes);
         }
         ArrayBuffer::new(ctx, Vec::<u8>::new())
+    }
+
+    async fn bytes(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        if let Some(bytes) = self.take_bytes(&ctx).await? {
+            return TypedArray::new(ctx, bytes).map(|m| m.into_value());
+        }
+        TypedArray::new(ctx, Vec::<u8>::new()).map(|m| m.into_value())
     }
 
     async fn blob(&mut self, ctx: Ctx<'js>) -> Result<Blob> {

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -275,15 +275,22 @@ describe("Request class", () => {
     expect(request.bodyUsed).toBeTruthy();
   });
 
-  it("should set the body to a JSON object if a JSON object is provided", () => {
+  it("should set the body to a JSON object if a JSON object is provided", async () => {
     const jsonBody = { key: "value" };
     const request = new Request("http://localhost", {
       body: JSON.stringify(jsonBody),
       method: "POST",
     });
-    request.json().then((parsedJson) => {
-      expect(parsedJson).toStrictEqual(jsonBody);
+    expect(await request.json()).toStrictEqual(jsonBody);
+  });
+
+  it("should set the body to a bytes object if a bytes object is provided", async () => {
+    const myArray = new Uint8Array([1, 2, 3]);
+    const request = new Request("http://localhost", {
+      body: myArray,
+      method: "POST",
     });
+    expect(await request.bytes()).toStrictEqual(myArray);
   });
 });
 
@@ -324,18 +331,21 @@ describe("Response class", () => {
   it("should set the body to a Blob if a Blob is provided", async () => {
     const blob = new Blob(["Hello, world!"], { type: "text/plain" });
     const response = new Response(blob);
-
     expect(await response.text()).toEqual("Hello, world!");
   });
 
-  it("should set the body to a JSON object if a JSON object is provided", () => {
+  it("should set the body to a JSON object if a JSON object is provided", async () => {
     const jsonBody = { key: "value" };
     const response = new Response(JSON.stringify(jsonBody), {
       headers: { "Content-Type": "application/json" },
     });
-    response.json().then((parsedJson) => {
-      expect(parsedJson).toStrictEqual(jsonBody);
-    });
+    expect(await response.json()).toStrictEqual(jsonBody);
+  });
+
+  it("should set the body to a bytes object if a bytes object is provided", async () => {
+    const myArray = new Uint8Array([1, 2, 3]);
+    const response = new Response(myArray);
+    expect(await response.bytes()).toStrictEqual(myArray);
   });
 
   it("should clone the response with the clone() method", () => {


### PR DESCRIPTION
### Description of changes

Add the following methods to improve the compliance of `request` and `response` Object.
See also. https://fetch.spec.whatwg.org/#dom-body-bytes

- request.bytes()
- response.bytes()

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
