### PR TITLE
minor URL & URLSearchParams adjustments

### DIFF
--- a/llrt_core/src/modules/http/url.rs
+++ b/llrt_core/src/modules/http/url.rs
@@ -1,15 +1,13 @@
-use std::{path::PathBuf, str::FromStr};
-
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 use super::url_search_params::URLSearchParams;
 use crate::utils::result::ResultExt;
-use rquickjs::atom::PredefinedAtom;
-use rquickjs::class::Trace;
-use rquickjs::function::Opt;
-use rquickjs::{Class, Coerced, Ctx, Exception, FromJs, IntoJs, Null, Object, Result, Value};
-use std::cell::RefCell;
-use std::rc::Rc;
+use rquickjs::{
+    atom::PredefinedAtom, class::Trace, function::Opt, Class, Coerced, Ctx, Exception, FromJs,
+    IntoJs, Null, Object, Result, Value,
+};
+use std::{cell::RefCell, path::PathBuf, rc::Rc, str::FromStr};
 use url::{quirks, Url};
 
 /// Naively checks for hostname delimiter, a colon ":", that's *probably* not


### PR DESCRIPTION
### Description of changes

Minor adjustments to URL and URLSearchparams.

`delete` and `has` methods are no longer cloning, checking for `undefined` and converting to string for each iteration. Some shared conversion logic is moved into a function

`from_str` only adds a "?" if not already there.

@stephencroberts please verify

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
