### PR TITLE
Fix new S3 API and bytes with offset

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -519,6 +519,7 @@ async function loadShims() {
     loadShim(/collect-stream-body\.js/, "collect-stream-body.js"),
     loadShim(/sdk-stream-mixin.browser\.js/, "sdk-stream-mixin.js"),
     loadShim(/stream-collector\.js/, "stream-collector.js"),
+    loadShim(/splitStream.browser\.js/, "@smithy/split-stream.js"),
   ]);
 }
 

--- a/llrt_utils/src/bytes.rs
+++ b/llrt_utils/src/bytes.rs
@@ -42,7 +42,7 @@ pub fn get_bytes_offset_length<'js>(
         if let Some((array_buffer, source_length, source_offset)) = obj_to_array_buffer(obj)? {
             let (start, end) = get_start_end_indexes(source_length, length, offset);
             let bytes: &[u8] = array_buffer.as_ref();
-            return Ok(bytes[start + source_offset..end - source_offset].to_vec());
+            return Ok(bytes[(start + source_offset)..(end + source_offset)].to_vec());
         }
     }
 

--- a/shims/@smithy/split-stream.js
+++ b/shims/@smithy/split-stream.js
@@ -1,0 +1,5 @@
+export async function splitStream(stream) {
+  //stream is blob here
+  const typedArray = await stream.bytes();
+  return [typedArray.subarray(0, 3000), typedArray];
+}


### PR DESCRIPTION
### Description of changes

Fixes latest S3 AWS SDK API & a bug with `get_bytes` with large offset from array buffer. 

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
