### PR TITLE
Add SIMD flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171aca76a3199e771ea0b94ec260984ed9cba62af8e478142974dbaa594d583b"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bytesize",
  "cargo-platform",
  "cargo-util",
@@ -1761,7 +1767,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f01c2bf7b989c679695ef635fc7d9e80072e08101be4b53193c8e8b649900102"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bstr",
  "curl",
  "gix-command",
@@ -2499,7 +2505,9 @@ dependencies = [
 name = "llrt_utils"
 version = "0.1.15-beta"
 dependencies = [
+ "base64 0.22.1",
  "base64-simd",
+ "hex",
  "hex-simd",
  "rquickjs",
  "tokio",
@@ -4448,7 +4456,7 @@ checksum = "ec874e1eef0df2dcac546057fe5e29186f09c378181cd7b635b4b7bcc98e9d81"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "deadpool",
  "futures",
  "http",

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -19,8 +19,8 @@ patches = ["patches/promise-poll.patch"]
 rquickjs-core = { path = "target/patch/rquickjs-core-0.6.2" }
 
 [dependencies]
-llrt_modules = { path = "../llrt_modules", features = ["all"] }
-llrt_utils = { path = "../llrt_utils", features = ["all"] }
+llrt_modules = { path = "../llrt_modules", features = ["all-simd"], default-features = false }
+llrt_utils = { path = "../llrt_utils", features = ["all-simd"], default-features = false }
 chrono = { version = "0.4.38", default-features = false, features = ["std"] }
 quick-xml = "0.35.0"
 crc32c = { version = "0.6.8" }

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -7,8 +7,10 @@ license-file = "LICENSE"
 [features]
 default = ["all"]
 all = ["buffer", "fs", "path"]
+all-simd = ["buffer-simd", "fs", "path"]
 
 buffer = ["llrt_utils/encoding"]
+buffer-simd = ["llrt_utils/encoding-simd"]
 fs = ["tokio/fs", "llrt_utils/fs", "ring", "buffer", "path"]
 path = []
 

--- a/llrt_modules/src/modules/mod.rs
+++ b/llrt_modules/src/modules/mod.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-#[cfg(feature = "buffer")]
+#[cfg(any(feature = "buffer", feature = "buffer-simd"))]
 pub mod buffer;
 #[cfg(feature = "fs")]
 pub mod fs;

--- a/llrt_utils/Cargo.toml
+++ b/llrt_utils/Cargo.toml
@@ -7,12 +7,16 @@ license-file = "LICENSE"
 [features]
 default = ["all"]
 all = ["fs", "encoding"]
+all-simd = ["fs", "encoding-simd"]
 
 fs = ["tokio/fs"]
-encoding = ["base64-simd", "hex-simd"]
+encoding = ["base64", "hex"]
+encoding-simd = ["base64-simd", "hex-simd"]
 
 [dependencies]
+base64 = { version = "0.22", optional = true }
 base64-simd = { version = "0.8.0", optional = true }
+hex = { version = "0.4", optional = true }
 hex-simd = { version = "0.8.0", optional = true }
 rquickjs = { version = "0.6.2", features = [
   "array-buffer",

--- a/llrt_utils/src/encoding.rs
+++ b/llrt_utils/src/encoding.rs
@@ -1,5 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(not(feature = "encoding-simd"))]
+use base64::{
+    alphabet,
+    engine::general_purpose::STANDARD,
+    engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
+    Engine,
+};
+#[cfg(feature = "encoding-simd")]
 use hex_simd::AsciiCase;
 
 macro_rules! encoder_enum {
@@ -86,28 +94,68 @@ impl Encoder {
     }
 }
 
+#[cfg(feature = "encoding-simd")]
 pub fn bytes_to_hex(bytes: &[u8]) -> Vec<u8> {
     hex_simd::encode_type(bytes, AsciiCase::Lower)
 }
 
+#[cfg(not(feature = "encoding-simd"))]
+pub fn bytes_to_hex(bytes: &[u8]) -> Vec<u8> {
+    hex::encode(bytes).into_bytes()
+}
+
+#[cfg(feature = "encoding-simd")]
 pub fn bytes_from_hex(hex_bytes: &[u8]) -> Result<Vec<u8>, String> {
     hex_simd::decode_to_vec(hex_bytes).map_err(|err| err.to_string())
 }
 
+#[cfg(not(feature = "encoding-simd"))]
+pub fn bytes_from_hex(hex_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    hex::decode(hex_bytes).map_err(|err| err.to_string())
+}
+
+#[cfg(feature = "encoding-simd")]
 pub fn bytes_to_b64_string(bytes: &[u8]) -> String {
     base64_simd::STANDARD.encode_to_string(bytes)
 }
 
+#[cfg(not(feature = "encoding-simd"))]
+pub fn bytes_to_b64_string(bytes: &[u8]) -> String {
+    STANDARD.encode(bytes)
+}
+
+#[cfg(feature = "encoding-simd")]
 pub fn bytes_from_b64(bytes: &[u8]) -> Result<Vec<u8>, String> {
     base64_simd::forgiving_decode_to_vec(bytes).map_err(|e| e.to_string())
 }
 
+#[cfg(not(feature = "encoding-simd"))]
+pub fn bytes_from_b64(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    const STANDARD_FORGIVING: GeneralPurpose = GeneralPurpose::new(
+        &alphabet::STANDARD,
+        GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent),
+    );
+    STANDARD_FORGIVING.decode(bytes).map_err(|e| e.to_string())
+}
+
+#[cfg(feature = "encoding-simd")]
 pub fn bytes_to_b64(bytes: &[u8]) -> Vec<u8> {
     base64_simd::STANDARD.encode_type(bytes)
 }
 
+#[cfg(not(feature = "encoding-simd"))]
+pub fn bytes_to_b64(bytes: &[u8]) -> Vec<u8> {
+    STANDARD.encode(bytes).into_bytes()
+}
+
+#[cfg(feature = "encoding-simd")]
 pub fn bytes_to_hex_string(bytes: &[u8]) -> String {
     hex_simd::encode_to_string(bytes, AsciiCase::Lower)
+}
+
+#[cfg(not(feature = "encoding-simd"))]
+pub fn bytes_to_hex_string(bytes: &[u8]) -> String {
+    hex::encode(bytes)
 }
 
 pub fn bytes_to_string(bytes: &[u8]) -> String {

--- a/llrt_utils/src/lib.rs
+++ b/llrt_utils/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 pub mod bytes;
-#[cfg(feature = "encoding")]
+#[cfg(any(feature = "encoding", feature = "encoding-simd"))]
 pub mod encoding;
 #[cfg(feature = "fs")]
 pub mod fs;


### PR DESCRIPTION
### Description of changes

- Started flagging SIMD dependencies, I know they have fallbacks but the language used in those crates makes me nervous (`The runtime detection will be skipped if the fastest implementation is already available at compile-time`)

If we agree this is a good idea, then I would add some CI checks to make sure we compile both variants.

If the feature system of rust was a bit better I could add only a `simd` feature, but there is currently no way to do that so I added `-simd` variants.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
