### PR TITLE
Windows support for modules + move os 

### DIFF
--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -1,0 +1,30 @@
+name: Setup, Build & Test modules
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      platform:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Run tests
+        run: |
+          cargo test -p llrt_modules
+     

--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable # Modules should work on stable, not just nightly
       - name: Run tests
         run: |
           cargo test -p llrt_modules
-     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,24 @@ jobs:
       os: ${{ matrix.os }}
       platform: ${{ matrix.platform }}
       arch: ${{ matrix.arch }}
+  modules:
+    needs:
+      - check
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            arch: x86_64
+          - os: macos-latest
+            platform: darwin
+            arch: x86_64
+          - os: windows-latest
+            platform: windows
+            arch: x86_64
+    uses: ./.github/workflows/build-modules.yml
+    with:
+      os: ${{ matrix.os }}
+      platform: ${{ matrix.platform }}
+      arch: ${{ matrix.arch }}
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "dlopen"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2115,6 +2126,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,12 +2251,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "bd69211b9b519e98303c015e21a007e293db403b6c85b9b124e133d25e242cdd"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -2416,6 +2547,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "llrt"
@@ -3328,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "once_cell",
  "ring",
@@ -3638,6 +3775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,6 +3837,17 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3788,6 +3942,16 @@ checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -3985,12 +4149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4043,14 +4201,26 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -4508,6 +4678,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,10 +4734,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2472,7 +2472,6 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-core",
- "uname",
  "url",
  "uuid",
  "uuid-simd",
@@ -2494,6 +2493,9 @@ dependencies = [
  "ring",
  "rquickjs",
  "tokio",
+ "windows-registry",
+ "windows-result",
+ "windows-version",
 ]
 
 [[package]]
