### PR TITLE
Fix runtime emulator logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
         "AWS_LAMBDA_FUNCTION_NAME": "n/a",
         "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1",
         "AWS_LAMBDA_FUNCTION_VERSION": "1",
-        "_AWS_LAMBDA_RUNTIME_API": "http://localhost:3000",
+        //"AWS_LAMBDA_RUNTIME_API": "localhost:3000",
         "_EXIT_LOOP": "1",
         "RUST_LOG": "llrt=trace,hyper::http=trace",
         //"_HANDLER": "index.handler",

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ run: export JS_MINIFY = 0
 run: export RUST_LOG = llrt=trace
 run: export _HANDLER = index.handler
 run: | clean-js js
-	cargo run -r -vv
+	cargo run -vv
 
 run-ssr: export AWS_LAMBDA_RUNTIME_API = localhost:3000
 run-ssr: export TABLE_NAME=quickjs-table

--- a/example/functions/src/external-sdk.mjs
+++ b/example/functions/src/external-sdk.mjs
@@ -1,0 +1,24 @@
+// Import the necessary AWS SDK clients and commands
+import { EC2Client, DescribeInstancesCommand } from "@aws-sdk/client-ec2";
+
+// Create an EC2 client
+const client = new EC2Client();
+
+// Lambda handler function
+export const handler = async () => {
+  const command = new DescribeInstancesCommand({});
+
+  // Send the command to the EC2 client
+  const response = await client.send(command);
+
+  // Extract instances information
+  const instances = response.Reservations.flatMap(
+    (reservation) => reservation.Instances
+  );
+
+  // Return the list of instances
+  return {
+    statusCode: 200,
+    body: JSON.stringify(instances),
+  };
+};

--- a/fixtures/primitive-handler.mjs
+++ b/fixtures/primitive-handler.mjs
@@ -1,0 +1,3 @@
+export const handler = () => {
+  return "hello";
+};


### PR DESCRIPTION
### Description of changes

Simplify printing errors on exit and lambda logging

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
