### PR TITLE
perf: Misc string perf improvements

### DIFF
--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -97,3 +97,7 @@ criterion = "0.5.1"
 [[bench]]
 name = "json"
 harness = false
+
+[[bench]]
+name = "numbers"
+harness = false

--- a/llrt_core/benches/numbers.rs
+++ b/llrt_core/benches/numbers.rs
@@ -1,0 +1,76 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use llrt_core::number::i64_to_base_n;
+use rand::Rng;
+use std::fmt::Write;
+
+macro_rules! write_formatted {
+    ($format:expr, $number:expr) => {{
+        let digits = ($number as f64).log10() as usize + 2;
+        let mut string = String::with_capacity(digits);
+        write!(string, $format, $number).unwrap();
+        string
+    }};
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+
+    c.bench_function("to_binary", |b| {
+        b.iter(|| {
+            let num: i64 = rng.gen();
+            i64_to_base_n(black_box(num), 2);
+        })
+    });
+
+    c.bench_function("to_octal", |b| {
+        b.iter(|| {
+            let num: i64 = rng.gen();
+            i64_to_base_n(black_box(num), 2);
+        })
+    });
+
+    c.bench_function("to_dec", |b| {
+        b.iter(|| {
+            let num: i64 = rng.gen();
+            i64_to_base_n(black_box(num), 10);
+        })
+    });
+
+    c.bench_function("to_hex", |b| {
+        b.iter(|| {
+            let num: i64 = rng.gen();
+            i64_to_base_n(black_box(num), 16);
+        })
+    });
+
+    c.bench_function("write_formatted bin", |b| {
+        b.iter(|| {
+            let num: i64 = rng.gen();
+            write_formatted!("{:b}", black_box(num));
+        })
+    });
+
+    c.bench_function("write_formatted octal", |b| {
+        b.iter(|| {
+            let num: i64 = rng.gen();
+            write_formatted!("{:o}", black_box(num));
+        })
+    });
+
+    c.bench_function("write_formatted dec", |b| {
+        b.iter(|| {
+            let num: i64 = rng.gen();
+            write_formatted!("{}", black_box(num));
+        })
+    });
+
+    c.bench_function("write_formatted hex", |b| {
+        b.iter(|| {
+            let num: i64 = rng.gen();
+            write_formatted!("{:x}", black_box(num));
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/llrt_core/src/lib.rs
+++ b/llrt_core/src/lib.rs
@@ -15,7 +15,7 @@ pub mod json;
 // mod minimal_tracer;
 mod module_builder;
 pub mod modules;
-mod number;
+pub mod number;
 pub mod runtime_client;
 mod security;
 mod stream;

--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -282,7 +282,7 @@ fn format_raw_inner<'js>(
         Type::Float => {
             Color::YELLOW.push(result, color_enabled_mask);
             let mut buffer = ryu::Buffer::new();
-            result.push_str(float_to_string(&mut buffer, value.as_float().unwrap())?);
+            result.push_str(float_to_string(&mut buffer, value.as_float().unwrap()));
         },
         Type::String => {
             Color::GREEN.push(result, not_root_mask & color_enabled_mask);


### PR DESCRIPTION
### Description of changes

Reducing allocations in XML parsing & number formatting

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
