### PR TITLE
fix: get method does not return null

### DIFF
--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -80,7 +80,7 @@ describe("Headers class", () => {
     const headers = { "Content-Type": "application/json" };
     const h = new Headers(headers);
     h.delete("Content-Type");
-    expect(h.get("Content-Type")).toEqual(undefined);
+    expect(h.get("Content-Type")).toBeNull();
   });
 
   it("should return an iterator over the headers", () => {


### PR DESCRIPTION
### Description of changes

In the `get()` method of the `Headers` object, `undefined` is returned when a non-existent key is specified.

```shell
% ./llrt -e "console.log(new Headers().get('aaa'));"
undefined
```
Normally, `null` should be returned.

https://developer.mozilla.org/en-US/docs/Web/API/Headers/get
> The get() method of the [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) interface returns a byte string of all the values of a header within a Headers object with a given name. If the requested header doesn't exist in the Headers object, it returns null.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
