### PR TITLE
add support for extra ca certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,7 +2477,6 @@ dependencies = [
  "ryu",
  "simd-json",
  "socket2",
- "thiserror",
  "tokio",
  "tokio-context",
  "tokio-rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171aca76a3199e771ea0b94ec260984ed9cba62af8e478142974dbaa594d583b"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bytesize",
  "cargo-platform",
  "cargo-util",
@@ -1761,7 +1767,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f01c2bf7b989c679695ef635fc7d9e80072e08101be4b53193c8e8b649900102"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bstr",
  "curl",
  "gix-command",
@@ -2467,6 +2473,7 @@ dependencies = [
  "ring",
  "rquickjs",
  "rustls",
+ "rustls-pemfile",
  "ryu",
  "simd-json",
  "socket2",
@@ -3338,6 +3345,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3345,9 +3362,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4448,7 +4465,7 @@ checksum = "ec874e1eef0df2dcac546057fe5e29186f09c378181cd7b635b4b7bcc98e9d81"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,6 +2477,7 @@ dependencies = [
  "ryu",
  "simd-json",
  "socket2",
+ "thiserror",
  "tokio",
  "tokio-context",
  "tokio-rustls",
@@ -3743,18 +3744,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",

--- a/README.md
+++ b/README.md
@@ -362,6 +362,11 @@ Then run llrt:
 
     make run
 
+## Environment Variables
+
+### `LLRT_EXTRA_CA_CERTS=file`
+Load extra certificate authorities from a PEM encoded file
+
 ## Benchmark Methodology
 
 Although Init Duration [reported by Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) is commonly used to understand cold start impact on overall request latency, this metric does not include the time needed to copy code into the Lambda sandbox.

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -85,6 +85,7 @@ flate2 = { version = "1.0.30", features = [
 ], default-features = false }
 brotlic = "0.8.2"
 encoding_rs = "0.8.34"
+rustls-pemfile = "2.1.2"
 
 [build-dependencies]
 rquickjs = { version = "0.6.2", features = [

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -86,7 +86,6 @@ flate2 = { version = "1.0.30", features = [
 brotlic = "0.8.2"
 encoding_rs = "0.8.34"
 rustls-pemfile = "2.1.2"
-thiserror = "1.0.62"
 
 [build-dependencies]
 rquickjs = { version = "0.6.2", features = [

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -86,6 +86,7 @@ flate2 = { version = "1.0.30", features = [
 brotlic = "0.8.2"
 encoding_rs = "0.8.34"
 rustls-pemfile = "2.1.2"
+thiserror = "1.0.62"
 
 [build-dependencies]
 rquickjs = { version = "0.6.2", features = [

--- a/llrt_core/src/environment.rs
+++ b/llrt_core/src/environment.rs
@@ -4,6 +4,7 @@ pub const ENV_LLRT_NET_DENY: &str = "LLRT_NET_DENY";
 pub const ENV_LLRT_NET_POOL_IDLE_TIMEOUT: &str = "LLRT_NET_POOL_IDLE_TIMEOUT";
 pub const ENV_LLRT_HTTP_VERSION: &str = "LLRT_HTTP_VERSION";
 pub const ENV_LLRT_TLS_VERSION: &str = "LLRT_TLS_VERSION";
+pub const ENV_LLRT_EXTRA_CA_CERTS: &str = "LLRT_EXTRA_CA_CERTS";
 
 //log
 pub const ENV_LLRT_LOG: &str = "LLRT_LOG";

--- a/llrt_core/src/modules/http/fetch.rs
+++ b/llrt_core/src/modules/http/fetch.rs
@@ -52,7 +52,7 @@ pub(crate) fn init(ctx: &Ctx<'_>, globals: &Object) -> Result<()> {
     }
 
     //init eagerly
-    let client = &*HTTP_CLIENT;
+    let client = HTTP_CLIENT.as_ref().or_throw(ctx)?;
 
     globals.set(
         "fetch",

--- a/llrt_core/src/modules/net/mod.rs
+++ b/llrt_core/src/modules/net/mod.rs
@@ -68,11 +68,17 @@ pub static TLS_CONFIG: Lazy<ClientConfig> = Lazy::new(|| {
     }
 
     if let Ok(extra_ca_certs) = env::var(environment::ENV_LLRT_EXTRA_CA_CERTS) {
-        if let Ok(file) = File::open(extra_ca_certs) {
-            let mut reader = BufReader::new(file);
-            root_certificates.add_parsable_certificates(
-                rustls_pemfile::certs(&mut reader).filter_map(std::io::Result::ok),
-            );
+        match File::open(&extra_ca_certs) {
+            Ok(file) => {
+                let mut reader = BufReader::new(file);
+                root_certificates.add_parsable_certificates(
+                    rustls_pemfile::certs(&mut reader).filter_map(std::io::Result::ok),
+                );
+            },
+            _ => warn!(
+                r#"Ignoring extra certs from "{}", load failed"#,
+                extra_ca_certs
+            ),
         }
     }
 

--- a/llrt_core/src/modules/net/mod.rs
+++ b/llrt_core/src/modules/net/mod.rs
@@ -67,7 +67,7 @@ pub static TLS_CONFIG: Lazy<ClientConfig> = Lazy::new(|| {
         root_certificates.roots.push(cert)
     }
 
-    if let Ok(extra_ca_certs) = env::var(environment::ENV_LLRT_EXTRA_CA_CERTS).as_deref() {
+    if let Ok(extra_ca_certs) = env::var(environment::ENV_LLRT_EXTRA_CA_CERTS) {
         if let Ok(file) = File::open(extra_ca_certs) {
             let mut reader = BufReader::new(file);
             root_certificates.add_parsable_certificates(

--- a/llrt_core/src/runtime_client.rs
+++ b/llrt_core/src/runtime_client.rs
@@ -220,7 +220,7 @@ async fn start_with_cfg(ctx: &Ctx<'_>, config: RuntimeConfig) -> Result<()> {
         ));
     }
 
-    let client = (*HTTP_CLIENT).clone();
+    let client = HTTP_CLIENT.as_ref().or_throw(ctx)?.clone();
 
     let base_url = ["http://", &config.runtime_api, "/", ENV_RUNTIME_PATH].concat();
     let handler = handler.as_function().unwrap();


### PR DESCRIPTION
### Issue #
#469 

### Description of changes

Adds support for extra CA certificates, mirroring the NODE_EXTRA_CA_CERTS functionality in Node.js. This is utilizing the rustls-pemfile crate for PEM file parsing.

The environment variable `LLRT_EXTRA_CA_CERTS` is used to configure the path to the extra certificates file.

I didn't see any relevant tests for this module. I'm happy to add them if required.

<!-- **Please explain what your changes does** -->

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
