### PR TITLE
feat: Improved compliance of TextEncoder

### DIFF
--- a/llrt_core/src/modules/encoding/text_encoder.rs
+++ b/llrt_core/src/modules/encoding/text_encoder.rs
@@ -3,7 +3,6 @@
 use rquickjs::{Ctx, Object, Result, TypedArray, Value};
 
 use crate::utils::{object::obj_to_array_buffer, result::ResultExt};
-use std::str::from_utf8;
 
 #[derive(rquickjs::class::Trace)]
 #[rquickjs::class]
@@ -46,7 +45,9 @@ impl TextEncoder {
 
             let mut enc = encoding_rs::UTF_8.new_encoder();
             (_, _, written, _) = enc.encode_from_utf8(string.as_str(), bytes, false);
-            read = from_utf8(&bytes[..written]).unwrap().encode_utf16().count();
+            read = string[..written]
+                .chars()
+                .fold(0, |acc, ch| acc + ch.len_utf16());
         }
 
         let obj = Object::new(ctx)?;

--- a/llrt_core/src/modules/encoding/text_encoder.rs
+++ b/llrt_core/src/modules/encoding/text_encoder.rs
@@ -1,12 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use rquickjs::{Ctx, Result, TypedArray, Value};
+use rquickjs::{Ctx, Object, Result, TypedArray, Value};
+
+use crate::utils::{object::obj_to_array_buffer, result::ResultExt};
+use std::str::from_utf8;
 
 #[derive(rquickjs::class::Trace)]
 #[rquickjs::class]
 pub struct TextEncoder {}
 
-#[rquickjs::methods]
+#[rquickjs::methods(rename_all = "camelCase")]
 impl TextEncoder {
     #[qjs(constructor)]
     pub fn new() -> Self {
@@ -20,5 +23,35 @@ impl TextEncoder {
 
     pub fn encode<'js>(&self, ctx: Ctx<'js>, string: String) -> Result<Value<'js>> {
         TypedArray::new(ctx, string.as_bytes()).map(|m| m.into_value())
+    }
+
+    pub fn encode_into<'js>(
+        &self,
+        ctx: Ctx<'js>,
+        string: String,
+        obj: Object<'js>,
+    ) -> Result<Object<'js>> {
+        let mut read = 0;
+        let mut written = 0;
+
+        if let Some((array_buffer, source_length, source_offset)) = obj_to_array_buffer(&obj)? {
+            let raw = array_buffer
+                .as_raw()
+                .ok_or("ArrayBuffer is detached")
+                .or_throw(&ctx)?;
+
+            let bytes = unsafe {
+                std::slice::from_raw_parts_mut(raw.ptr.as_ptr().add(source_offset), source_length)
+            };
+
+            let mut enc = encoding_rs::UTF_8.new_encoder();
+            (_, _, written, _) = enc.encode_from_utf8(string.as_str(), bytes, false);
+            read = from_utf8(&bytes[..written]).unwrap().encode_utf16().count();
+        }
+
+        let obj = Object::new(ctx)?;
+        obj.set("read", read)?;
+        obj.set("written", written)?;
+        Ok(obj)
     }
 }

--- a/tests/unit/encoding.test.ts
+++ b/tests/unit/encoding.test.ts
@@ -28,7 +28,7 @@ describe("atoa & btoa", () => {
 });
 
 describe("TextDecoder", () => {
-  it("Should be able to decode even non UTF-8 labels ", () => {
+  it("should be able to decode even non UTF-8 labels", () => {
     const hono = "炎"; // hono - [炎] means flame🔥 in Japanese
     const honoSjis = new Uint8Array([0x89, 0x8a]);
     const decoded = new TextDecoder("sjis");
@@ -67,5 +67,48 @@ describe("TextDecoder", () => {
     } catch (ex) {
       expect(ex.message).toEqual("Unsupported encoding label");
     }
+  });
+});
+
+describe("TextEncoder", () => {
+  it("should be able to encodeInto of surrogate pair character", () => {
+    const hono = "🔥";
+    const encoded = new TextEncoder();
+
+    const u8Array3 = new Uint8Array(3);
+    const result3 = encoded.encodeInto(hono, u8Array3);
+    expect(result3.read).toEqual(0);
+    expect(result3.written).toEqual(0);
+    expect(u8Array3).toEqual(new Uint8Array([0, 0, 0]));
+
+    const u8Array4 = new Uint8Array(4);
+    const result4 = encoded.encodeInto(hono, u8Array4);
+    expect(result4.read).toEqual(2);
+    expect(result4.written).toEqual(4);
+    expect(u8Array4).toEqual(new Uint8Array([240, 159, 148, 165]));
+
+    const u8Array5 = new Uint8Array(5);
+    const result5 = encoded.encodeInto(hono, u8Array5);
+    expect(result5.read).toEqual(2);
+    expect(result5.written).toEqual(4);
+    expect(u8Array5).toEqual(new Uint8Array([240, 159, 148, 165, 0]));
+  });
+
+  it("should be able to encodeInto and decode", () => {
+    const hono = "hono - [炎] means flame🔥 in Japanese";
+    const encoded = new TextEncoder();
+
+    const u8Array40 = new Uint8Array(40);
+    const resultHono = encoded.encodeInto(hono, u8Array40);
+    expect(resultHono.read).toEqual(36);
+    expect(resultHono.written).toEqual(40);
+    expect(u8Array40).toEqual(
+      new Uint8Array([
+        104, 111, 110, 111, 32, 45, 32, 91, 231, 130, 142, 93, 32, 109, 101, 97,
+        110, 115, 32, 102, 108, 97, 109, 101, 240, 159, 148, 165, 32, 105, 110,
+        32, 74, 97, 112, 97, 110, 101, 115, 101,
+      ])
+    );
+    expect(new TextDecoder().decode(u8Array40)).toEqual(hono);
   });
 });

--- a/tests/unit/encoding.test.ts
+++ b/tests/unit/encoding.test.ts
@@ -71,7 +71,7 @@ describe("TextDecoder", () => {
 });
 
 describe("TextEncoder", () => {
-  it("should be able to encodeInto of surrogate pair character", () => {
+  it("should be able to encodeInto of surrogate pair character(Short Array)", () => {
     const hono = "🔥";
     const encoded = new TextEncoder();
 
@@ -80,12 +80,22 @@ describe("TextEncoder", () => {
     expect(result3.read).toEqual(0);
     expect(result3.written).toEqual(0);
     expect(u8Array3).toEqual(new Uint8Array([0, 0, 0]));
+  });
+
+  it("should be able to encodeInto of surrogate pair character(Equal Length Array)", () => {
+    const hono = "🔥";
+    const encoded = new TextEncoder();
 
     const u8Array4 = new Uint8Array(4);
     const result4 = encoded.encodeInto(hono, u8Array4);
     expect(result4.read).toEqual(2);
     expect(result4.written).toEqual(4);
     expect(u8Array4).toEqual(new Uint8Array([240, 159, 148, 165]));
+  });
+
+  it("should be able to encodeInto of surrogate pair character(Long Array)", () => {
+    const hono = "🔥";
+    const encoded = new TextEncoder();
 
     const u8Array5 = new Uint8Array(5);
     const result5 = encoded.encodeInto(hono, u8Array5);


### PR DESCRIPTION
### Description of changes

Add the following methods to improve the compliance of Encoding API.

- TextEncoder.encodeInto()

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
