### PR TITLE
fix: rename hex module to @llrt/hex

### DIFF
--- a/API.md
+++ b/API.md
@@ -108,7 +108,7 @@ Available globally
 
 [writeFile](https://nodejs.org/api/fs.html#fspromiseswritefilefile-data-options)
 
-## hex
+## @llrt/hex
 
 ```typescript
 export function encode(

--- a/build.mjs
+++ b/build.mjs
@@ -56,7 +56,7 @@ const ES_BUILD_OPTIONS = {
     "node:console",
     "crypto",
     "uuid",
-    "hex",
+    "@llrt/hex",
     "os",
     "fs",
     "child_process",

--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -7,6 +7,7 @@ use crate::modules::{
     crypto::CryptoModule,
     events::EventsModule,
     fs::{FsModule, FsPromisesModule},
+    llrt::hex::LlrtHexModule,
     module::ModuleModule,
     net::NetModule,
     os::OsModule,
@@ -92,6 +93,7 @@ impl Default for ModuleBuilder {
             .with_global(crate::modules::performance::init)
             .with_global(crate::modules::http::init)
             .with_global(crate::modules::exceptions::init)
+            .with_module(LlrtHexModule)
     }
 }
 

--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -5,7 +5,6 @@ use crate::modules::{
     child_process::ChildProcessModule,
     console::ConsoleModule,
     crypto::CryptoModule,
-    encoding::HexModule,
     events::EventsModule,
     fs::{FsModule, FsPromisesModule},
     module::ModuleModule,
@@ -67,7 +66,6 @@ impl Default for ModuleBuilder {
         Self::new()
             .with_module(CryptoModule)
             .with_global(crate::modules::crypto::init)
-            .with_module(HexModule)
             .with_global(crate::modules::encoding::init)
             .with_module(FsPromisesModule)
             .with_module(FsModule)

--- a/llrt_core/src/modules/encoding/mod.rs
+++ b/llrt_core/src/modules/encoding/mod.rs
@@ -6,68 +6,13 @@ pub mod encoder {
 pub mod text_decoder;
 pub mod text_encoder;
 
-use rquickjs::{
-    module::{Declarations, Exports, ModuleDef},
-    prelude::Func,
-    Class, Ctx, Result, Value,
-};
+use rquickjs::{prelude::Func, Class, Ctx, Result};
 
-use crate::{
-    module_builder::ModuleInfo,
-    modules::module::export_default,
-    utils::{
-        object::{bytes_to_typed_array, get_bytes},
-        result::ResultExt,
-    },
-};
+use crate::utils::result::ResultExt;
 
-use self::encoder::{bytes_from_b64, bytes_from_hex, bytes_to_b64_string, bytes_to_hex_string};
+use self::encoder::{bytes_from_b64, bytes_to_b64_string};
 use self::text_decoder::TextDecoder;
 use self::text_encoder::TextEncoder;
-
-pub struct HexModule;
-
-impl HexModule {
-    pub fn encode<'js>(ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let bytes = get_bytes(&ctx, buffer)?;
-        Ok(bytes_to_hex_string(&bytes))
-    }
-
-    pub fn decode(ctx: Ctx, encoded: String) -> Result<Value> {
-        let bytes = bytes_from_hex(encoded.as_bytes())
-            .or_throw_msg(&ctx, "Cannot decode unrecognized sequence")?;
-
-        bytes_to_typed_array(ctx, &bytes)
-    }
-}
-
-impl ModuleDef for HexModule {
-    fn declare(declare: &Declarations) -> Result<()> {
-        declare.declare(stringify!(encode))?;
-        declare.declare(stringify!(decode))?;
-        declare.declare("default")?;
-        Ok(())
-    }
-
-    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
-        export_default(ctx, exports, |default| {
-            default.set(stringify!(encode), Func::from(Self::encode))?;
-            default.set(stringify!(decode), Func::from(Self::decode))?;
-            Ok(())
-        })?;
-
-        Ok(())
-    }
-}
-
-impl From<HexModule> for ModuleInfo<HexModule> {
-    fn from(val: HexModule) -> Self {
-        ModuleInfo {
-            name: "hex",
-            module: val,
-        }
-    }
-}
 
 pub fn atob(ctx: Ctx<'_>, encoded_value: String) -> Result<String> {
     let vec = bytes_from_b64(encoded_value.as_bytes()).or_throw(&ctx)?;

--- a/llrt_core/src/modules/llrt/hex.rs
+++ b/llrt_core/src/modules/llrt/hex.rs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+pub mod encoder {
+    pub use llrt_utils::encoding::*;
+}
+
+use rquickjs::{
+    module::{Declarations, Exports, ModuleDef},
+    prelude::Func,
+    Ctx, Result, Value,
+};
+
+use crate::{
+    module_builder::ModuleInfo,
+    modules::module::export_default,
+    utils::{
+        object::{bytes_to_typed_array, get_bytes},
+        result::ResultExt,
+    },
+};
+
+use self::encoder::{bytes_from_hex, bytes_to_hex_string};
+
+pub struct LlrtHexModule;
+
+impl LlrtHexModule {
+    pub fn encode<'js>(ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
+        let bytes = get_bytes(&ctx, buffer)?;
+        Ok(bytes_to_hex_string(&bytes))
+    }
+
+    pub fn decode(ctx: Ctx, encoded: String) -> Result<Value> {
+        let bytes = bytes_from_hex(encoded.as_bytes())
+            .or_throw_msg(&ctx, "Cannot decode unrecognized sequence")?;
+
+        bytes_to_typed_array(ctx, &bytes)
+    }
+}
+
+impl ModuleDef for LlrtHexModule {
+    fn declare(declare: &Declarations) -> Result<()> {
+        declare.declare(stringify!(encode))?;
+        declare.declare(stringify!(decode))?;
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        export_default(ctx, exports, |default| {
+            default.set(stringify!(encode), Func::from(Self::encode))?;
+            default.set(stringify!(decode), Func::from(Self::decode))?;
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}
+
+impl From<LlrtHexModule> for ModuleInfo<LlrtHexModule> {
+    fn from(val: LlrtHexModule) -> Self {
+        ModuleInfo {
+            name: "@llrt/hex",
+            module: val,
+        }
+    }
+}

--- a/llrt_core/src/modules/llrt/mod.rs
+++ b/llrt_core/src/modules/llrt/mod.rs
@@ -1,0 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+pub mod hex;

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -7,6 +7,7 @@ pub mod encoding;
 pub mod events;
 pub mod exceptions;
 pub mod http;
+pub mod llrt;
 pub mod module;
 pub mod navigator;
 pub mod net;

--- a/shims/util-hex-encoding.js
+++ b/shims/util-hex-encoding.js
@@ -1,4 +1,4 @@
-import { encode, decode } from "hex";
+import { encode, decode } from "@llrt/hex";
 
 export const fromHex = decode;
 export const toHex = encode;

--- a/tests/unit/encoding.test.ts
+++ b/tests/unit/encoding.test.ts
@@ -1,19 +1,10 @@
-import hex from "hex";
-
-describe("hex", () => {
+describe("TextEncoder/TextDecoder", () => {
   it("should encode/decode text", () => {
     let hello = "hello";
     const encoded = new TextEncoder().encode(hello);
     const decoded = new TextDecoder().decode(encoded);
 
     expect(decoded).toEqual(hello);
-  });
-
-  it("should encode/decode hex", () => {
-    const byteArray = new TextEncoder().encode("hello");
-    const encoded = hex.encode(byteArray);
-
-    expect(encoded).toEqual("68656c6c6f");
   });
 });
 

--- a/tests/unit/encoding.test.ts
+++ b/tests/unit/encoding.test.ts
@@ -1,10 +1,19 @@
-describe("TextEncoder/TextDecoder", () => {
+import hex from "@llrt/hex";
+
+describe("@llrt/hex", () => {
   it("should encode/decode text", () => {
     let hello = "hello";
     const encoded = new TextEncoder().encode(hello);
     const decoded = new TextDecoder().decode(encoded);
 
     expect(decoded).toEqual(hello);
+  });
+
+  it("should encode/decode hex", () => {
+    const byteArray = new TextEncoder().encode("hello");
+    const encoded = hex.encode(byteArray);
+
+    expect(encoded).toEqual("68656c6c6f");
   });
 });
 


### PR DESCRIPTION
### Description of changes

While reviewing the module implementation, I noticed that a `hex` module is provided that does not exist in the standard node.js API.

```shell
% node -e "const a = require('hex');"
node:internal/modules/cjs/loader:1148
  throw err;
  ^

Error: Cannot find module 'hex'
Require stack:
- /Users/shinya/Workspaces/llrt-test/[eval]
    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
    at Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
    at [eval]:1:11
    at runScriptInThisContext (node:internal/vm:209:10)
    at node:internal/process/execution:118:14
    at [eval]-wrapper:6:24
    at runScript (node:internal/process/execution:101:62)
    at evalScript (node:internal/process/execution:133:3) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/shinya/Workspaces/llrt-test/[eval]' ]
}

Node.js v20.13.1
```

There is a `hex` module in the npm package, but it exists for a completely different purpose.
https://www.npmjs.com/package/hex

~~Therefore, we felt that we should stop publishing the `hex` module within LLRT.~~
Avoid conflicts by renaming the `hex` module to `@llrt/hex`.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
