### PR TITLE
fix: make check broken

### DIFF
--- a/llrt_core/src/runtime_client.rs
+++ b/llrt_core/src/runtime_client.rs
@@ -467,8 +467,6 @@ async fn post_error<'js>(
 
     #[cfg(not(test))]
     {
-        use crate::modules::console;
-        use rquickjs::function::Rest;
         console::log_std_err(
             ctx,
             Rest(vec![error_object.clone()]),


### PR DESCRIPTION
### Issue # (if available)

Related #406 

### Description of changes

Fix `make check` no longer passes.

```bash
% make check
cargo clippy --all-targets --all-features -- -D warnings
   Compiling llrt_core v0.1.14-beta (/Users/shinya/Workspaces/llrt/llrt_core)
error: the item `console` is imported redundantly
   --> llrt_core/src/runtime_client.rs:470:13
    |
6   | use crate::modules::console;
    |     ----------------------- the item `console` is already imported here
...
470 |         use crate::modules::console;
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: the item `Rest` is imported redundantly
   --> llrt_core/src/runtime_client.rs:471:13
    |
23  | use rquickjs::function::{Rest, This};
    |                          ---- the item `Rest` is already imported here
...
471 |         use rquickjs::function::Rest;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `llrt_core` (lib) due to 2 previous errors
make: *** [check] Error 101
```
### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
