### PR TITLE
Export constants on sync fs API

### DIFF
--- a/llrt_modules/src/modules/fs/mod.rs
+++ b/llrt_modules/src/modules/fs/mod.rs
@@ -96,6 +96,7 @@ impl ModuleDef for FsModule {
         declare.declare("rmSync")?;
         declare.declare("statSync")?;
         declare.declare("writeFileSync")?;
+        declare.declare("constants")?;
 
         declare.declare("default")?;
 
@@ -109,6 +110,7 @@ impl ModuleDef for FsModule {
         export_default(ctx, exports, |default| {
             let promises = Object::new(ctx.clone())?;
             export_promises(ctx, &promises)?;
+            export_constants(ctx, default)?;
 
             default.set("promises", promises)?;
             default.set("accessSync", Func::from(access_sync))?;
@@ -127,11 +129,7 @@ impl ModuleDef for FsModule {
 }
 
 fn export_promises<'js>(ctx: &Ctx<'js>, exports: &Object<'js>) -> Result<()> {
-    let constants = Object::new(ctx.clone())?;
-    constants.set("F_OK", CONSTANT_F_OK)?;
-    constants.set("R_OK", CONSTANT_R_OK)?;
-    constants.set("W_OK", CONSTANT_W_OK)?;
-    constants.set("X_OK", CONSTANT_X_OK)?;
+    export_constants(ctx, exports)?;
 
     exports.set("readdir", Func::from(Async(read_dir)))?;
     exports.set("readFile", Func::from(Async(read_file)))?;
@@ -142,6 +140,16 @@ fn export_promises<'js>(ctx: &Ctx<'js>, exports: &Object<'js>) -> Result<()> {
     exports.set("rm", Func::from(Async(rmfile)))?;
     exports.set("stat", Func::from(Async(stat_fn)))?;
     exports.set("access", Func::from(Async(access)))?;
+
+    Ok(())
+}
+
+fn export_constants<'js>(ctx: &Ctx<'js>, exports: &Object<'js>) -> Result<()> {
+    let constants = Object::new(ctx.clone())?;
+    constants.set("F_OK", CONSTANT_F_OK)?;
+    constants.set("R_OK", CONSTANT_R_OK)?;
+    constants.set("W_OK", CONSTANT_W_OK)?;
+    constants.set("X_OK", CONSTANT_X_OK)?;
 
     exports.set("constants", constants)?;
 


### PR DESCRIPTION
### Description of changes

-  Also exporting constants on the sync fs API

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
