### PR TITLE
fix: rename uuid module to llrt:uuid

### DIFF
--- a/API.md
+++ b/API.md
@@ -257,7 +257,28 @@ URLSearchParams.sort(): void;
 
 [TextEncoder](https://nodejs.org/api/util.html#class-utiltextdecoder)
 
-## uuid
+## net
+
+> [!WARNING]
+> These APIs uses native streams that is not 100% compatible with the Node.js Streams API. Server APIs like `createSever` provides limited functionality useful for testing purposes. Serverless applications typically don't expose servers. Some server options are not supported:
+> `highWaterMark`, `pauseOnConnect`, `keepAlive`, `noDelay`, `keepAliveInitialDelay`
+
+[connect](https://nodejs.org/api/net.html#netconnect)
+
+[createConnection](https://nodejs.org/api/net.html#netcreateconnection)
+
+[createServer](https://nodejs.org/api/net.html#netcreateserveroptions-connectionlistener)
+
+## llrt:hex
+
+```typescript
+export function encode(
+  value: string | Array | ArrayBuffer | Uint8Array
+): string;
+export function decode(value: string): Uint8Array;
+```
+
+## llrt:uuid
 
 ```typescript
 export const NIL: string;
@@ -283,27 +304,6 @@ export function stringify(arr: Array | Uint8Array): string;
 export function validate(arr: string): boolean;
 
 export function version(arr: Array | Uint8Array): number;
-```
-
-## net
-
-> [!WARNING]
-> These APIs uses native streams that is not 100% compatible with the Node.js Streams API. Server APIs like `createSever` provides limited functionality useful for testing purposes. Serverless applications typically don't expose servers. Some server options are not supported:
-> `highWaterMark`, `pauseOnConnect`, `keepAlive`, `noDelay`, `keepAliveInitialDelay`
-
-[connect](https://nodejs.org/api/net.html#netconnect)
-
-[createConnection](https://nodejs.org/api/net.html#netcreateconnection)
-
-[createServer](https://nodejs.org/api/net.html#netcreateserveroptions-connectionlistener)
-
-## llrt:hex
-
-```typescript
-export function encode(
-  value: string | Array | ArrayBuffer | Uint8Array
-): string;
-export function decode(value: string): Uint8Array;
 ```
 
 ## llrt:xml

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ The test runner also has support for filters. Using filters is as simple as addi
 | fs            | ✔︎     | ✘⏱     |
 | path          | ✔︎     | ✔︎     |
 | timers        | ✔︎     | ✔︎     |
-| uuid          | ✔︎     | ✔︎     |
 | crypto        | ✔︎     | ✔︎     |
 | process       | ✔︎     | ✔︎     |
 | encoding      | ✔︎     | ✔︎     |
@@ -135,10 +134,19 @@ Since LLRT is meant for performance critical application it's not recommended to
 
 LLRT can work with any bundler of your choice. Below are some configurations for popular bundlers:
 
+> [!WARNING]
+> LLRT implements native modules that are largely compatible with the following external packages.
+> By implementing the following conversions in the bundler's alias function, your application may be faster, but we recommend that you test thoroughly as they are not fully compatible.
+
+| Node.js         | LLRT      |
+| --------------- | --------- |
+| fast-xml-parser | llrt:xml  | 
+| uuid            | llrt:uuid |
+
 ### ESBuild
 
 ```shell
-esbuild index.js --platform=node --target=es2020 --format=esm --bundle --minify --external:@aws-sdk --external:@smithy --external:uuid
+esbuild index.js --platform=node --target=es2020 --format=esm --bundle --minify --external:@aws-sdk --external:@smithy
 ```
 
 ### Rollup
@@ -157,7 +165,7 @@ export default {
     target: "es2020",
   },
   plugins: [resolve(), commonjs(), terser()],
-  external: ["@aws-sdk", "@smithy", "uuid"],
+  external: ["@aws-sdk", "@smithy"],
 };
 ```
 
@@ -179,7 +187,7 @@ export default {
   resolve: {
     extensions: [".js"],
   },
-  externals: [nodeExternals(), "@aws-sdk", "@smithy", "uuid"],
+  externals: [nodeExternals(), "@aws-sdk", "@smithy"],
   optimization: {
     minimize: true,
     minimizer: [

--- a/build.mjs
+++ b/build.mjs
@@ -55,8 +55,6 @@ const ES_BUILD_OPTIONS = {
     "console",
     "node:console",
     "crypto",
-    "uuid",
-    "llrt:hex",
     "os",
     "fs",
     "child_process",
@@ -66,10 +64,12 @@ const ES_BUILD_OPTIONS = {
     "path",
     "events",
     "buffer",
-    "llrt:xml",
     "net",
     "util",
     "url",
+    "llrt:hex",
+    "llrt:uuid",
+    "llrt:xml",
   ],
 };
 
@@ -584,8 +584,9 @@ async function buildSdks() {
       plugins: [AWS_SDK_PLUGIN, esbuildShimPlugin([[/^bowser$/]])],
       alias: {
         "@aws-sdk/util-utf8": "@aws-sdk/util-utf8-browser",
-        "fast-xml-parser": "llrt:xml",
         "@smithy/md5-js": "crypto",
+        "fast-xml-parser": "llrt:xml",
+        uuid: "llrt:uuid",
       },
       chunkNames: "llrt-[name]-sdk-[hash]",
       metafile: true,

--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -7,7 +7,7 @@ use crate::modules::{
     crypto::CryptoModule,
     events::EventsModule,
     fs::{FsModule, FsPromisesModule},
-    llrt::{hex::LlrtHexModule, xml::LlrtXmlModule},
+    llrt::{hex::LlrtHexModule, uuid::LlrtUuidModule, xml::LlrtXmlModule},
     module::ModuleModule,
     net::NetModule,
     os::OsModule,
@@ -16,7 +16,6 @@ use crate::modules::{
     timers::TimersModule,
     url::UrlModule,
     util::UtilModule,
-    uuid::UuidModule,
 };
 pub use llrt_modules::ModuleInfo;
 use rquickjs::{
@@ -83,7 +82,6 @@ impl Default for ModuleBuilder {
             .with_global(crate::modules::buffer::init)
             .with_module(ChildProcessModule)
             .with_module(UtilModule)
-            .with_module(UuidModule)
             .with_module(ProcessModule)
             .with_global(crate::modules::process::init)
             .with_global(crate::modules::navigator::init)
@@ -92,6 +90,7 @@ impl Default for ModuleBuilder {
             .with_global(crate::modules::http::init)
             .with_global(crate::modules::exceptions::init)
             .with_module(LlrtHexModule)
+            .with_module(LlrtUuidModule)
             .with_module(LlrtXmlModule)
     }
 }

--- a/llrt_core/src/modules/crypto/mod.rs
+++ b/llrt_core/src/modules/crypto/mod.rs
@@ -21,8 +21,8 @@ use crate::{
     modules::{
         buffer::Buffer,
         encoding::encoder::{bytes_to_b64_string, bytes_to_hex_string},
+        llrt::uuid::uuidv4,
         module::export_default,
-        uuid::uuidv4,
     },
     utils::{
         class::get_class_name,

--- a/llrt_core/src/modules/llrt/mod.rs
+++ b/llrt_core/src/modules/llrt/mod.rs
@@ -1,4 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 pub mod hex;
+pub mod uuid;
 pub mod xml;

--- a/llrt_core/src/modules/llrt/uuid.rs
+++ b/llrt_core/src/modules/llrt/uuid.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 
-pub struct UuidModule;
+pub struct LlrtUuidModule;
 
 static ERROR_MESSAGE: &str = "Not a valid UUID";
 
@@ -92,7 +92,7 @@ fn version(ctx: Ctx<'_>, value: String) -> Result<u8> {
     Ok(uuid.get_version().map(|v| v as u8).unwrap_or(0))
 }
 
-impl ModuleDef for UuidModule {
+impl ModuleDef for LlrtUuidModule {
     fn declare(declare: &Declarations) -> Result<()> {
         declare.declare("v1")?;
         declare.declare("v3")?;
@@ -138,10 +138,10 @@ impl ModuleDef for UuidModule {
     }
 }
 
-impl From<UuidModule> for ModuleInfo<UuidModule> {
-    fn from(val: UuidModule) -> Self {
+impl From<LlrtUuidModule> for ModuleInfo<LlrtUuidModule> {
+    fn from(val: LlrtUuidModule) -> Self {
         ModuleInfo {
-            name: "uuid",
+            name: "llrt:uuid",
             module: val,
         }
     }

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -17,4 +17,3 @@ pub mod process;
 pub mod timers;
 pub mod url;
 pub mod util;
-pub mod uuid;

--- a/llrt_core/src/runtime_client.rs
+++ b/llrt_core/src/runtime_client.rs
@@ -558,7 +558,7 @@ mod tests {
     use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
 
     use crate::{
-        modules::uuid::uuidv4,
+        modules::llrt::uuid::uuidv4,
         runtime_client::{
             self, RuntimeConfig, ENV_RUNTIME_PATH, HEADER_INVOKED_FUNCTION_ARN, HEADER_REQUEST_ID,
         },

--- a/tests/unit/uuid.test.ts
+++ b/tests/unit/uuid.test.ts
@@ -9,7 +9,7 @@ import {
   validate,
   NIL,
   version,
-} from "uuid";
+} from "llrt:uuid";
 
 const UUID_PATTERN =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;


### PR DESCRIPTION
### Issue # (if available)

Fixed #472 

### Description of changes

The `uuid` module implemented as a native module in LLRT is intended to speed up the bundled SDK in LLRT. At this time, it is not fully compatible with the `uuid` in the node.js package.

This PR is a renaming so that it can provide functionality in its own namespace.

In addition, we have decided to include information on alias in the README so that you can understand it and use it in your own applications.

I am not confident in the writing of the README because I am not a resident of an English-speaking country. I would appreciate it if someone could correct me. :)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