@@ -2791,7 +2793,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3983,15 +3985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4300,7 +4293,37 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4318,7 +4341,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4338,18 +4361,27 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4360,9 +4392,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4372,9 +4404,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4384,15 +4416,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4402,9 +4434,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4414,9 +4446,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4426,9 +4458,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4438,9 +4470,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,7 @@ dependencies = [
  "libc",
  "llrt_utils",
  "nanoid",
+ "once_cell",
  "ring",
  "rquickjs",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -461,13 +461,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.101"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -519,18 +518,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -862,7 +861,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1135,7 +1134,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2004,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -2240,7 +2239,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2293,12 +2292,12 @@ dependencies = [
 
 [[package]]
 name = "imara-diff"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
+checksum = "af13c8ceb376860ff0c6a66d83a8cdd4ecd9e464da24621bbffcd02b49619434"
 dependencies = [
  "ahash",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2657,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "maybe-async"
@@ -2669,7 +2668,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2808,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -2823,9 +2822,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opener"
@@ -2928,7 +2927,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3041,7 +3040,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3279,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3303,7 +3302,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3411,7 +3410,7 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "rquickjs-core",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3559,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -3578,13 +3577,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3598,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -3830,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
@@ -3847,7 +3846,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3893,22 +3892,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3966,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3981,9 +3980,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4015,7 +4014,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4123,7 +4122,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4355,7 +4354,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -4377,7 +4376,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4709,28 +4708,28 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4750,7 +4749,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
  "synstructure",
 ]
 
@@ -4779,7 +4778,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4793,18 +4792,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.11+zstd.1.5.6"
+version = "2.0.12+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2487,6 +2487,7 @@ name = "llrt_modules"
 version = "0.1.15-beta"
 dependencies = [
  "either",
+ "libc",
  "llrt_utils",
  "nanoid",
  "ring",

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -79,7 +79,6 @@ tokio-rustls = { version = "0.26.0", features = [
 ], default-features = false }
 ring = "0.17.8"
 rand = "0.8.5"
-uname = "0.1.1"
 flate2 = { version = "1.0.30", features = [
     "zlib-ng",
 ], default-features = false }

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -1,4 +1,4 @@
-pub use llrt_modules::{buffer, fs, path};
+pub use llrt_modules::{buffer, fs, os, path};
 
 pub mod child_process;
 pub mod console;
@@ -11,7 +11,6 @@ pub mod llrt;
 pub mod module;
 pub mod navigator;
 pub mod net;
-pub mod os;
 pub mod performance;
 pub mod process;
 pub mod timers;

--- a/llrt_core/src/modules/process.rs
+++ b/llrt_core/src/modules/process.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{collections::HashMap, env, sync::atomic::Ordering};
 
+use llrt_modules::process::get_platform;
 use rquickjs::{
     atom::PredefinedAtom,
     convert::Coerced,
@@ -34,15 +35,6 @@ pub fn get_arch() -> &'static str {
     }
 
     arch
-}
-
-pub fn get_platform() -> &'static str {
-    let platform = env::consts::OS;
-    match platform {
-        "macos" => "darwin",
-        "windows" => "win32",
-        _ => platform,
-    }
 }
 
 fn hr_time_big_int(ctx: Ctx<'_>) -> Result<BigInt> {

--- a/llrt_core/src/modules/process.rs
+++ b/llrt_core/src/modules/process.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{collections::HashMap, env, sync::atomic::Ordering};
 
-use llrt_modules::process::get_platform;
+pub use llrt_modules::process::get_platform;
 use rquickjs::{
     atom::PredefinedAtom,
     convert::Coerced,

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -6,11 +6,18 @@ license-file = "LICENSE"
 
 [features]
 default = ["all"]
-all = ["buffer", "fs", "os", "path"]
+all = ["buffer", "fs", "os", "path", "process"]
 
 buffer = ["llrt_utils/encoding"]
 fs = ["tokio/fs", "llrt_utils/fs", "ring", "buffer", "path"]
-os = ["process", "libc", "once_cell"]
+os = [
+  "process",
+  "libc",
+  "windows-result",
+  "windows-registry",
+  "windows-version",
+  "once_cell",
+]
 path = []
 process = []
 
@@ -28,6 +35,11 @@ tokio = { version = "1", features = ["rt", "io-util"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-registry = { version = "0.2", optional = true }
+windows-result = { version = "0.2", optional = true }
+windows-version = { version = "0.1", optional = true }
 
 [dev-dependencies]
 nanoid = "0.4.0"

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -10,11 +10,13 @@ all = ["buffer", "fs", "os", "path"]
 
 buffer = ["llrt_utils/encoding"]
 fs = ["tokio/fs", "llrt_utils/fs", "ring", "buffer", "path"]
-os = ["libc"]
+os = ["process", "libc", "once_cell"]
 path = []
+process = []
 
 [dependencies]
 either = "1"
+once_cell = { version = "1", optional = true }
 llrt_utils = { path = "../llrt_utils", default-features = false }
 rquickjs = { version = "0.6", features = [
   "either",

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -6,10 +6,11 @@ license-file = "LICENSE"
 
 [features]
 default = ["all"]
-all = ["buffer", "fs", "path"]
+all = ["buffer", "fs", "os", "path"]
 
 buffer = ["llrt_utils/encoding"]
 fs = ["tokio/fs", "llrt_utils/fs", "ring", "buffer", "path"]
+os = ["libc"]
 path = []
 
 [dependencies]
@@ -22,6 +23,9 @@ rquickjs = { version = "0.6", features = [
 ], default-features = false }
 ring = { version = "0.17", optional = true }
 tokio = { version = "1", features = ["rt", "io-util"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 nanoid = "0.4.0"

--- a/llrt_modules/src/modules/fs/file_handle.rs
+++ b/llrt_modules/src/modules/fs/file_handle.rs
@@ -503,6 +503,8 @@ mod tests {
     #[tokio::test]
     async fn test_file_handle_read() {
         let (file, path) = given_file("Hello World", OpenOptions::new().read(true)).await;
+        let path_1 = path.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 Class::<FileHandle>::register(&ctx).unwrap();
@@ -523,18 +525,23 @@ mod tests {
                 .unwrap();
 
                 let result =
-                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file, path),)).await;
+                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file, path_1),)).await;
 
                 assert!(result.starts_with(b"Hello World"));
             })
         })
         .await;
+
+        tokio::fs::remove_file(&path).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_file_handle_read_concurrent() {
         let (file_a, path_a) = given_file(&"a".repeat(20000), OpenOptions::new().read(true)).await;
         let (file_b, path_b) = given_file(&"b".repeat(20000), OpenOptions::new().read(true)).await;
+        let path_a_1 = path_a.clone();
+        let path_b_1 = path_b.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 Class::<FileHandle>::register(&ctx).unwrap();
@@ -555,7 +562,7 @@ mod tests {
                 .unwrap();
 
                 let result =
-                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file_a, path_a), FileHandle::new(file_b, path_b))).await;
+                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file_a, path_a_1), FileHandle::new(file_b, path_b_1))).await;
 
                 assert_eq!(result.len(), 10000);
                 if result.iter().all(|&b| b == b'a') {
@@ -568,11 +575,16 @@ mod tests {
             })
         })
         .await;
+
+        tokio::fs::remove_file(&path_a).await.unwrap();
+        tokio::fs::remove_file(&path_b).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_file_handle_read_position() {
         let (file, path) = given_file("Hello World", OpenOptions::new().read(true)).await;
+        let path_1 = path.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 Class::<FileHandle>::register(&ctx).unwrap();
@@ -595,17 +607,21 @@ mod tests {
                 .unwrap();
 
                 let result =
-                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file, path),)).await;
+                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file, path_1),)).await;
 
                 assert!(result.starts_with(b"WorldHello World"));
             })
         })
         .await;
+
+        tokio::fs::remove_file(&path).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_file_handle_read_subarray() {
         let (file, path) = given_file("Hello World", OpenOptions::new().read(true)).await;
+        let path_1 = path.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 Class::<FileHandle>::register(&ctx).unwrap();
@@ -627,17 +643,21 @@ mod tests {
                 .unwrap();
 
                 let result =
-                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file, path),)).await;
+                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file, path_1),)).await;
 
                 assert!(result.starts_with(b"\x00\x00\x00Hello\x00"));
             })
         })
         .await;
+
+        tokio::fs::remove_file(&path).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_file_handle_read_buffer() {
         let (file, path) = given_file("Hello World", OpenOptions::new().read(true)).await;
+        let path_1 = path.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 buffer::init(&ctx).unwrap();
@@ -657,7 +677,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let error = call_test_err::<(), _>(&ctx, &module, (FileHandle::new(file, path),))
+                let error = call_test_err::<(), _>(&ctx, &module, (FileHandle::new(file, path_1),))
                     .await
                     .unwrap_err();
 
@@ -669,11 +689,15 @@ mod tests {
             })
         })
         .await;
