### PR TITLE
fix: throwing exceptions during module initialization

### DIFF
--- a/API.md
+++ b/API.md
@@ -115,6 +115,18 @@ Available globally
 > [!NOTE]
 > `require` is available from esm modules natively. This function is just for compatibility
 
+## net
+
+> [!WARNING]
+> These APIs uses native streams that is not 100% compatible with the Node.js Streams API. Server APIs like `createSever` provides limited functionality useful for testing purposes. Serverless applications typically don't expose servers. Some server options are not supported:
+> `highWaterMark`, `pauseOnConnect`, `keepAlive`, `noDelay`, `keepAliveInitialDelay`
+
+[connect](https://nodejs.org/api/net.html#netconnect)
+
+[createConnection](https://nodejs.org/api/net.html#netcreateconnection)
+
+[createServer](https://nodejs.org/api/net.html#netcreateserveroptions-connectionlistener)
+
 ## os
 
 [platform](https://nodejs.org/api/os.html#osplatform)
@@ -241,33 +253,14 @@ export class URLSearchParams {
 }
 ```
 
-### TODO, URLSearchParams see tracking [ticket](https://github.com/awslabs/llrt/issues/307):
-
-```typescript
-URLSearchParams.sort(): void;
-```
-
 ## util
 
 > [!IMPORTANT]
-> Supported encodings: hex, base64, utf8, iso88591.
-> Supported methods: `encode` & `decode`
+> Supported encodings: hex, base64, utf8, utf16le, iso88591.
 
 [TextDecoder](https://nodejs.org/api/util.html#class-utiltextdecoder)
 
 [TextEncoder](https://nodejs.org/api/util.html#class-utiltextdecoder)
-
-## net
-
-> [!WARNING]
-> These APIs uses native streams that is not 100% compatible with the Node.js Streams API. Server APIs like `createSever` provides limited functionality useful for testing purposes. Serverless applications typically don't expose servers. Some server options are not supported:
-> `highWaterMark`, `pauseOnConnect`, `keepAlive`, `noDelay`, `keepAliveInitialDelay`
-
-[connect](https://nodejs.org/api/net.html#netconnect)
-
-[createConnection](https://nodejs.org/api/net.html#netcreateconnection)
-
-[createServer](https://nodejs.org/api/net.html#netcreateserveroptions-connectionlistener)
 
 ## llrt:hex
 

--- a/llrt_core/src/modules/net/mod.rs
+++ b/llrt_core/src/modules/net/mod.rs
@@ -36,11 +36,24 @@ enum ReadyState {
     WriteOnly,
 }
 
+impl ReadyState {
+    pub fn to_string(&self) -> String {
+        String::from(match self {
+            ReadyState::Opening => "opening",
+            ReadyState::Open => "open",
+            ReadyState::Closed => "closed",
+            ReadyState::ReadOnly => "readOnly",
+            ReadyState::WriteOnly => "writeOnly",
+        })
+    }
+}
+
 enum NetStream {
     Tcp((TcpStream, SocketAddr)),
     #[cfg(unix)]
     Unix((UnixStream, tokio::net::unix::SocketAddr)),
 }
+
 impl NetStream {
     async fn process<'js>(
         self,
@@ -83,18 +96,6 @@ impl Listener {
                 .map(|(stream, addr)| NetStream::Unix((stream, addr)))
                 .or_throw(ctx),
         }
-    }
-}
-
-impl ReadyState {
-    pub fn to_string(&self) -> String {
-        String::from(match self {
-            ReadyState::Opening => "opening",
-            ReadyState::Open => "open",
-            ReadyState::Closed => "closed",
-            ReadyState::ReadOnly => "readOnly",
-            ReadyState::WriteOnly => "writeOnly",
-        })
     }
 }
 

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -423,10 +423,16 @@ impl Vm {
         let ctx = AsyncContext::full(&runtime).await?;
         ctx.with(|ctx| {
             for init_global in init_globals {
-                init_global(&ctx)?;
+                if let Err(err) = init_global(&ctx).catch(&ctx) {
+                    Self::print_error_and_exit(&ctx, err);
+                }
             }
-            timers::init_timers(&ctx)?;
-            init(&ctx, module_names)?;
+            if let Err(err) = timers::init_timers(&ctx).catch(&ctx) {
+                Self::print_error_and_exit(&ctx, err);
+            }
+            if let Err(err) = init(&ctx, module_names).catch(&ctx) {
+                Self::print_error_and_exit(&ctx, err);
+            }
             Ok::<_, Error>(())
         })
         .await?;


### PR DESCRIPTION
### Issue # (if available)

Fixed #482 

### Description of changes

This PR will allow the correct output of the content of errors during module initialization.

After the revision:
```shell
% LLRT_NET_DENY=/ ./llrt -e 'console.log("123")'
ReferenceError: LLRT_NET_DENY env contains an invalid URI
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
