### PR TITLE
Rework time management & remove inter module dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,7 +2617,6 @@ dependencies = [
 name = "llrt_modules"
 version = "0.1.15-beta"
 dependencies = [
- "chrono",
  "either",
  "itoa",
  "libc",

--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -13,7 +13,6 @@ use crate::modules::{
     os::OsModule,
     path::PathModule,
     perf_hooks::PerfHooksModule,
-    performance,
     process::ProcessModule,
     timers::TimersModule,
     url::UrlModule,
@@ -88,13 +87,13 @@ impl Default for ModuleBuilder {
             .with_global(crate::modules::process::init)
             .with_global(crate::modules::navigator::init)
             .with_module(UrlModule)
-            .with_global(performance::init)
             .with_global(crate::modules::http::init)
             .with_global(crate::modules::exceptions::init)
             .with_module(LlrtHexModule)
             .with_module(LlrtUuidModule)
             .with_module(LlrtXmlModule)
             .with_module(PerfHooksModule)
+            .with_global(crate::modules::perf_hooks::init)
     }
 }
 

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -1,4 +1,4 @@
-pub use llrt_modules::{buffer, child_process, fs, os, path, perf_hooks, performance, process};
+pub use llrt_modules::{buffer, child_process, fs, os, path, perf_hooks, process};
 
 pub mod console;
 pub mod crypto;

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -362,7 +362,7 @@ impl Vm {
     pub async fn from_options(
         vm_options: VmOptions,
     ) -> StdResult<Self, Box<dyn std::error::Error + Send + Sync>> {
-        llrt_modules::perf_hooks::init();
+        llrt_modules::time::init();
 
         SYSTEM_RANDOM
             .fill(&mut [0; 8])

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -25,7 +25,6 @@ child-process = ["events", "__stream", "itoa"]
 events = []
 fs = ["tokio/fs", "llrt_utils/fs", "ring", "buffer", "path"]
 os = [
-  "process",
   "libc",
   "windows-result",
   "windows-registry",
@@ -34,16 +33,12 @@ os = [
 ]
 path = []
 process = []
-perf-hooks = ["chrono"]
+perf-hooks = []
 
 __bytearray-buffer = ["tokio/sync"]
 __stream = ["buffer", "__bytearray-buffer"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = [
-  "std",
-  "now",
-], optional = true }
 either = "1"
 itoa = { version = "1", optional = true }
 once_cell = { version = "1", optional = true }

--- a/llrt_modules/src/lib.rs
+++ b/llrt_modules/src/lib.rs
@@ -3,16 +3,15 @@
 #![allow(clippy::new_without_default)]
 pub use self::module_info::ModuleInfo;
 pub use self::modules::*;
-use std::sync::atomic::AtomicUsize;
 
 mod module_info;
 mod modules;
 #[cfg(feature = "__stream")]
 pub mod stream;
+mod sysinfo;
 #[cfg(test)]
 mod test;
+pub mod time;
 mod utils;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-pub static TIME_ORIGIN: AtomicUsize = AtomicUsize::new(0);

--- a/llrt_modules/src/modules/mod.rs
+++ b/llrt_modules/src/modules/mod.rs
@@ -14,7 +14,5 @@ pub mod os;
 pub mod path;
 #[cfg(feature = "perf-hooks")]
 pub mod perf_hooks;
-#[cfg(feature = "perf-hooks")]
-pub mod performance;
 #[cfg(feature = "process")]
 pub mod process;

--- a/llrt_modules/src/modules/os/mod.rs
+++ b/llrt_modules/src/modules/os/mod.rs
@@ -14,7 +14,7 @@ use self::unix::{get_release, get_type, get_version};
 #[cfg(windows)]
 use self::windows::{get_release, get_type, get_version};
 use crate::module_info::ModuleInfo;
-use crate::process::get_platform;
+use crate::sysinfo::get_platform;
 
 #[cfg(unix)]
 mod unix;

--- a/llrt_modules/src/modules/performance.rs
+++ b/llrt_modules/src/modules/performance.rs
@@ -1,9 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-use crate::perf_hooks::new_performance;
-use rquickjs::{Ctx, Result};
-
-pub fn init(ctx: &Ctx<'_>) -> Result<()> {
-    new_performance(ctx.clone())?;
-    Ok(())
-}

--- a/llrt_modules/src/sysinfo.rs
+++ b/llrt_modules/src/sysinfo.rs
@@ -1,0 +1,22 @@
+use std::env;
+
+pub fn get_platform() -> &'static str {
+    let platform = env::consts::OS;
+    match platform {
+        "macos" => "darwin",
+        "windows" => "win32",
+        _ => platform,
+    }
+}
+
+pub fn get_arch() -> &'static str {
+    let arch = env::consts::ARCH;
+
+    match arch {
+        "x86_64" | "x86" => return "x64",
+        "aarch64" => return "arm64",
+        _ => (),
+    }
+
+    arch
+}

--- a/llrt_modules/src/time.rs
+++ b/llrt_modules/src/time.rs
@@ -1,0 +1,26 @@
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::SystemTime,
+};
+
+pub(crate) static TIME_ORIGIN: AtomicU64 = AtomicU64::new(0);
+
+/// Get the current time in nanoseconds.
+///
+/// # Safety
+/// - Good until the year 2554
+/// - Always use a checked substraction since this can return 0
+pub(crate) fn now_nanos() -> u64 {
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64
+}
+
+// For accuracy reasons, this function should be executed when the vm is initialized
+pub fn init() {
+    if TIME_ORIGIN.load(Ordering::Relaxed) == 0 {
+        let time_origin = now_nanos();
+        TIME_ORIGIN.store(time_origin, Ordering::Relaxed)
+    }
+}

--- a/types/process.d.ts
+++ b/types/process.d.ts
@@ -27,7 +27,12 @@ declare module "process" {
   // Alias for compatibility
   interface ProcessEnv extends Dict<string> {}
   interface HRTime {
-    (time?: [number, number]): [number, number];
+    (): [number, number];
+
+    /**
+     * The `bigint` version of the `{@link process.hrtime()}` method returning the current high-resolution real time in nanoseconds as a `bigint`.
+     */
+    bigint(): bigint;
   }
   interface ProcessRelease {
     name: string;


### PR DESCRIPTION
### Description of changes

- Remove `os` dependency on `process`
- Remove `chrono` (using `SystemTime`)
- Remove `performance` (merged into `perf_hooks`)
- Rework time to be independent of `perf_hook`
- Switched `TIME_ORIGIN` to an `AtomicU64` and removed casting (ensuring i686 works correctly) 

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