+
+        tokio::fs::remove_file(&path).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_file_handle_read_out_of_range() {
         let (file, path) = given_file("Hello World", OpenOptions::new().read(true)).await;
+        let path_1 = path.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 buffer::init(&ctx).unwrap();
@@ -694,17 +718,21 @@ mod tests {
                 .unwrap();
 
                 let result =
-                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file, path),)).await;
+                    call_test::<Vec<u8>, _>(&ctx, &module, (FileHandle::new(file, path_1),)).await;
 
                 assert!(result.starts_with(b"Hello World"));
             })
         })
         .await;
+
+        tokio::fs::remove_file(&path).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_file_handle_read_file() {
         let (file, path) = given_file("Hello World", OpenOptions::new().read(true)).await;
+        let path_1 = path.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 Class::<FileHandle>::register(&ctx).unwrap();
@@ -723,18 +751,21 @@ mod tests {
                 .unwrap();
 
                 let result =
-                    call_test::<String, _>(&ctx, &module, (FileHandle::new(file, path),)).await;
+                    call_test::<String, _>(&ctx, &module, (FileHandle::new(file, path_1),)).await;
 
                 assert_eq!(result, "Hello World");
             })
         })
         .await;
+
+        tokio::fs::remove_file(&path).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_file_handle_write() {
         let (file, path) = given_file("", OpenOptions::new().write(true)).await;
         let path_1 = path.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 Class::<FileHandle>::register(&ctx).unwrap();
@@ -745,6 +776,7 @@ mod tests {
                     r#"
                         export async function test(filehandle) {
                             const { bytesWritten } = await filehandle.write("Hello World", null, "utf8");
+                            await filehandle.sync();
                             return bytesWritten;
                         }
                     "#,
@@ -760,7 +792,8 @@ mod tests {
         })
         .await;
 
-        let file_content = tokio::fs::read(path).await.unwrap();
+        let file_content = tokio::fs::read(&path).await.unwrap();
+        tokio::fs::remove_file(&path).await.unwrap();
         assert_eq!(file_content, b"Hello World");
     }
 
@@ -779,6 +812,7 @@ mod tests {
                         export async function test(filehandle) {
                             const { bytesWritten } = await filehandle.write("Hello World", null, "utf8", 4);
                             await filehandle.write("a", null, "utf8");
+                            await filehandle.sync();
                             return bytesWritten;
                         }
                     "#,
@@ -794,7 +828,8 @@ mod tests {
         })
         .await;
 
-        let file_content = tokio::fs::read(path).await.unwrap();
+        let file_content = tokio::fs::read(&path).await.unwrap();
+        tokio::fs::remove_file(&path).await.unwrap();
         assert_eq!(file_content, b"a\x00\x00\x00Hello World");
     }
 
@@ -831,7 +866,8 @@ mod tests {
         })
         .await;
 
-        let file_content = tokio::fs::read(path).await.unwrap();
+        let file_content = tokio::fs::read(&path).await.unwrap();
+        tokio::fs::remove_file(&path).await.unwrap();
         assert_eq!(file_content, b"");
     }
 
@@ -853,6 +889,7 @@ mod tests {
                     r#"
                         export async function test(filehandle) {
                             await filehandle.writeFile("Hello World", "utf8");
+                            await filehandle.sync();
                         }
                     "#,
                 )
@@ -864,7 +901,8 @@ mod tests {
         })
         .await;
 
-        let file_content = tokio::fs::read(path).await.unwrap();
+        let file_content = tokio::fs::read(&path).await.unwrap();
+        tokio::fs::remove_file(&path).await.unwrap();
         assert_eq!(file_content, b"Hello World");
     }
 }

--- a/llrt_modules/src/modules/fs/file_handle.rs
+++ b/llrt_modules/src/modules/fs/file_handle.rs
@@ -837,8 +837,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_file_handle_write_file() {
-        let (file, path) =
-            given_file("Other Data", OpenOptions::new().write(true).append(true)).await;
+        let (file, path) = given_file(
+            "Other very very very very long Data",
+            OpenOptions::new().write(true),
+        )
+        .await;
         let path_1 = path.clone();
         test_async_with(|ctx| {
             Box::pin(async move {

--- a/llrt_modules/src/modules/fs/mkdir.rs
+++ b/llrt_modules/src/modules/fs/mkdir.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(unix)]
 use std::os::unix::prelude::PermissionsExt;
 
 use llrt_utils::result::ResultExt;
@@ -17,9 +18,16 @@ pub async fn mkdir<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) 
     }
     .or_throw_msg(&ctx, &["Can't create dir \"", &path, "\""].concat())?;
 
-    fs::set_permissions(&path, PermissionsExt::from_mode(mode))
-        .await
-        .or_throw_msg(&ctx, &["Can't set permissions of \"", &path, "\""].concat())?;
+    #[cfg(unix)]
+    {
+        fs::set_permissions(&path, PermissionsExt::from_mode(mode))
+            .await
+            .or_throw_msg(&ctx, &["Can't set permissions of \"", &path, "\""].concat())?;
+    }
+    #[cfg(not(unix))]
+    {
+        _ = mode;
+    }
 
     Ok(path)
 }
@@ -34,8 +42,15 @@ pub fn mkdir_sync<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -
     }
     .or_throw_msg(&ctx, &["Can't create dir \"", &path, "\""].concat())?;
 
