### PR TITLE
Cleanup and minor improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,7 +2639,6 @@ version = "0.1.15-beta"
 dependencies = [
  "base64-simd",
  "hex-simd",
- "once_cell",
  "phf",
  "rquickjs",
  "tokio",

--- a/llrt_core/src/modules/encoding/mod.rs
+++ b/llrt_core/src/modules/encoding/mod.rs
@@ -6,27 +6,13 @@ pub mod encoder {
 pub mod text_decoder;
 pub mod text_encoder;
 
-use rquickjs::{prelude::Func, Class, Ctx, Result};
+use rquickjs::{Class, Ctx, Result};
 
-use crate::utils::result::ResultExt;
-
-use self::encoder::{bytes_from_b64, bytes_to_b64_string};
 use self::text_decoder::TextDecoder;
 use self::text_encoder::TextEncoder;
 
-pub fn atob(ctx: Ctx<'_>, encoded_value: String) -> Result<String> {
-    let vec = bytes_from_b64(encoded_value.as_bytes()).or_throw(&ctx)?;
-    Ok(unsafe { String::from_utf8_unchecked(vec) })
-}
-
-pub fn btoa(value: String) -> String {
-    bytes_to_b64_string(value.as_bytes())
-}
-
 pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     let globals = ctx.globals();
-    globals.set("atob", Func::from(atob))?;
-    globals.set("btoa", Func::from(btoa))?;
 
     Class::<TextEncoder>::define(&globals)?;
     Class::<TextDecoder>::define(&globals)?;

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -16,9 +16,8 @@ all = [
   "fs",
   "os",
   "path",
+  "perf-hooks",
   "process",
-  "perf_hooks",
-  "performance",
 ]
 
 buffer = ["llrt_utils/encoding"]
@@ -35,8 +34,7 @@ os = [
 ]
 path = []
 process = []
-perf_hooks = ["chrono"]
-performance = ["perf_hooks"]
+perf-hooks = ["chrono"]
 
 __bytearray-buffer = ["tokio/sync"]
 __stream = ["buffer", "__bytearray-buffer"]

--- a/llrt_modules/README.md
+++ b/llrt_modules/README.md
@@ -53,13 +53,17 @@ async fn main() -> anyhow::Result<()> {
 > [!NOTE]
 > Only a fraction of the Node.js APIs are supported. Below is a high level overview of partially supported APIs and modules.
 
-|               | Node.js | LLRT Modules | Feature  |
-| ------------- | ------- | ------------ | -------- |
-| buffer        | ✔︎     | ✔︎️         | `buffer` |
-| fs/promises   | ✔︎     | ⚠️           | `fs`     |
-| fs            | ✔︎     | ⚠️           | `fs`     |
-| path          | ✔︎     | ✔︎          | `path`   |
-| Other modules | ✔︎     | ✘            | N/A      |
+|               | Node.js | LLRT Modules | Feature         |
+| ------------- | ------- | ------------ | --------------- |
+| buffer        | ✔︎     | ✔︎️         | `buffer`        |
+| child process | ✔︎     | ⚠️           | `child-process` |
+| events        | ✔︎     | ⚠️           | `events`        |
+| fs/promises   | ✔︎     | ⚠️           | `fs`            |
+| fs            | ✔︎     | ⚠️           | `fs`            |
+| path          | ✔︎     | ✔︎          | `path`          |
+| perf hooks    | ✔︎     | ⚠️           | `perf-hooks`    |
+| os            | ✔︎     | ⚠️           | `os`            |
+| Other modules | ✔︎     | ✘            | N/A             |
 
 _⚠️ = partially supported_
 _⏱ = planned partial support_

--- a/llrt_modules/src/modules/mod.rs
+++ b/llrt_modules/src/modules/mod.rs
@@ -12,9 +12,9 @@ pub mod fs;
 pub mod os;
 #[cfg(feature = "path")]
 pub mod path;
-#[cfg(feature = "perf_hooks")]
+#[cfg(feature = "perf-hooks")]
 pub mod perf_hooks;
-#[cfg(feature = "performance")]
+#[cfg(feature = "perf-hooks")]
 pub mod performance;
 #[cfg(feature = "process")]
 pub mod process;

--- a/llrt_utils/Cargo.toml
+++ b/llrt_utils/Cargo.toml
@@ -12,7 +12,7 @@ all = ["ctx", "fs", "encoding"]
 
 ctx = ["tokio/sync"]
 fs = ["tokio/fs"]
-encoding = ["base64-simd", "hex-simd"]
+encoding = ["base64-simd", "hex-simd", "phf"]
 
 [dependencies]
 base64-simd = { version = "0.8.0", optional = true }
@@ -23,7 +23,7 @@ rquickjs = { version = "0.6.2", features = [
 tokio = { version = "1", optional = true }
 tracing = "0.1"
 once_cell = "1.19.0"
-phf = { version = "0.11.2", features = ["macros"] }
+phf = { version = "0.11.2", features = ["macros"], optional = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rust_nightly)'] }

--- a/llrt_utils/Cargo.toml
+++ b/llrt_utils/Cargo.toml
@@ -22,7 +22,6 @@ rquickjs = { version = "0.6.2", features = [
 ], default-features = false }
 tokio = { version = "1", optional = true }
 tracing = "0.1"
-once_cell = "1.19.0"
 phf = { version = "0.11.2", features = ["macros"], optional = true }
 
 [lints.rust]

--- a/types/buffer.d.ts
+++ b/types/buffer.d.ts
@@ -184,5 +184,27 @@ declare module "buffer" {
   interface Buffer extends Uint8Array {}
   var Buffer: BufferConstructor;
 
-  export { Buffer };
+  /**
+   * Decodes a string of Base64-encoded data into bytes, and encodes those bytes
+   * into a string using UTF-8.
+   *
+   * The `data` may be any JavaScript-value that can be coerced into a string.
+   *
+   * @legacy Use `Buffer.from(data, 'base64')` instead.
+   * @param data The Base64-encoded input string.
+   */
+  function atob(data: string): string;
+
+  /**
+   * Decodes a string into bytes using UTF-8, and encodes those bytes
+   * into a string using Base64.
+   *
+   * The `data` may be any JavaScript-value that can be coerced into a string.
+   *
+   * @legacy Use `buf.toString('base64')` instead.
+   * @param data An ASCII (Latin1) string.
+   */
+  function btoa(data: string): string;
+
+  export { Buffer, atob, btoa };
 }


### PR DESCRIPTION
### Description of changes

- We dont need a separate feature flag for performance, it is part of the same module for node.
- Flag should respect the naming convention
- New modules should be added to the README
- Dependencies should be marked optional and enabled in feature flag whenever possible
- Move the `atob` and `btoa` legacy methods to buffer

Once we have a better module trait, we should merge `performance.rs` and `perf_hooks.rs`.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
