### PR TITLE
Fix: Removed several module offerings

### DIFF
--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -9,11 +9,9 @@ use crate::modules::{
     events::EventsModule,
     fs::{FsModule, FsPromisesModule},
     module::ModuleModule,
-    navigator::NavigatorModule,
     net::NetModule,
     os::OsModule,
     path::PathModule,
-    performance::PerformanceModule,
     process::ProcessModule,
     timers::TimersModule,
     url::UrlModule,
@@ -95,10 +93,8 @@ impl Default for ModuleBuilder {
             .with_module(UuidModule)
             .with_module(ProcessModule)
             .with_global(crate::modules::process::init)
-            .with_module(NavigatorModule)
             .with_global(crate::modules::navigator::init)
             .with_module(UrlModule)
-            .with_module(PerformanceModule)
             .with_global(crate::modules::performance::init)
             .with_global(crate::modules::http::init)
             .with_global(crate::modules::exceptions::init)

--- a/llrt_core/src/modules/navigator.rs
+++ b/llrt_core/src/modules/navigator.rs
@@ -1,11 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use rquickjs::{
-    module::{Declarations, Exports, ModuleDef},
-    Ctx, Object, Result, Value,
-};
-
-use crate::{module_builder::ModuleInfo, modules::module::export_default};
+use rquickjs::{Ctx, Object, Result};
 
 use crate::VERSION;
 
@@ -23,40 +18,4 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     globals.set("navigator", navigator)?;
 
     Ok(())
-}
-
-pub struct NavigatorModule;
-
-impl ModuleDef for NavigatorModule {
-    fn declare(declare: &Declarations) -> Result<()> {
-        declare.declare("userAgent")?;
-        declare.declare("default")?;
-        Ok(())
-    }
-
-    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
-        let globals = ctx.globals();
-        let navigator: Object = globals.get("navigator")?;
-
-        export_default(ctx, exports, |default| {
-            for name in navigator.keys::<String>() {
-                let name = name?;
-                let value: Value = navigator.get(&name)?;
-                default.set(name, value)?;
-            }
-
-            Ok(())
-        })?;
-
-        Ok(())
-    }
-}
-
-impl From<NavigatorModule> for ModuleInfo<NavigatorModule> {
-    fn from(val: NavigatorModule) -> Self {
-        ModuleInfo {
-            name: "navigator",
-            module: val,
-        }
-    }
 }

--- a/llrt_core/src/modules/performance.rs
+++ b/llrt_core/src/modules/performance.rs
@@ -2,14 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::sync::atomic::Ordering;
 
-use rquickjs::{
-    atom::PredefinedAtom,
-    module::{Declarations, Exports, ModuleDef},
-    prelude::Func,
-    Ctx, Object, Result, Value,
-};
-
-use crate::{module_builder::ModuleInfo, modules::module::export_default};
+use rquickjs::{atom::PredefinedAtom, prelude::Func, Ctx, Object, Result};
 
 use chrono::Utc;
 
@@ -48,42 +41,4 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     globals.set("performance", performance)?;
 
     Ok(())
-}
-
-pub struct PerformanceModule;
-
-impl ModuleDef for PerformanceModule {
-    fn declare(declare: &Declarations) -> Result<()> {
-        declare.declare("timeOrigin")?;
-        declare.declare("now")?;
-        declare.declare("toJSON")?;
-        declare.declare("default")?;
-        Ok(())
-    }
-
-    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
-        let globals = ctx.globals();
-        let performance: Object = globals.get("performance")?;
-
-        export_default(ctx, exports, |default| {
-            for name in performance.keys::<String>() {
-                let name = name?;
-                let value: Value = performance.get(&name)?;
-                default.set(name, value)?;
-            }
-
-            Ok(())
-        })?;
-
-        Ok(())
-    }
-}
-
-impl From<PerformanceModule> for ModuleInfo<PerformanceModule> {
-    fn from(val: PerformanceModule) -> Self {
-        ModuleInfo {
-            name: "performance",
-            module: val,
-        }
-    }
 }

--- a/tests/unit/navigator.test.ts
+++ b/tests/unit/navigator.test.ts
@@ -1,12 +1,5 @@
-import defaultImport from "navigator";
-import * as namedImport from "navigator";
-
 describe("navigator.userAgent", () => {
-  it("should have a navigator userAgent", () => {
-    expect(defaultImport.userAgent).toEqual(navigator.userAgent);
-    expect(namedImport.userAgent).toEqual(navigator.userAgent);
-  });
-  it("should start with \"llrt \"", () => {
+  it('should start with "llrt "', () => {
     expect(navigator.userAgent.startsWith("llrt ")).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Description of changes

Currently, the following functions are provided as modules in LLRT.

- Performance
- Navigator

This is a module that is not compatible with node.js (or has a name that does not exist) and should stop being offered as a module before it is misused.

In fact, the following code will result in a `MODULE_NOT_FOUND` error in node.js.

```shell
% node -e "const a = require('navigator');"  
node:internal/modules/cjs/loader:1148
  throw err;
  ^

Error: Cannot find module 'navigator'
Require stack:
- /Users/shinya/Workspaces/llrt-test/[eval]
    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
    at Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
    at [eval]:1:11
    at runScriptInThisContext (node:internal/vm:209:10)
    at node:internal/process/execution:118:14
    at [eval]-wrapper:6:24
    at runScript (node:internal/process/execution:101:62)
    at evalScript (node:internal/process/execution:133:3) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/shinya/Workspaces/llrt-test/[eval]' ]
}

Node.js v20.13.1
```

In addition, it is necessary to continue to provide these functions from globalThis.
```shell
% ./llrt -e "console.log(globalThis.navigator.userAgent);"
llrt 0.1.15-beta
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