-    std::fs::set_permissions(&path, PermissionsExt::from_mode(mode))
-        .or_throw_msg(&ctx, &["Can't set permissions of \"", &path, "\""].concat())?;
+    #[cfg(unix)]
+    {
+        std::fs::set_permissions(&path, PermissionsExt::from_mode(mode))
+            .or_throw_msg(&ctx, &["Can't set permissions of \"", &path, "\""].concat())?;
+    }
+    #[cfg(not(unix))]
+    {
+        _ = mode;
+    }
 
     Ok(path)
 }

--- a/llrt_modules/src/modules/fs/mod.rs
+++ b/llrt_modules/src/modules/fs/mod.rs
@@ -25,7 +25,7 @@ use self::open::open;
 use self::read_dir::{read_dir, read_dir_sync, Dirent};
 use self::read_file::{read_file, read_file_sync};
 use self::rm::{rmdir, rmfile};
-use self::stats::{stat_fn, Stat};
+use self::stats::{stat_fn, Stats};
 use self::write_file::write_file;
 
 use crate::modules::fs::{
@@ -68,7 +68,7 @@ impl ModuleDef for FsPromisesModule {
     fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
         Class::<Dirent>::register(ctx)?;
         Class::<FileHandle>::register(ctx)?;
-        Class::<Stat>::register(ctx)?;
+        Class::<Stats>::register(ctx)?;
 
         export_default(ctx, exports, |default| {
             export_promises(ctx, default)?;
@@ -111,7 +111,7 @@ impl ModuleDef for FsModule {
     fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
         Class::<Dirent>::register(ctx)?;
         Class::<FileHandle>::register(ctx)?;
-        Class::<Stat>::register(ctx)?;
+        Class::<Stats>::register(ctx)?;
 
         export_default(ctx, exports, |default| {
             let promises = Object::new(ctx.clone())?;

--- a/llrt_modules/src/modules/fs/open.rs
+++ b/llrt_modules/src/modules/fs/open.rs
@@ -66,6 +66,8 @@ mod tests {
             .await
             .to_string_lossy()
             .to_string();
+        let path_1 = path.clone();
+
         test_async_with(|ctx| {
             Box::pin(async move {
                 buffer::init(&ctx).unwrap();
@@ -94,11 +96,13 @@ mod tests {
                 .await
                 .unwrap();
 
-                let result = call_test::<Vec<u8>, _>(&ctx, &module, (path,)).await;
+                let result = call_test::<Vec<u8>, _>(&ctx, &module, (path_1,)).await;
 
                 assert!(result.starts_with(b"Hello World"));
             })
         })
         .await;
+
+        tokio::fs::remove_file(path).await.unwrap();
     }
 }

--- a/llrt_modules/src/modules/fs/open.rs
+++ b/llrt_modules/src/modules/fs/open.rs
@@ -28,12 +28,12 @@ pub async fn open(ctx: Ctx<'_>, path: String, flags: String, mode: Opt<u32>) -> 
             ))
         },
     };
-    #[cfg(linux)]
+    #[cfg(unix)]
     {
         let mode = mode.0.unwrap_or(0o666);
         options.mode(mode);
     }
-    #[cfg(not(linux))]
+    #[cfg(not(unix))]
     {
         _ = mode;
     }

--- a/llrt_modules/src/modules/fs/open.rs
+++ b/llrt_modules/src/modules/fs/open.rs
@@ -28,8 +28,15 @@ pub async fn open(ctx: Ctx<'_>, path: String, flags: String, mode: Opt<u32>) -> 
             ))
         },
     };
-    let mode = mode.0.unwrap_or(0o666);
-    options.mode(mode);
+    #[cfg(linux)]
+    {
+        let mode = mode.0.unwrap_or(0o666);
+        options.mode(mode);
+    }
+    #[cfg(not(linux))]
+    {
+        _ = mode;
+    }
 
     let path = PathBuf::from(path);
     let file = options

--- a/llrt_modules/src/modules/fs/open.rs
+++ b/llrt_modules/src/modules/fs/open.rs
@@ -8,9 +8,14 @@ use tokio::fs::OpenOptions;
 
 use super::file_handle::FileHandle;
 
-pub async fn open(ctx: Ctx<'_>, path: String, flags: String, mode: Opt<u32>) -> Result<FileHandle> {
+pub async fn open(
+    ctx: Ctx<'_>,
+    path: String,
+    flags: Opt<String>,
+    mode: Opt<u32>,
+) -> Result<FileHandle> {
     let mut options = OpenOptions::new();
-    match flags.as_str() {
+    match flags.0.as_deref().unwrap_or("r") {
         // We are not supporting the sync modes
         "a" => options.append(true).create(true),
         "ax" => options.append(true).create_new(true),
@@ -21,7 +26,7 @@ pub async fn open(ctx: Ctx<'_>, path: String, flags: String, mode: Opt<u32>) -> 
         "wx" => options.write(true).create_new(true),
         "w+" => options.write(true).read(true).create(true).truncate(true),
         "wx+" => options.write(true).read(true).create_new(true),
-        _ => {
+        flags => {
             return Err(Exception::throw_message(
                 &ctx,
                 &format!("Invalid flags '{}'", flags),

--- a/llrt_modules/src/modules/fs/stats.rs
+++ b/llrt_modules/src/modules/fs/stats.rs
@@ -174,7 +174,8 @@ impl Stats {
     pub fn atime_ms(&self, ctx: Ctx<'_>) -> Result<u64> {
         #[cfg(unix)]
         {
-            Ok(self.metadata.atime_nsec() / 1e6 as u64)
+            _ = ctx;
+            Ok(self.metadata.atime_nsec() as u64 / 1e6 as u64)
         }
         #[cfg(not(unix))]
         {
@@ -186,7 +187,8 @@ impl Stats {
     pub fn mtime_ms(&self, ctx: Ctx<'_>) -> Result<u64> {
         #[cfg(unix)]
         {
-            Ok(self.metadata.mtime_nsec() / 1e6 as u64)
+            _ = ctx;
+            Ok(self.metadata.mtime_nsec() as u64 / 1e6 as u64)
         }
         #[cfg(not(unix))]
         {
@@ -198,7 +200,8 @@ impl Stats {
     pub fn ctime_ms(&self, ctx: Ctx<'_>) -> Result<u64> {
         #[cfg(unix)]
         {
-            Ok(self.metadata.ctime_nsec() / 1e6 as u64)
+            _ = ctx;
+            Ok(self.metadata.ctime_nsec() as u64 / 1e6 as u64)
         }
         #[cfg(not(unix))]
         {
@@ -225,11 +228,11 @@ impl Stats {
         self.metadata.modified().or_throw(&ctx)
     }
 
-    #[allow(unused_variables)]
     #[qjs(get, enumerable)]
     pub fn ctime(&self, ctx: Ctx<'_>) -> Result<SystemTime> {
         #[cfg(unix)]
         {
+            _ = ctx;
             Ok(SystemTime::UNIX_EPOCH + Duration::from_nanos(self.metadata.ctime_nsec() as u64))
         }
         #[cfg(not(unix))]
@@ -330,6 +333,7 @@ pub fn stat_fn_sync(ctx: Ctx<'_>, path: String) -> Result<Stats> {
     Ok(stats)
 }
 
+#[allow(dead_code)]
 #[inline(always)]
 fn to_msec(time: SystemTime) -> u64 {
     time.duration_since(SystemTime::UNIX_EPOCH)

--- a/llrt_modules/src/modules/fs/stats.rs
+++ b/llrt_modules/src/modules/fs/stats.rs
@@ -4,6 +4,9 @@
 use std::os::unix::fs::FileTypeExt;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+#[cfg(windows)]
+use std::os::windows::fs::MetadataExt;
+#[allow(unused_imports)]
 use std::{
     fs::Metadata,
     time::{Duration, SystemTime},
@@ -13,15 +16,24 @@ use llrt_utils::result::ResultExt;
 use rquickjs::{Ctx, Result};
 use tokio::fs;
 
+// The Stats implementation is very much based on Unix. The Windows implementation
+// tries its best to mimic the implementation of libuv since it is the standard.
+// See: https://github.com/libuv/libuv/blob/90648ea3e55125a5a819b32106da6462da310da6/src/win/fs.c
+//
+// By comparison, the Deno implementation is very basic and doesn't even try much.
+// See: https://github.com/denoland/deno/blob/c9da27e147d0681724dd647593abbaa46417feb7/ext/io/fs.rs#L114-L182
+//
+// This implementation doesn't handle files created before UNIX_EPOCH.
+
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace)]
-pub struct Stat {
+pub struct Stats {
     #[qjs(skip_trace)]
     metadata: Metadata,
 }
 
 #[rquickjs::methods(rename_all = "camelCase")]
-impl Stat {
+impl Stats {
     #[qjs(skip)]
     pub fn new(metadata: Metadata) -> Self {
         Self { metadata }
@@ -29,73 +41,171 @@ impl Stat {
 
     #[qjs(get, enumerable)]
     pub fn dev(&self) -> u64 {
-        self.metadata.dev()
+        #[cfg(unix)]
+        {
+            self.metadata.dev()
+        }
+        #[cfg(not(unix))]
+        {
+            // Unstable feature, see https://github.com/rust-lang/rust/issues/63010
+            0
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn ino(&self) -> u64 {
-        self.metadata.ino()
+        #[cfg(unix)]
+        {
+            self.metadata.ino()
+        }
+        #[cfg(not(unix))]
+        {
+            // Unstable feature, see https://github.com/rust-lang/rust/issues/63010
+            0
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn mode(&self) -> u32 {
-        self.metadata.mode()
+        #[cfg(unix)]
+        {
+            self.metadata.mode()
+        }
+        #[cfg(not(unix))]
+        {
+            0o666
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn nlink(&self) -> u64 {
-        self.metadata.nlink()
+        #[cfg(unix)]
+        {
+            self.metadata.nlink()
+        }
+        #[cfg(not(unix))]
+        {
+            // Unstable feature, see https://github.com/rust-lang/rust/issues/63010
+            1
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn uid(&self) -> u32 {
-        self.metadata.uid()
+        #[cfg(unix)]
+        {
+            self.metadata.uid()
+        }
+        #[cfg(not(unix))]
+        {
+            0
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn gid(&self) -> u32 {
-        self.metadata.gid()
+        #[cfg(unix)]
+        {
+            self.metadata.gid()
+        }
+        #[cfg(not(unix))]
+        {
+            0
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn rdev(&self) -> u64 {
-        self.metadata.rdev()
+        #[cfg(unix)]
+        {
+            self.metadata.rdev()
+        }
+        #[cfg(not(unix))]
+        {
+            0
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn size(&self) -> u64 {
-        self.metadata.size()
+        #[cfg(unix)]
+        {
+            self.metadata.size()
+        }
+        #[cfg(windows)]
+        {
+            if self.metadata.is_dir() {
+                0
+            } else {
+                self.metadata.file_size()
+            }
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            0
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn blksize(&self) -> u64 {
-        self.metadata.blksize()
+        #[cfg(unix)]
+        {
+            self.metadata.blksize()
+        }
+        #[cfg(not(unix))]
+        {
+            4096
+        }
     }
 
     #[qjs(get, enumerable)]
     pub fn blocks(&self) -> u64 {
-        self.metadata.blocks()
+        #[cfg(unix)]
+        {
+            self.metadata.blocks()
+        }
+        #[cfg(not(unix))]
+        {
+            0
+        }
     }
 
-    #[cfg(unix)]
     #[qjs(get, enumerable)]
-    pub fn atime_ms(&self) -> i64 {
-        self.metadata.atime_nsec() / 1e6 as i64
+    pub fn atime_ms(&self, ctx: Ctx<'_>) -> Result<u64> {
+        #[cfg(unix)]
+        {
+            Ok(self.metadata.atime_nsec() / 1e6 as u64)
+        }
+        #[cfg(not(unix))]
+        {
+            self.metadata.accessed().map(to_msec).or_throw(&ctx)
+        }
     }
 
-    #[cfg(unix)]
     #[qjs(get, enumerable)]
-    pub fn mtime_ms(&self) -> i64 {
-        self.metadata.mtime_nsec() / 1e6 as i64
+    pub fn mtime_ms(&self, ctx: Ctx<'_>) -> Result<u64> {
+        #[cfg(unix)]
+        {
+            Ok(self.metadata.mtime_nsec() / 1e6 as u64)
+        }
+        #[cfg(not(unix))]
+        {
+            self.metadata.modified().map(to_msec).or_throw(&ctx)
+        }
     }
 
-    #[cfg(unix)]
     #[qjs(get, enumerable)]
-    pub fn ctime_ms(&self) -> i64 {
-        self.metadata.ctime_nsec() / 1e6 as i64
+    pub fn ctime_ms(&self, ctx: Ctx<'_>) -> Result<u64> {
+        #[cfg(unix)]
+        {
+            Ok(self.metadata.ctime_nsec() / 1e6 as u64)
+        }
+        #[cfg(not(unix))]
+        {
+            self.metadata.modified().map(to_msec).or_throw(&ctx)
+        }
     }
 
-    #[cfg(unix)]
     #[qjs(get, enumerable)]
     pub fn birthtime_ms(&self, ctx: Ctx<'_>) -> Result<u64> {
         self.metadata
@@ -115,9 +225,17 @@ impl Stat {
         self.metadata.modified().or_throw(&ctx)
     }
 
+    #[allow(unused_variables)]
     #[qjs(get, enumerable)]
-    pub fn ctime(&self) -> SystemTime {
-        SystemTime::UNIX_EPOCH + Duration::from_nanos(self.metadata.ctime_nsec() as u64)
+    pub fn ctime(&self, ctx: Ctx<'_>) -> Result<SystemTime> {
+        #[cfg(unix)]
+        {
+            Ok(SystemTime::UNIX_EPOCH + Duration::from_nanos(self.metadata.ctime_nsec() as u64))
+        }
+        #[cfg(not(unix))]
+        {
+            self.metadata.modified().or_throw(&ctx)
+        }
     }
 
     #[qjs(get, enumerable)]
@@ -128,11 +246,22 @@ impl Stat {
     pub fn is_file(&self) -> bool {
         self.metadata.is_file()
     }
+
+    /// @deprecated Use `is_directory` instead
     pub fn is_dir(&self) -> bool {
         self.metadata.is_dir()
     }
 
+    pub fn is_directory(&self) -> bool {
+        self.metadata.is_dir()
+    }
+
+    /// @deprecated Use `is_symbolic_link` instead
     pub fn is_symlink(&self) -> bool {
+        self.metadata.is_symlink()
+    }
+
+    pub fn is_symbolic_link(&self) -> bool {
         self.metadata.is_symlink()
     }
 
@@ -182,21 +311,28 @@ impl Stat {
     }
 }
 
-pub async fn stat_fn(ctx: Ctx<'_>, path: String) -> Result<Stat> {
+pub async fn stat_fn(ctx: Ctx<'_>, path: String) -> Result<Stats> {
     let metadata = fs::metadata(&path)
         .await
         .or_throw_msg(&ctx, &["Can't stat \"", &path, "\""].concat())?;
 
-    let stats = Stat::new(metadata);
+    let stats = Stats::new(metadata);
 
     Ok(stats)
 }
 
-pub fn stat_fn_sync(ctx: Ctx<'_>, path: String) -> Result<Stat> {
+pub fn stat_fn_sync(ctx: Ctx<'_>, path: String) -> Result<Stats> {
     let metadata =
         std::fs::metadata(&path).or_throw_msg(&ctx, &["Can't stat \"", &path, "\""].concat())?;
 
-    let stats = Stat::new(metadata);
+    let stats = Stats::new(metadata);
 
     Ok(stats)
+}
+
+#[inline(always)]
+fn to_msec(time: SystemTime) -> u64 {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .map(|t| t.as_millis() as u64)
+        .unwrap_or_else(|err| err.duration().as_millis() as u64)
 }

--- a/llrt_modules/src/modules/mod.rs
+++ b/llrt_modules/src/modules/mod.rs
@@ -8,3 +8,5 @@ pub mod fs;
 pub mod os;
 #[cfg(feature = "path")]
 pub mod path;
+#[cfg(feature = "process")]
+pub mod process;

--- a/llrt_modules/src/modules/mod.rs
+++ b/llrt_modules/src/modules/mod.rs
@@ -4,5 +4,7 @@
 pub mod buffer;
 #[cfg(feature = "fs")]
 pub mod fs;
+#[cfg(feature = "os")]
+pub mod os;
 #[cfg(feature = "path")]
 pub mod path;

--- a/llrt_modules/src/modules/os.rs
+++ b/llrt_modules/src/modules/os.rs
@@ -1,2 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0

--- a/llrt_modules/src/modules/os.rs
+++ b/llrt_modules/src/modules/os.rs
@@ -1,0 +1,2 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0

--- a/llrt_modules/src/modules/os/mod.rs
+++ b/llrt_modules/src/modules/os/mod.rs
@@ -2,40 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::env;
 
-use once_cell::sync::Lazy;
+use llrt_utils::module::export_default;
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
     prelude::Func,
     Ctx, Result,
 };
 
-use crate::{
-    module_builder::ModuleInfo,
-    modules::{module::export_default, process::get_platform},
-};
+#[cfg(unix)]
+use self::unix::{get_release, get_type, get_version};
+#[cfg(windows)]
+use self::windows::{get_release, get_type, get_version};
+use crate::module_info::ModuleInfo;
+use crate::process::get_platform;
 
-static OS_INFO: Lazy<(String, String, String)> = Lazy::new(|| {
-    if let Ok(uts) = uname::uname() {
-        return (uts.sysname, uts.release, uts.version);
-    }
-    (
-        String::from("n/a"),
-        String::from("n/a"),
-        String::from("n/a"),
-    )
-});
-
-fn get_type() -> &'static str {
-    &OS_INFO.0
-}
-
-fn get_release() -> &'static str {
-    &OS_INFO.1
-}
-
-fn get_version() -> &'static str {
-    &OS_INFO.2
-}
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
 
 fn get_tmp_dir() -> String {
     env::temp_dir().to_string_lossy().to_string()

--- a/llrt_modules/src/modules/os/mod.rs
+++ b/llrt_modules/src/modules/os/mod.rs
@@ -61,3 +61,99 @@ impl From<OsModule> for ModuleInfo<OsModule> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::{call_test, test_async_with, ModuleEvaluator};
+
+    #[tokio::test]
+    async fn test_type() {
+        test_async_with(|ctx| {
+            Box::pin(async move {
+                ModuleEvaluator::eval_rust::<OsModule>(ctx.clone(), "os")
+                    .await
+                    .unwrap();
+
+                let module = ModuleEvaluator::eval_js(
+                    ctx.clone(),
+                    "test",
+                    r#"
+                        import { type } from 'os';
+
+                        export async function test() {
+                            return type()
+                        }
+                    "#,
+                )
+                .await
+                .unwrap();
+
+                let result = call_test::<String, _>(&ctx, &module, ()).await;
+
+                assert!(result == "Linux" || result == "Windows_NT" || result == "Darwin");
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_release() {
+        test_async_with(|ctx| {
+            Box::pin(async move {
+                ModuleEvaluator::eval_rust::<OsModule>(ctx.clone(), "os")
+                    .await
+                    .unwrap();
+
+                let module = ModuleEvaluator::eval_js(
+                    ctx.clone(),
+                    "test",
+                    r#"
+                        import { release } from 'os';
+
+                        export async function test() {
+                            return release()
+                        }
+                    "#,
+                )
+                .await
+                .unwrap();
+
+                let result = call_test::<String, _>(&ctx, &module, ()).await;
+
+                assert!(!result.is_empty()); // Format is platform dependant
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_version() {
+        test_async_with(|ctx| {
+            Box::pin(async move {
+                ModuleEvaluator::eval_rust::<OsModule>(ctx.clone(), "os")
+                    .await
+                    .unwrap();
+
+                let module = ModuleEvaluator::eval_js(
+                    ctx.clone(),
+                    "test",
+                    r#"
+                        import { version } from 'os';
+
+                        export async function test() {
+                            return version()
+                        }
+                    "#,
+                )
+                .await
+                .unwrap();
+
+                let result = call_test::<String, _>(&ctx, &module, ()).await;
+
+                assert!(!result.is_empty()); // Format is platform dependant
+            })
+        })
+        .await;
+    }
+}

--- a/llrt_modules/src/modules/os/unix.rs
+++ b/llrt_modules/src/modules/os/unix.rs
@@ -1,0 +1,47 @@
+use std::ffi::CStr;
+
+use once_cell::sync::Lazy;
+
+static OS_INFO: Lazy<(String, String, String)> = Lazy::new(uname);
+
+pub fn get_type() -> &'static str {
+    &OS_INFO.0
+}
+
+pub fn get_release() -> &'static str {
+    &OS_INFO.1
+}
+
+pub fn get_version() -> &'static str {
+    &OS_INFO.2
+}
+
+fn uname() -> (String, String, String) {
+    let mut info = std::mem::MaybeUninit::uninit();
+    let res = unsafe { libc::uname(info.as_mut_ptr()) };
+    if res != 0 {
+        return (
+            String::from("n/a"),
+            String::from("n/a"),
+            String::from("n/a"),
+        );
+    }
+    let info = unsafe { info.assume_init() };
+    (
+        unsafe {
+            CStr::from_ptr(info.sysname.as_ptr())
+                .to_string_lossy()
+                .into_owned()
+        },
+        unsafe {
+            CStr::from_ptr(info.release.as_ptr())
+                .to_string_lossy()
+                .into_owned()
+        },
+        unsafe {
+            CStr::from_ptr(info.version.as_ptr())
+                .to_string_lossy()
+                .into_owned()
+        },
+    )
+}

--- a/llrt_modules/src/modules/os/unix.rs
+++ b/llrt_modules/src/modules/os/unix.rs
@@ -18,26 +18,27 @@ pub fn get_version() -> &'static str {
 
 fn uname() -> (String, String, String) {
     let mut info = std::mem::MaybeUninit::uninit();
+    // SAFETY: `info` is a valid pointer to a `libc::utsname` struct.
     let res = unsafe { libc::uname(info.as_mut_ptr()) };
     if res != 0 {
-        return (
-            String::from("n/a"),
-            String::from("n/a"),
-            String::from("n/a"),
-        );
+        return (String::new(), String::new(), String::new());
     }
+    // SAFETY: `uname` returns 0 on success and info is initialized.
     let info = unsafe { info.assume_init() };
     (
+        // SAFETY: `info.sysname` is a valid NUL-terminated pointer.
         unsafe {
             CStr::from_ptr(info.sysname.as_ptr())
                 .to_string_lossy()
                 .into_owned()
         },
+        // SAFETY: `info.release` is a valid NUL-terminated pointer.
         unsafe {
             CStr::from_ptr(info.release.as_ptr())
                 .to_string_lossy()
                 .into_owned()
         },
+        // SAFETY: `info.version` is a valid NUL-terminated pointer.
         unsafe {
             CStr::from_ptr(info.version.as_ptr())
                 .to_string_lossy()

--- a/llrt_modules/src/modules/os/windows.rs
+++ b/llrt_modules/src/modules/os/windows.rs
@@ -1,0 +1,44 @@
+use once_cell::sync::Lazy;
+use windows_registry::{Value, LOCAL_MACHINE};
+use windows_result::{Error, Result};
+use windows_version::OsVersion;
+
+static OS_RELEASE: Lazy<String> = Lazy::new(release);
+static OS_VERSION: Lazy<String> = Lazy::new(|| version().unwrap_or_default());
+
+pub fn get_type() -> &'static str {
+    // In theory there are more types linx MinGW but in practice this is good enough
+    "Windows_NT"
+}
+
+pub fn get_release() -> &'static str {
+    &OS_RELEASE
+}
+
+pub fn get_version() -> &'static str {
+    &OS_VERSION
+}
+
+fn release() -> String {
+    let version = OsVersion::current();
+    format!("{}.{}.{}", version.major, version.minor, version.build)
+}
+
+fn version() -> Result<String> {
+    let version = OsVersion::current();
+
+    let registry_key = LOCAL_MACHINE.open("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion")?;
+    let value = registry_key.get_value("ProductName")?;
+    let Value::String(mut value) = value else {
+        return Err(Error::empty());
+    };
+
+    // Windows 11 shares dwMajorVersion with Windows 10
+    // this workaround tries to disambiguate that by checking
+    // if the dwBuildNumber is from Windows 11 releases (>= 22000).
+    if version.major == 10 && version.build >= 22000 && value.starts_with("Windows 10") {
+        value.replace_range(9..10, "1");
+    }
+
+    Ok(value)
+}

--- a/llrt_modules/src/modules/path.rs
+++ b/llrt_modules/src/modules/path.rs
@@ -233,6 +233,7 @@ impl ModuleDef for PathModule {
         declare.declare("normalize")?;
         declare.declare("isAbsolute")?;
         declare.declare("delimiter")?;
+        declare.declare("sep")?;
 
         declare.declare("default")?;
         Ok(())
@@ -250,6 +251,7 @@ impl ModuleDef for PathModule {
             default.set("normalize", Func::from(normalize))?;
             default.set("isAbsolute", Func::from(is_absolute))?;
             default.prop("delimiter", DELIMITER.to_string())?;
+            default.prop("sep", MAIN_SEPARATOR.to_string())?;
             Ok(())
         })
     }

--- a/llrt_modules/src/modules/process.rs
+++ b/llrt_modules/src/modules/process.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::env;
+
+// This is not the full module for now since we are not yet sure
+// how to implement the TIME_ORIGIN Atomic in what are supposed to
+// be independant modules.
+
+pub fn get_platform() -> &'static str {
+    let platform = env::consts::OS;
+    match platform {
+        "macos" => "darwin",
+        "windows" => "win32",
+        _ => platform,
+    }
+}


### PR DESCRIPTION
### Description of changes

-  Added windows support for the modules
- Move OS module and added windows support
- Added CI for modules for windows, macos and linux (x86 only, it is sufficient)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
