### PR TITLE
feat: implement zlib module

### DIFF
--- a/API.md
+++ b/API.md
@@ -296,16 +296,6 @@ export class URLSearchParams {
 
 [brotliDecompressSync](https://nodejs.org/api/zlib.html#zlibbrotlidecompresssyncbuffer-options)
 
-
-> [!NOTE]
-> The following functions are LLRT's own implementation of Zstandard format compression/decompression.
-
-- zstandardCompress
-- zstandardCompressSync
-- zstandardDecompress
-- zstandardDecompressSync
-
-
 ## llrt:hex
 
 ```typescript

--- a/API.md
+++ b/API.md
@@ -262,6 +262,50 @@ export class URLSearchParams {
 
 [TextEncoder](https://nodejs.org/api/util.html#class-utiltextdecoder)
 
+## zlib
+
+[deflate](https://nodejs.org/api/zlib.html#zlibdeflatebuffer-options-callback)
+
+[deflateSync](https://nodejs.org/api/zlib.html#zlibdeflatesyncbuffer-options)
+
+[deflateRaw](https://nodejs.org/api/zlib.html#zlibdeflaterawbuffer-options-callback)
+
+[deflateRawSync](https://nodejs.org/api/zlib.html#zlibdeflaterawsyncbuffer-options)
+
+[gzip](https://nodejs.org/api/zlib.html#zlibgzipbuffer-options-callback)
+
+[gzipSync](https://nodejs.org/api/zlib.html#zlibgzipsyncbuffer-options)
+
+[inflate](https://nodejs.org/api/zlib.html#zlibinflatebuffer-options-callback)
+
+[inflateSync](https://nodejs.org/api/zlib.html#zlibinflatesyncbuffer-options)
+
+[inflateRaw](https://nodejs.org/api/zlib.html#zlibinflaterawbuffer-options-callback)
+
+[inflateRawSync](https://nodejs.org/api/zlib.html#zlibinflaterawsyncbuffer-options)
+
+[gunzip](https://nodejs.org/api/zlib.html#zlibgunzipbuffer-options-callback)
+
+[gunzipSync](https://nodejs.org/api/zlib.html#zlibgunzipsyncbuffer-options)
+
+[brotliCompress](https://nodejs.org/api/zlib.html#zlibbrotlicompressbuffer-options-callback)
+
+[brotliCompressSync](https://nodejs.org/api/zlib.html#zlibbrotlicompresssyncbuffer-options)
+
+[brotliDecompress](https://nodejs.org/api/zlib.html#zlibbrotlidecompressbuffer-options-callback)
+
+[brotliDecompressSync](https://nodejs.org/api/zlib.html#zlibbrotlidecompresssyncbuffer-options)
+
+
+> [!NOTE]
+> The following functions are LLRT's own implementation of Zstandard format compression/decompression.
+
+- zstandardCompress
+- zstandardCompressSync
+- zstandardDecompress
+- zstandardDecompressSync
+
+
 ## llrt:hex
 
 ```typescript

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,7 +2617,9 @@ dependencies = [
 name = "llrt_modules"
 version = "0.1.15-beta"
 dependencies = [
+ "brotlic",
  "either",
+ "flate2",
  "itoa",
  "libc",
  "llrt_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,7 +2632,6 @@ dependencies = [
  "windows-registry",
  "windows-result",
  "windows-version",
- "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,6 +2632,7 @@ dependencies = [
  "windows-registry",
  "windows-result",
  "windows-version",
+ "zstd",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The test runner also has support for filters. Using filters is as simple as addi
 | encoding      | ✔︎     | ✔︎     |
 | console       | ✔︎     | ✔︎     |
 | events        | ✔︎     | ✔︎     |
+| zlib          | ✔︎     | ✔︎     |
 | ESM           | ✔︎     | ✔︎     |
 | CJS           | ✔︎     | ✔︎     |
 | async/await   | ✔︎     | ✔︎     |

--- a/build.mjs
+++ b/build.mjs
@@ -67,6 +67,7 @@ const ES_BUILD_OPTIONS = {
     "net",
     "util",
     "url",
+    "zlib",
     "llrt:hex",
     "llrt:uuid",
     "llrt:xml",

--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -17,6 +17,7 @@ use crate::modules::{
     timers::TimersModule,
     url::UrlModule,
     util::UtilModule,
+    zlib::ZlibModule,
 };
 pub use llrt_modules::ModuleInfo;
 use rquickjs::{
@@ -94,6 +95,7 @@ impl Default for ModuleBuilder {
             .with_module(LlrtXmlModule)
             .with_module(PerfHooksModule)
             .with_global(crate::modules::perf_hooks::init)
+            .with_module(ZlibModule)
     }
 }
 

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -1,5 +1,5 @@
 pub use llrt_modules::{
-    buffer, child_process, exceptions, fs, navigator, os, path, perf_hooks, process,
+    buffer, child_process, exceptions, fs, navigator, os, path, perf_hooks, process, zlib,
 };
 
 pub mod console;

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -20,6 +20,7 @@ all = [
   "process",
   "exceptions",
   "navigator",
+  "zlib",
 ]
 
 buffer = ["llrt_utils/encoding"]
@@ -38,6 +39,8 @@ process = []
 perf-hooks = []
 navigator = []
 exceptions = []
+zlib = []
+
 __bytearray-buffer = ["tokio/sync"]
 __stream = ["buffer", "__bytearray-buffer"]
 
@@ -57,6 +60,10 @@ rquickjs = { version = "0.6", features = [
 ring = { version = "0.17", optional = true }
 tokio = { version = "1", features = ["rt", "io-util"] }
 tracing = "0.1"
+flate2 = { version = "1.0.30", features = [
+    "zlib-ng",
+], default-features = false }
+brotlic = "0.8.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -64,6 +64,7 @@ flate2 = { version = "1.0.30", features = [
     "zlib-ng",
 ], default-features = false }
 brotlic = "0.8.2"
+zstd = { version = "0.13.2", default-features = false, features = [] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -39,7 +39,7 @@ process = []
 perf-hooks = []
 navigator = []
 exceptions = []
-zlib = []
+zlib = ["flate2", "brotlic", "zstd"]
 
 __bytearray-buffer = ["tokio/sync"]
 __stream = ["buffer", "__bytearray-buffer"]
@@ -62,9 +62,9 @@ tokio = { version = "1", features = ["rt", "io-util"] }
 tracing = "0.1"
 flate2 = { version = "1.0.30", features = [
     "zlib-ng",
-], default-features = false }
-brotlic = "0.8.2"
-zstd = { version = "0.13.2", default-features = false, features = [] }
+], default-features = false, optional = true }
+brotlic = { version = "0.8.2", optional = true }
+zstd = { version = "0.13.2", default-features = false, features = [], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -39,7 +39,7 @@ process = []
 perf-hooks = []
 navigator = []
 exceptions = []
-zlib = ["flate2", "brotlic", "zstd"]
+zlib = ["flate2", "brotlic"]
 
 __bytearray-buffer = ["tokio/sync"]
 __stream = ["buffer", "__bytearray-buffer"]
@@ -64,7 +64,6 @@ flate2 = { version = "1.0.30", features = [
     "zlib-ng",
 ], default-features = false, optional = true }
 brotlic = { version = "0.8.2", optional = true }
-zstd = { version = "0.13.2", default-features = false, features = [], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/llrt_modules/README.md
+++ b/llrt_modules/README.md
@@ -65,6 +65,7 @@ async fn main() -> anyhow::Result<()> {
 | os            | ✔︎     | ⚠️           | `os`            |
 | exceptions    | ✔︎     | ⚠️           | `exceptions`    |
 | navigator     | ✔︎     | ⚠️           | `navigator`     |
+| zlib          | ✔︎     | ⚠️           | `zlib`          |
 | Other modules | ✔︎     | ✘            | N/A             |
 
 _⚠️ = partially supported_

--- a/llrt_modules/src/modules/mod.rs
+++ b/llrt_modules/src/modules/mod.rs
@@ -20,3 +20,5 @@ pub mod path;
 pub mod perf_hooks;
 #[cfg(feature = "process")]
 pub mod process;
+#[cfg(feature = "zlib")]
+pub mod zlib;

--- a/llrt_modules/src/modules/zlib.rs
+++ b/llrt_modules/src/modules/zlib.rs
@@ -61,11 +61,11 @@ macro_rules! define_async_function {
 }
 
 enum ZlibCommand {
-    Inflate,
-    InflateRaw,
-    Gzip,
     Deflate,
     DeflateRaw,
+    Gzip,
+    Inflate,
+    InflateRaw,
     Gunzip,
 }
 
@@ -93,31 +93,31 @@ fn zlib_converter<'js>(
     let mut dst: Vec<u8> = Vec::with_capacity(src.len());
 
     let _ = match command {
-        ZlibCommand::Inflate => ZlibEncoder::new(&src[..], level).read_to_end(&mut dst)?,
-        ZlibCommand::InflateRaw => DeflateEncoder::new(&src[..], level).read_to_end(&mut dst)?,
+        ZlibCommand::Deflate => ZlibEncoder::new(&src[..], level).read_to_end(&mut dst)?,
+        ZlibCommand::DeflateRaw => DeflateEncoder::new(&src[..], level).read_to_end(&mut dst)?,
         ZlibCommand::Gzip => GzEncoder::new(&src[..], level).read_to_end(&mut dst)?,
-        ZlibCommand::Deflate => ZlibDecoder::new(&src[..]).read_to_end(&mut dst)?,
-        ZlibCommand::DeflateRaw => DeflateDecoder::new(&src[..]).read_to_end(&mut dst)?,
+        ZlibCommand::Inflate => ZlibDecoder::new(&src[..]).read_to_end(&mut dst)?,
+        ZlibCommand::InflateRaw => DeflateDecoder::new(&src[..]).read_to_end(&mut dst)?,
         ZlibCommand::Gunzip => GzDecoder::new(&src[..]).read_to_end(&mut dst)?,
     };
 
     Buffer(dst).into_js(&ctx)
 }
 
-define_async_function!(inflate, zlib_converter, ZlibCommand::Inflate);
-define_sync_function!(inflate_sync, zlib_converter, ZlibCommand::Inflate);
-
-define_async_function!(inflate_raw, zlib_converter, ZlibCommand::InflateRaw);
-define_sync_function!(inflate_raw_sync, zlib_converter, ZlibCommand::InflateRaw);
-
-define_async_function!(gzip, zlib_converter, ZlibCommand::Gzip);
-define_sync_function!(gzip_sync, zlib_converter, ZlibCommand::Gzip);
-
 define_async_function!(deflate, zlib_converter, ZlibCommand::Deflate);
 define_sync_function!(deflate_sync, zlib_converter, ZlibCommand::Deflate);
 
 define_async_function!(deflate_raw, zlib_converter, ZlibCommand::DeflateRaw);
 define_sync_function!(deflate_raw_sync, zlib_converter, ZlibCommand::DeflateRaw);
+
+define_async_function!(gzip, zlib_converter, ZlibCommand::Gzip);
+define_sync_function!(gzip_sync, zlib_converter, ZlibCommand::Gzip);
+
+define_async_function!(inflate, zlib_converter, ZlibCommand::Inflate);
+define_sync_function!(inflate_sync, zlib_converter, ZlibCommand::Inflate);
+
+define_async_function!(inflate_raw, zlib_converter, ZlibCommand::InflateRaw);
+define_sync_function!(inflate_raw_sync, zlib_converter, ZlibCommand::InflateRaw);
 
 define_async_function!(gunzip, zlib_converter, ZlibCommand::Gunzip);
 define_sync_function!(gunzip_sync, zlib_converter, ZlibCommand::Gunzip);
@@ -223,20 +223,20 @@ pub struct ZlibModule;
 
 impl ModuleDef for ZlibModule {
     fn declare(declare: &Declarations) -> Result<()> {
-        declare.declare("inflate")?;
-        declare.declare("inflateSync")?;
-
-        declare.declare("inflateRaw")?;
-        declare.declare("inflateRawSync")?;
-
-        declare.declare("gzip")?;
-        declare.declare("gzipSync")?;
-
         declare.declare("deflate")?;
         declare.declare("deflateSync")?;
 
         declare.declare("deflateRaw")?;
         declare.declare("deflateRawSync")?;
+
+        declare.declare("gzip")?;
+        declare.declare("gzipSync")?;
+
+        declare.declare("inflate")?;
+        declare.declare("inflateSync")?;
+
+        declare.declare("inflateRaw")?;
+        declare.declare("inflateRawSync")?;
 
         declare.declare("gunzip")?;
         declare.declare("gunzipSync")?;
@@ -259,20 +259,20 @@ impl ModuleDef for ZlibModule {
 
     fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
         export_default(ctx, exports, |default| {
-            default.set("inflate", Func::from(inflate))?;
-            default.set("inflateSync", Func::from(inflate_sync))?;
-
-            default.set("inflateRaw", Func::from(inflate_raw))?;
-            default.set("inflateRawSync", Func::from(inflate_raw_sync))?;
-
-            default.set("gzip", Func::from(gzip))?;
-            default.set("gzipSync", Func::from(gzip_sync))?;
-
             default.set("deflate", Func::from(deflate))?;
             default.set("deflateSync", Func::from(deflate_sync))?;
 
             default.set("deflateRaw", Func::from(deflate_raw))?;
             default.set("deflateRawSync", Func::from(deflate_raw_sync))?;
+
+            default.set("gzip", Func::from(gzip))?;
+            default.set("gzipSync", Func::from(gzip_sync))?;
+
+            default.set("inflate", Func::from(inflate))?;
+            default.set("inflateSync", Func::from(inflate_sync))?;
+
+            default.set("inflateRaw", Func::from(inflate_raw))?;
+            default.set("inflateRawSync", Func::from(inflate_raw_sync))?;
 
             default.set("gunzip", Func::from(gunzip))?;
             default.set("gunzipSync", Func::from(gunzip_sync))?;

--- a/llrt_modules/src/modules/zlib.rs
+++ b/llrt_modules/src/modules/zlib.rs
@@ -1,0 +1,164 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::io::Read;
+
+use brotlic::{CompressorReader as BrotliEncoder, DecompressorReader as BrotliDecoder};
+use flate2::read::{DeflateDecoder, GzDecoder, ZlibDecoder};
+use llrt_utils::{bytes::get_array_bytes, ctx::CtxExtension, module::export_default};
+use rquickjs::function::Func;
+use rquickjs::{
+    module::{Declarations, Exports, ModuleDef},
+    Ctx, Error, Exception, FromJs, Function, IntoJs, Null, Result, Value,
+};
+
+use crate::{utils::array_buffer::ArrayBufferView, ModuleInfo};
+
+use super::buffer::Buffer;
+
+macro_rules! define_sync_function {
+    ($fn_name:ident, $converter:expr, $command:expr) => {
+        pub fn $fn_name<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<Value<'js>> {
+            $converter(ctx.clone(), value, $command)
+        }
+    };
+}
+
+macro_rules! define_async_function {
+    ($fn_name:ident, $converter:expr, $command:expr) => {
+        pub fn $fn_name<'js>(ctx: Ctx<'js>, value: Value<'js>, cb: Function<'js>) -> Result<()> {
+            ctx.clone().spawn_exit(async move {
+                match $converter(ctx.clone(), value, $command) {
+                    Ok(obj) => {
+                        () = cb.call((Null.into_js(&ctx), obj))?;
+                        Ok::<_, Error>(())
+                    },
+                    Err(err) => {
+                        () = cb.call((Exception::from_message(ctx, &err.to_string()),))?;
+                        Ok(())
+                    },
+                }
+            })?;
+            Ok(())
+        }
+    };
+}
+
+enum ZlibCommand {
+    Deflate,
+    DeflateRaw,
+    Gunzip,
+}
+
+fn zlib_converter<'js>(
+    ctx: Ctx<'js>,
+    value: Value<'js>,
+    command: ZlibCommand,
+) -> Result<Value<'js>> {
+    let src = if value.is_string() {
+        let string = value.as_string().unwrap().to_string()?;
+        string.as_bytes().to_vec()
+    } else if value.is_array() {
+        get_array_bytes(&ctx, &value, 0, None)?.unwrap()
+    } else {
+        let buffer = ArrayBufferView::from_js(&ctx, value)?;
+        buffer.as_bytes().unwrap().to_vec()
+    };
+
+    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
+
+    let _ = match command {
+        ZlibCommand::Deflate => ZlibDecoder::new(&src[..]).read_to_end(&mut dst)?,
+        ZlibCommand::DeflateRaw => DeflateDecoder::new(&src[..]).read_to_end(&mut dst)?,
+        ZlibCommand::Gunzip => GzDecoder::new(&src[..]).read_to_end(&mut dst)?,
+    };
+
+    Buffer(dst).into_js(&ctx)
+}
+
+define_sync_function!(deflate_sync, zlib_converter, ZlibCommand::Deflate);
+define_sync_function!(deflate_raw_sync, zlib_converter, ZlibCommand::DeflateRaw);
+define_sync_function!(gunzip_sync, zlib_converter, ZlibCommand::Gunzip);
+
+define_async_function!(deflate, zlib_converter, ZlibCommand::Deflate);
+define_async_function!(deflate_raw, zlib_converter, ZlibCommand::DeflateRaw);
+define_async_function!(gunzip, zlib_converter, ZlibCommand::Gunzip);
+
+enum BrotliCommand {
+    Compress,
+    Decompress,
+}
+
+fn brotli_converter<'js>(
+    ctx: Ctx<'js>,
+    value: Value<'js>,
+    command: BrotliCommand,
+) -> Result<Value<'js>> {
+    let src = if value.is_string() {
+        let string = value.as_string().unwrap().to_string()?;
+        string.as_bytes().to_vec()
+    } else if value.is_array() {
+        get_array_bytes(&ctx, &value, 0, None)?.unwrap()
+    } else {
+        let buffer = ArrayBufferView::from_js(&ctx, value)?;
+        buffer.as_bytes().unwrap().to_vec()
+    };
+
+    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
+
+    let _ = match command {
+        BrotliCommand::Compress => BrotliEncoder::new(&src[..]).read_to_end(&mut dst)?,
+        BrotliCommand::Decompress => BrotliDecoder::new(&src[..]).read_to_end(&mut dst)?,
+    };
+
+    Buffer(dst).into_js(&ctx)
+}
+
+define_sync_function!(compress_sync, brotli_converter, BrotliCommand::Compress);
+define_sync_function!(decompress_sync, brotli_converter, BrotliCommand::Decompress);
+
+define_async_function!(compress, brotli_converter, BrotliCommand::Compress);
+define_async_function!(decompress, brotli_converter, BrotliCommand::Decompress);
+
+pub struct ZlibModule;
+
+impl ModuleDef for ZlibModule {
+    fn declare(declare: &Declarations) -> Result<()> {
+        declare.declare("deflate")?;
+        declare.declare("deflateSync")?;
+        declare.declare("deflateRaw")?;
+        declare.declare("deflateRawSync")?;
+        declare.declare("gunzip")?;
+        declare.declare("gunzipSync")?;
+        declare.declare("brotliCompress")?;
+        declare.declare("brotliDecompress")?;
+        declare.declare("brotliCompressSync")?;
+        declare.declare("brotliDecompressSync")?;
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        export_default(ctx, exports, |default| {
+            default.set("deflate", Func::from(deflate))?;
+            default.set("deflateSync", Func::from(deflate_sync))?;
+            default.set("deflateRaw", Func::from(deflate_raw))?;
+            default.set("deflateRawSync", Func::from(deflate_raw_sync))?;
+            default.set("gunzip", Func::from(gunzip))?;
+            default.set("gunzipSync", Func::from(gunzip_sync))?;
+            default.set("brotliCompress", Func::from(compress))?;
+            default.set("brotliDecompress", Func::from(decompress))?;
+            default.set("brotliCompressSync", Func::from(compress_sync))?;
+            default.set("brotliDecompressSync", Func::from(decompress_sync))?;
+            Ok(())
+        })
+    }
+}
+
+impl From<ZlibModule> for ModuleInfo<ZlibModule> {
+    fn from(val: ZlibModule) -> Self {
+        ModuleInfo {
+            name: "zlib",
+            module: val,
+        }
+    }
+}

--- a/llrt_modules/src/modules/zlib.rs
+++ b/llrt_modules/src/modules/zlib.rs
@@ -151,26 +151,22 @@ fn brotli_converter<'js>(
     Buffer(dst).into_js(&ctx)
 }
 
-define_async_function!(br_compress, brotli_converter, BrotliCommand::Compress);
-define_sync_function!(br_compress_sync, brotli_converter, BrotliCommand::Compress);
+define_async_function!(br_comp, brotli_converter, BrotliCommand::Compress);
+define_sync_function!(br_comp_sync, brotli_converter, BrotliCommand::Compress);
 
-define_async_function!(br_decompress, brotli_converter, BrotliCommand::Decompress);
-define_sync_function!(
-    br_decompress_sync,
-    brotli_converter,
-    BrotliCommand::Decompress
-);
+define_async_function!(br_decomp, brotli_converter, BrotliCommand::Decompress);
+define_sync_function!(br_decomp_sync, brotli_converter, BrotliCommand::Decompress);
 
-enum ZstandardCommand {
+enum ZstdCommand {
     Compress,
     Decompress,
 }
 
-fn zstandard_converter<'js>(
+fn zstd_converter<'js>(
     ctx: Ctx<'js>,
     value: Value<'js>,
     options: Opt<Object<'js>>,
-    command: ZstandardCommand,
+    command: ZstdCommand,
 ) -> Result<Value<'js>> {
     let src = if value.is_string() {
         let string = value.as_string().unwrap().to_string()?;
@@ -190,34 +186,18 @@ fn zstandard_converter<'js>(
     let mut dst: Vec<u8> = Vec::with_capacity(src.len());
 
     let _ = match command {
-        ZstandardCommand::Compress => ZstdEncoder::new(&src[..], level)?.read_to_end(&mut dst)?,
-        ZstandardCommand::Decompress => ZstdDecoder::new(&src[..])?.read_to_end(&mut dst)?,
+        ZstdCommand::Compress => ZstdEncoder::new(&src[..], level)?.read_to_end(&mut dst)?,
+        ZstdCommand::Decompress => ZstdDecoder::new(&src[..])?.read_to_end(&mut dst)?,
     };
 
     Buffer(dst).into_js(&ctx)
 }
 
-define_async_function!(
-    zstd_compress,
-    zstandard_converter,
-    ZstandardCommand::Compress
-);
-define_sync_function!(
-    zstd_compress_sync,
-    zstandard_converter,
-    ZstandardCommand::Compress
-);
+define_async_function!(zstd_comp, zstd_converter, ZstdCommand::Compress);
+define_sync_function!(zstd_comp_sync, zstd_converter, ZstdCommand::Compress);
 
-define_async_function!(
-    zstd_decompress,
-    zstandard_converter,
-    ZstandardCommand::Decompress
-);
-define_sync_function!(
-    zstd_decompress_sync,
-    zstandard_converter,
-    ZstandardCommand::Decompress
-);
+define_async_function!(zstd_decomp, zstd_converter, ZstdCommand::Decompress);
+define_sync_function!(zstd_decomp_sync, zstd_converter, ZstdCommand::Decompress);
 
 pub struct ZlibModule;
 
@@ -277,17 +257,17 @@ impl ModuleDef for ZlibModule {
             default.set("gunzip", Func::from(gunzip))?;
             default.set("gunzipSync", Func::from(gunzip_sync))?;
 
-            default.set("brotliCompress", Func::from(br_compress))?;
-            default.set("brotliCompressSync", Func::from(br_compress_sync))?;
+            default.set("brotliCompress", Func::from(br_comp))?;
+            default.set("brotliCompressSync", Func::from(br_comp_sync))?;
 
-            default.set("brotliDecompress", Func::from(br_decompress))?;
-            default.set("brotliDecompressSync", Func::from(br_decompress_sync))?;
+            default.set("brotliDecompress", Func::from(br_decomp))?;
+            default.set("brotliDecompressSync", Func::from(br_decomp_sync))?;
 
-            default.set("zstandardCompress", Func::from(zstd_compress))?;
-            default.set("zstandardCompressSync", Func::from(zstd_compress_sync))?;
+            default.set("zstandardCompress", Func::from(zstd_comp))?;
+            default.set("zstandardCompressSync", Func::from(zstd_comp_sync))?;
 
-            default.set("zstandardDecompress", Func::from(zstd_decompress))?;
-            default.set("zstandardDecompressSync", Func::from(zstd_decompress_sync))?;
+            default.set("zstandardDecompress", Func::from(zstd_decomp))?;
+            default.set("zstandardDecompressSync", Func::from(zstd_decomp_sync))?;
 
             Ok(())
         })

--- a/tests/unit/zlib.test.ts
+++ b/tests/unit/zlib.test.ts
@@ -1,0 +1,82 @@
+const zlib = require("zlib");
+const data = "Hello LLRT!!";
+
+describe("deflate/inflate", () => {
+  it("deflate/inflate", (done) => {
+    zlib.deflate(data, (err, compressed) => {
+      zlib.inflate(compressed, (err, decompressed) => {
+        expect(data).toEqual(decompressed.toString());
+        done();
+      });
+    });
+  });
+  it("deflateSync/inflateSync", () => {
+    const compressed = zlib.deflateSync(data);
+    const decompressed = zlib.inflateSync(compressed);
+    expect(data).toEqual(decompressed.toString());
+  });
+});
+
+describe("deflateRaw/inflateRaw", () => {
+  it("deflateRaw/inflateRaw", (done) => {
+    zlib.deflateRaw(data, (err, compressed) => {
+      zlib.inflateRaw(compressed, (err, decompressed) => {
+        expect(data).toEqual(decompressed.toString());
+        done();
+      });
+    });
+  });
+  it("deflateRawSync/inflateRawSync", () => {
+    const compressed = zlib.deflateRawSync(data);
+    const decompressed = zlib.inflateRawSync(compressed);
+    expect(data).toEqual(decompressed.toString());
+  });
+});
+
+describe("gzip/gunzip", () => {
+  it("gzip/gunzip", (done) => {
+    zlib.gzip(data, (err, compressed) => {
+      zlib.gunzip(compressed, (err, decompressed) => {
+        expect(data).toEqual(decompressed.toString());
+        done();
+      });
+    });
+  });
+  it("gzipSync/gunzipSync", () => {
+    const compressed = zlib.gzipSync(data);
+    const decompressed = zlib.gunzipSync(compressed);
+    expect(data).toEqual(decompressed.toString());
+  });
+});
+
+describe("brotli", () => {
+  it("brotliCompress/brotliDecompress", (done) => {
+    zlib.brotliCompress(data, (err, compressed) => {
+      zlib.brotliDecompress(compressed, (err, decompressed) => {
+        expect(data).toEqual(decompressed.toString());
+        done();
+      });
+    });
+  });
+  it("brotliCompressSync/brotliDecompressSync", () => {
+    const compressed = zlib.brotliCompressSync(data);
+    const decompressed = zlib.brotliDecompressSync(compressed);
+    expect(data).toEqual(decompressed.toString());
+  });
+});
+
+describe("zstandard", () => {
+  it("zstandardCompress/zstandardDecompress", (done) => {
+    zlib.zstandardCompress(data, (err, compressed) => {
+      zlib.zstandardDecompress(compressed, (err, decompressed) => {
+        expect(data).toEqual(decompressed.toString());
+        done();
+      });
+    });
+  });
+  it("zstandardCompressSync/zstandardDecompressSync", () => {
+    const compressed = zlib.zstandardCompressSync(data);
+    const decompressed = zlib.zstandardDecompressSync(compressed);
+    expect(data).toEqual(decompressed.toString());
+  });
+});

--- a/tests/unit/zlib.test.ts
+++ b/tests/unit/zlib.test.ts
@@ -64,19 +64,3 @@ describe("brotli", () => {
     expect(data).toEqual(decompressed.toString());
   });
 });
-
-describe("zstandard", () => {
-  it("zstandardCompress/zstandardDecompress", (done) => {
-    zlib.zstandardCompress(data, (err, compressed) => {
-      zlib.zstandardDecompress(compressed, (err, decompressed) => {
-        expect(data).toEqual(decompressed.toString());
-        done();
-      });
-    });
-  });
-  it("zstandardCompressSync/zstandardDecompressSync", () => {
-    const compressed = zlib.zstandardCompressSync(data);
-    const decompressed = zlib.zstandardDecompressSync(compressed);
-    expect(data).toEqual(decompressed.toString());
-  });
-});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,3 +12,4 @@
 /// <reference types="./perf_hooks.d.ts" />
 /// <reference types="./exceptions.d.ts" />
 /// <reference types="./navigator.d.ts" />
+/// <reference types="./zlib.d.ts" />

--- a/types/zlib.d.ts
+++ b/types/zlib.d.ts
@@ -1,0 +1,148 @@
+/**
+ * The `zlib` module provides compression functionality implemented using
+ * Gzip, Deflate/Inflate, Brotli and Zstandard.
+ *
+ * To access it:
+ *
+ * ```js
+ * const zlib = require('zlib');
+ * ```
+ *
+ * It is possible to compress or decompress data in a single step:
+ *
+ * ```js
+ * const { deflate, unzip } = require('zlib');
+ *
+ * const input = '.................................';
+ * deflate(input, (err, buffer) => {
+ *   if (err) {
+ *     console.error('An error occurred:', err);
+ *     process.exitCode = 1;
+ *   }
+ *   console.log(buffer.toString('base64'));
+ * });
+ *
+ * const buffer = Buffer.from('eJzT0yMAAGTvBe8=', 'base64');
+ * unzip(buffer, (err, buffer) => {
+ *   if (err) {
+ *     console.error('An error occurred:', err);
+ *     process.exitCode = 1;
+ *   }
+ *   console.log(buffer.toString());
+ * });
+ *
+ * ```
+ */
+declare module "zlib" {
+    import { Buffer } from "buffer";
+
+    interface ZlibOptions {
+        level?: number | undefined; // compression only
+    }
+    interface ZstandardOptions {
+        level?: number | undefined; // compression only
+    }
+    type InputType = string | ArrayBuffer | QuickJS.ArrayBufferView;
+    type CompressCallback = (error: Error | null, result: Buffer) => void;
+
+    /**
+     * Compress a chunk of data with `Deflate`.
+     */
+    function deflate(buf: InputType, callback: CompressCallback): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    /**
+     * Compress a chunk of data with `Deflate`.
+     */
+    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+
+    /**
+     * Compress a chunk of data with `DeflateRaw`.
+     */
+    function deflateRaw(buf: InputType, callback: CompressCallback): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    /**
+     * Compress a chunk of data with `DeflateRaw`.
+     */
+    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+
+    /**
+     * Compress a chunk of data with `Gzip`.
+     */
+    function gzip(buf: InputType, callback: CompressCallback): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    /**
+     * Compress a chunk of data with `Gzip`.
+     */
+    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+
+    /**
+     * Decompress a chunk of data with `Inflate`.
+     */
+    function inflate(buf: InputType, callback: CompressCallback): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    /**
+     * Decompress a chunk of data with `Inflate`.
+     */
+    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+
+    /**
+     * Decompress a chunk of data with `InflateRaw`.
+     */
+    function inflateRaw(buf: InputType, callback: CompressCallback): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    /**
+     * Decompress a chunk of data with `InflateRaw`.
+     */
+    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+
+    /**
+     * Decompress a chunk of data with `Gunzip`.
+     */
+    function gunzip(buf: InputType, callback: CompressCallback): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
+    /**
+     * Decompress a chunk of data with `Gunzip`.
+     */
+    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+
+    /**
+     * Compress a chunk of data with `BrotliCompress`.
+     */
+    function brotliCompress(buf: InputType, callback: CompressCallback): void;
+    /**
+     * Compress a chunk of data with `BrotliCompress`.
+     */
+    function brotliCompressSync(buf: InputType): Buffer;
+
+    /**
+     * Decompress a chunk of data with `BrotliDecompress`.
+     */
+    function brotliDecompress(buf: InputType, callback: CompressCallback): void;
+    /**
+     * Decompress a chunk of data with `BrotliDecompress`.
+     */
+    function brotliDecompressSync(buf: InputType): Buffer;
+
+    /**
+     * Compress a chunk of data with `ZstandardCompress`.
+     */
+    function zstandardCompress(buf: InputType, callback: CompressCallback): void;
+    function zstandardCompress(buf: InputType, options: ZstandardOptions, callback: CompressCallback): void;
+    /**
+     * Compress a chunk of data with `ZstandardCompress`.
+     */
+    function zstandardCompressSync(buf: InputType, options?: ZstandardOptions): Buffer;
+
+    /**
+     * Decompress a chunk of data with `ZstandardDecompress`.
+     */
+    function zstandardDecompress(buf: InputType, callback: CompressCallback): void;
+    function zstandardDecompress(buf: InputType, options: ZstandardOptions, callback: CompressCallback): void;
+    /**
+     * Decompress a chunk of data with `ZstandardDecompress`.
+     */
+    function zstandardDecompressSync(buf: InputType, options?: ZstandardOptions): Buffer;
+}
+declare module "node:zlib" {
+    export * from "zlib";
+}

--- a/types/zlib.d.ts
+++ b/types/zlib.d.ts
@@ -146,38 +146,4 @@ declare module "zlib" {
    * Decompress a chunk of data with `BrotliDecompress`.
    */
   function brotliDecompressSync(buf: InputType): Buffer;
-
-  /**
-   * Compress a chunk of data with `ZstandardCompress`.
-   */
-  function zstandardCompress(buf: InputType, callback: CompressCallback): void;
-  function zstandardCompress(
-    buf: InputType,
-    options: ZstdOptions,
-    callback: CompressCallback
-  ): void;
-  /**
-   * Compress a chunk of data with `ZstandardCompress`.
-   */
-  function zstandardCompressSync(buf: InputType, options?: ZstdOptions): Buffer;
-
-  /**
-   * Decompress a chunk of data with `ZstandardDecompress`.
-   */
-  function zstandardDecompress(
-    buf: InputType,
-    callback: CompressCallback
-  ): void;
-  function zstandardDecompress(
-    buf: InputType,
-    options: ZstdOptions,
-    callback: CompressCallback
-  ): void;
-  /**
-   * Decompress a chunk of data with `ZstandardDecompress`.
-   */
-  function zstandardDecompressSync(
-    buf: InputType,
-    options?: ZstdOptions
-  ): Buffer;
 }

--- a/types/zlib.d.ts
+++ b/types/zlib.d.ts
@@ -5,16 +5,16 @@
  * To access it:
  *
  * ```js
- * const zlib = require('zlib');
+ * import * as zlib from 'zlib';
  * ```
  *
  * It is possible to compress or decompress data in a single step:
  *
  * ```js
- * const { deflate, unzip } = require('zlib');
+ * mport * as zlib from 'zlib';
  *
  * const input = '.................................';
- * deflate(input, (err, buffer) => {
+ * zlib.deflate(input, (err, buffer) => {
  *   if (err) {
  *     console.error('An error occurred:', err);
  *     process.exitCode = 1;
@@ -22,8 +22,8 @@
  *   console.log(buffer.toString('base64'));
  * });
  *
- * const buffer = Buffer.from('eJzT0yMAAGTvBe8=', 'base64');
- * unzip(buffer, (err, buffer) => {
+ * const buffer = Buffer.from('CwWASGVsbG8gV29ybGQD', 'base64');
+ * zlib.brotliDecompress(buffer, (err, buffer) => {
  *   if (err) {
  *     console.error('An error occurred:', err);
  *     process.exitCode = 1;

--- a/types/zlib.d.ts
+++ b/types/zlib.d.ts
@@ -143,6 +143,3 @@ declare module "zlib" {
      */
     function zstandardDecompressSync(buf: InputType, options?: ZstandardOptions): Buffer;
 }
-declare module "node:zlib" {
-    export * from "zlib";
-}

--- a/types/zlib.d.ts
+++ b/types/zlib.d.ts
@@ -34,112 +34,150 @@
  * ```
  */
 declare module "zlib" {
-    import { Buffer } from "buffer";
+  import { Buffer } from "buffer";
 
-    interface ZlibOptions {
-        level?: number | undefined; // compression only
-    }
-    interface ZstandardOptions {
-        level?: number | undefined; // compression only
-    }
-    type InputType = string | ArrayBuffer | QuickJS.ArrayBufferView;
-    type CompressCallback = (error: Error | null, result: Buffer) => void;
+  interface ZlibOptions {
+    level?: number | undefined; // compression only
+  }
+  interface ZstdOptions {
+    level?: number | undefined; // compression only
+  }
+  type InputType = string | ArrayBuffer | QuickJS.ArrayBufferView;
+  type CompressCallback = (error: Error | null, result: Buffer) => void;
 
-    /**
-     * Compress a chunk of data with `Deflate`.
-     */
-    function deflate(buf: InputType, callback: CompressCallback): void;
-    function deflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
-    /**
-     * Compress a chunk of data with `Deflate`.
-     */
-    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+  /**
+   * Compress a chunk of data with `Deflate`.
+   */
+  function deflate(buf: InputType, callback: CompressCallback): void;
+  function deflate(
+    buf: InputType,
+    options: ZlibOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Compress a chunk of data with `Deflate`.
+   */
+  function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
 
-    /**
-     * Compress a chunk of data with `DeflateRaw`.
-     */
-    function deflateRaw(buf: InputType, callback: CompressCallback): void;
-    function deflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
-    /**
-     * Compress a chunk of data with `DeflateRaw`.
-     */
-    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+  /**
+   * Compress a chunk of data with `DeflateRaw`.
+   */
+  function deflateRaw(buf: InputType, callback: CompressCallback): void;
+  function deflateRaw(
+    buf: InputType,
+    options: ZlibOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Compress a chunk of data with `DeflateRaw`.
+   */
+  function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
 
-    /**
-     * Compress a chunk of data with `Gzip`.
-     */
-    function gzip(buf: InputType, callback: CompressCallback): void;
-    function gzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
-    /**
-     * Compress a chunk of data with `Gzip`.
-     */
-    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+  /**
+   * Compress a chunk of data with `Gzip`.
+   */
+  function gzip(buf: InputType, callback: CompressCallback): void;
+  function gzip(
+    buf: InputType,
+    options: ZlibOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Compress a chunk of data with `Gzip`.
+   */
+  function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
 
-    /**
-     * Decompress a chunk of data with `Inflate`.
-     */
-    function inflate(buf: InputType, callback: CompressCallback): void;
-    function inflate(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
-    /**
-     * Decompress a chunk of data with `Inflate`.
-     */
-    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+  /**
+   * Decompress a chunk of data with `Inflate`.
+   */
+  function inflate(buf: InputType, callback: CompressCallback): void;
+  function inflate(
+    buf: InputType,
+    options: ZlibOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Decompress a chunk of data with `Inflate`.
+   */
+  function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
 
-    /**
-     * Decompress a chunk of data with `InflateRaw`.
-     */
-    function inflateRaw(buf: InputType, callback: CompressCallback): void;
-    function inflateRaw(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
-    /**
-     * Decompress a chunk of data with `InflateRaw`.
-     */
-    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+  /**
+   * Decompress a chunk of data with `InflateRaw`.
+   */
+  function inflateRaw(buf: InputType, callback: CompressCallback): void;
+  function inflateRaw(
+    buf: InputType,
+    options: ZlibOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Decompress a chunk of data with `InflateRaw`.
+   */
+  function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
 
-    /**
-     * Decompress a chunk of data with `Gunzip`.
-     */
-    function gunzip(buf: InputType, callback: CompressCallback): void;
-    function gunzip(buf: InputType, options: ZlibOptions, callback: CompressCallback): void;
-    /**
-     * Decompress a chunk of data with `Gunzip`.
-     */
-    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+  /**
+   * Decompress a chunk of data with `Gunzip`.
+   */
+  function gunzip(buf: InputType, callback: CompressCallback): void;
+  function gunzip(
+    buf: InputType,
+    options: ZlibOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Decompress a chunk of data with `Gunzip`.
+   */
+  function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
 
-    /**
-     * Compress a chunk of data with `BrotliCompress`.
-     */
-    function brotliCompress(buf: InputType, callback: CompressCallback): void;
-    /**
-     * Compress a chunk of data with `BrotliCompress`.
-     */
-    function brotliCompressSync(buf: InputType): Buffer;
+  /**
+   * Compress a chunk of data with `BrotliCompress`.
+   */
+  function brotliCompress(buf: InputType, callback: CompressCallback): void;
+  /**
+   * Compress a chunk of data with `BrotliCompress`.
+   */
+  function brotliCompressSync(buf: InputType): Buffer;
 
-    /**
-     * Decompress a chunk of data with `BrotliDecompress`.
-     */
-    function brotliDecompress(buf: InputType, callback: CompressCallback): void;
-    /**
-     * Decompress a chunk of data with `BrotliDecompress`.
-     */
-    function brotliDecompressSync(buf: InputType): Buffer;
+  /**
+   * Decompress a chunk of data with `BrotliDecompress`.
+   */
+  function brotliDecompress(buf: InputType, callback: CompressCallback): void;
+  /**
+   * Decompress a chunk of data with `BrotliDecompress`.
+   */
+  function brotliDecompressSync(buf: InputType): Buffer;
 
-    /**
-     * Compress a chunk of data with `ZstandardCompress`.
-     */
-    function zstandardCompress(buf: InputType, callback: CompressCallback): void;
-    function zstandardCompress(buf: InputType, options: ZstandardOptions, callback: CompressCallback): void;
-    /**
-     * Compress a chunk of data with `ZstandardCompress`.
-     */
-    function zstandardCompressSync(buf: InputType, options?: ZstandardOptions): Buffer;
+  /**
+   * Compress a chunk of data with `ZstandardCompress`.
+   */
+  function zstandardCompress(buf: InputType, callback: CompressCallback): void;
+  function zstandardCompress(
+    buf: InputType,
+    options: ZstdOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Compress a chunk of data with `ZstandardCompress`.
+   */
+  function zstandardCompressSync(buf: InputType, options?: ZstdOptions): Buffer;
 
-    /**
-     * Decompress a chunk of data with `ZstandardDecompress`.
-     */
-    function zstandardDecompress(buf: InputType, callback: CompressCallback): void;
-    function zstandardDecompress(buf: InputType, options: ZstandardOptions, callback: CompressCallback): void;
-    /**
-     * Decompress a chunk of data with `ZstandardDecompress`.
-     */
-    function zstandardDecompressSync(buf: InputType, options?: ZstandardOptions): Buffer;
+  /**
+   * Decompress a chunk of data with `ZstandardDecompress`.
+   */
+  function zstandardDecompress(
+    buf: InputType,
+    callback: CompressCallback
+  ): void;
+  function zstandardDecompress(
+    buf: InputType,
+    options: ZstdOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Decompress a chunk of data with `ZstandardDecompress`.
+   */
+  function zstandardDecompressSync(
+    buf: InputType,
+    options?: ZstdOptions
+  ): Buffer;
 }


### PR DESCRIPTION
### Description of changes

Implement a portion of the Node.js zlib module ([Convenience methods](https://nodejs.org/api/zlib.html#convenience-methods)).

It is still rough around the edges at this point and some TODOs remain.

- ~Need to support more than just Brotli.~
All except unzip/unzipSync are now supported.
- ~Options also need to be supported as much as possible.~
For the time being, only the compression level has been addressed.
- ~Types/Tests/Docs also.~
All have been addressed.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
