### PR TITLE
llrt_core: delay should be optional

### DIFF
--- a/llrt_core/src/modules/timers.rs
+++ b/llrt_core/src/modules/timers.rs
@@ -12,7 +12,7 @@ use std::{
 use once_cell::sync::Lazy;
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
-    prelude::Func,
+    prelude::{Func, Opt},
     qjs, CatchResultExt, Ctx, Function, Persistent, Result, Value,
 };
 
@@ -168,12 +168,18 @@ pub fn init_timers(ctx: &Ctx<'_>) -> Result<()> {
 
     globals.set(
         "setTimeout",
-        Func::from(move |ctx, cb, delay| set_timeout_interval(&ctx, cb, delay, false)),
+        Func::from(move |ctx, cb, delay: Opt<f64>| {
+            let delay = delay.unwrap_or(0.).max(0.) as usize;
+            set_timeout_interval(&ctx, cb, delay, false)
+        }),
     )?;
 
     globals.set(
         "setInterval",
-        Func::from(move |ctx, cb, delay| set_timeout_interval(&ctx, cb, delay, true)),
+        Func::from(move |ctx, cb, delay: Opt<f64>| {
+            let delay = delay.unwrap_or(0.).max(0.) as usize;
+            set_timeout_interval(&ctx, cb, delay, true)
+        }),
     )?;
 
     globals.set(

--- a/tests/unit/timers.test.ts
+++ b/tests/unit/timers.test.ts
@@ -76,4 +76,22 @@ describe("timers", () => {
   it("should import timers", () => {
     expect(timers.setTimeout).toEqual(setTimeout)
   });
+
+  it("delay is optional", async () => {
+    const start = Date.now();
+    await new Promise((resolve) => {
+      setTimeout(resolve);
+    });
+    const end = Date.now();
+    expect(end - start >= 0).toBeTruthy();
+  });
+
+  it("delay can be negative.", async () => {
+    const start = Date.now();
+    await new Promise((resolve) => {
+      setTimeout(resolve, -1);
+    });
+    const end = Date.now();
+    expect(end - start >= 0).toBeTruthy();
+  });
 });


### PR DESCRIPTION
### Description of changes

The delay parameter is optional and can be negative.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

