### PR TITLE
feat: Improved compliance of Blob and Body

### DIFF
--- a/llrt_core/src/modules/http/blob.rs
+++ b/llrt_core/src/modules/http/blob.rs
@@ -6,7 +6,7 @@ use rquickjs::{
     atom::PredefinedAtom,
     class::{JsClass, Trace},
     function::{Func, Opt},
-    ArrayBuffer, Class, Coerced, Ctx, Exception, FromJs, Object, Result, Value,
+    ArrayBuffer, Class, Coerced, Ctx, Exception, FromJs, Object, Result, TypedArray, Value,
 };
 
 use super::file::File;
@@ -95,6 +95,10 @@ impl Blob {
     #[qjs(rename = "arrayBuffer")]
     pub async fn array_buffer<'js>(&self, ctx: Ctx<'js>) -> Result<ArrayBuffer<'js>> {
         ArrayBuffer::new(ctx, self.data.to_vec())
+    }
+
+    async fn bytes<'js>(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        TypedArray::new(ctx, self.data.to_vec()).map(|m| m.into_value())
     }
 
     pub fn slice(&self, start: Opt<isize>, end: Opt<isize>, content_type: Opt<String>) -> Blob {

--- a/llrt_core/src/modules/http/body.rs
+++ b/llrt_core/src/modules/http/body.rs
@@ -61,6 +61,11 @@ impl<'js> Body<'js> {
         Ok(Blob::from_bytes(bytes, self.content_type.take())) //no need to copy, we can only take bytes once
     }
 
+    pub async fn bytes(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        let bytes = self.take_bytes(&ctx).await?;
+        TypedArray::new(ctx, bytes).map(|m| m.into_value())
+    }
+
     pub fn is_used(&self) -> bool {
         if let BodyVariant::Incoming(data) = &self.data {
             return data.is_none();

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -217,6 +217,7 @@ describe("Request class", () => {
     expect(request.body).toStrictEqual(
       new Uint8Array(await blob.arrayBuffer())
     );
+    expect(request.body).toStrictEqual(await blob.bytes());
     expect(request.bodyUsed).toBeTruthy();
   });
 
@@ -713,6 +714,15 @@ describe("Blob class", () => {
     const arrayBuffer = await blob.arrayBuffer();
 
     expect(arrayBuffer).toBeInstanceOf(ArrayBuffer);
+  });
+
+  it("should return an Uint8Array with the bytes() method", async () => {
+    const blobData = ["Hello, world!"];
+    const blob = new Blob(blobData, { type: "text/plain" });
+
+    const bytes = await blob.bytes();
+
+    expect(bytes).toBeInstanceOf(Uint8Array);
   });
 
   it("should return a DataView with the slice method", () => {


### PR DESCRIPTION
### Description of changes

Add the following methods to improve the compliance of `Blob` and `Body` Object.

- Blob.bytes()
https://www.w3.org/TR/FileAPI/#bytes-method-algo

- Body.bytes()
https://fetch.spec.whatwg.org/#dom-body-bytes

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
