### PR TITLE
perf: replacement of @smithy/abort-controller

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -147,6 +147,7 @@ const REPLACEMENT_PACKAGES = {
   "@aws-crypto/sha256-browser": "shims/aws-crypto-sha256.js",
   "@aws-crypto/crc32": "shims/aws-crypto-crc32.js",
   "@aws-crypto/crc32c": "shims/aws-crypto-crc32c.js",
+  "@smithy/abort-controller": "shims/smithy-abort-controller.js",
 };
 
 const SERVICE_ENDPOINT_BY_PACKAGE = {};

--- a/shims/smithy-abort-controller.js
+++ b/shims/smithy-abort-controller.js
@@ -1,0 +1,2 @@
+// @smithy/abort-controller
+// Since a global object already exists, this module is not required.


### PR DESCRIPTION
### Description of changes

Many `@aws-sdk` packages directly or indirectly depend on `@smithy/abort-controller`.
But if you check the implementation of `@smithy/abort-controller`, `AbortController` and `AbortSignal` are just defined.

https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-abort-controller/
https://github.com/smithy-lang/smithy-typescript/tree/main/packages/abort-controller/src

LLRT already provides these classes as native objects of Rust, so there is no need for them.
This PR replaces the `@smithy/abort-controller` import statement with an empty javascript file so that the native implementation can be used.
We also believe that replacing with native implementation will lead to some performance improvement.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
