### PR TITLE
Implement uuid.MAX, uuid.v1ToV6(), uuid.V6(), uuid.v6ToV1(), uuid.V7()

### DIFF
--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -39,6 +39,8 @@ uuid = { version = "1.10.0", default-features = false, features = [
     "v3",
     "v4",
     "v5",
+    "v6",
+    "v7",
     "fast-rng",
 ] }
 once_cell = "1.19.0"

--- a/tests/unit/uuid.test.ts
+++ b/tests/unit/uuid.test.ts
@@ -4,10 +4,15 @@ import {
   v3 as uuidv3,
   v4 as uuidv4,
   v5 as uuidv5,
+  v6 as uuidv6,
+  v7 as uuidv7,
+  v1ToV6 as uuidv1ToV6,
+  v6ToV1 as uuidv6ToV1,
   parse,
   stringify,
   validate,
   NIL,
+  MAX,
   version,
 } from "llrt:uuid";
 
@@ -47,6 +52,35 @@ describe("UUID Generation", () => {
     expect(version(uuid)).toEqual(5);
   });
 
+  it("should generate a valid v6 UUID", () => {
+    const uuid = uuidv6();
+    expect(typeof uuid).toEqual("string");
+    expect(uuid.length).toEqual(36);
+    expect(uuid).toMatch(UUID_PATTERN);
+    expect(version(uuid)).toEqual(6);
+  })
+
+  it("should generate a valid v7 UUID", () => {
+    const uuid = uuidv7();
+    expect(typeof uuid).toEqual("string");
+    expect(uuid.length).toEqual(36);
+    expect(uuid).toMatch(UUID_PATTERN);
+    expect(version(uuid)).toEqual(7);
+  })
+
+  it("should convert v1 -> v6 and vice versa", () => {
+    const v1 = "f4df6856-5238-11ef-a311-d4807f27f0c6"
+    const v6 = "1ef5238f-4df6-6856-a311-d4807f27f0c6"
+    
+    const convertedv6 = uuidv1ToV6(v1)
+    expect(convertedv6).toEqual(v6)
+    expect(version(convertedv6)).toEqual(6)
+
+    const convertedv1 = uuidv6ToV1(convertedv6)
+    expect(convertedv1).toEqual(v1)
+    expect(version(convertedv1)).toEqual(1)
+  })
+
   it("should parse and stringify a UUID", () => {
     const uuid = uuidv1();
     const parsedUuid = parse(uuid);
@@ -71,15 +105,26 @@ describe("UUID Generation", () => {
     expect(version(nilUuid)).toEqual(0);
   });
 
+  it("should generate a MAX UUID", () => {
+    const maxUuid = MAX;
+    expect(maxUuid).toEqual("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    expect(version(maxUuid)).toEqual(15);
+  });
+
   it("should return correct versions", () => {
     const v1 = uuidv1();
     const v3 = uuidv3("hello", uuidv3.URL);
     const v4 = uuidv4();
     const v5 = uuidv5("hello", uuidv3.URL);
+    const v6 = uuidv6();
+    const v7 = uuidv7();
     expect(version(v1)).toEqual(1);
     expect(version(v3)).toEqual(3);
     expect(version(v4)).toEqual(4);
     expect(version(v5)).toEqual(5);
+    expect(version(v6)).toEqual(6);
+    expect(version(v7)).toEqual(7);
     expect(version(NIL)).toEqual(0);
+    expect(version(MAX)).toEqual(15);
   });
 });


### PR DESCRIPTION
### Issue

Closes #485 

### Description of changes

Implement the following methods on the `llrt:uuid` package:
- uuid.MAX
- uuid.v1ToV6()
- uuid.V6()
- uuid.v6ToV1()
- uuid.V7()

The goal is to achieve greater compatibility with the existing Node.js package: https://github.com/uuidjs/uuid

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in types/ directory
- [ ] Updated documentation if needed ([API.md](https://github.com/awslabs/llrt/pull/API.md)/[README.md](https://github.com/awslabs/llrt/pull/README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
