### PR TITLE
chore: Correction of target version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ ENV LAMBDA_HANDLER "app.handler"
 CMD [ "llrt" ]
 ```
 
-That's it 🎉
-
-> [!IMPORTANT]
-> Even though LLRT supports [ES2020](https://262.ecma-international.org/11.0/) it's **NOT** a drop in replacement for Node.js. Consult [Compatibility matrix](#compatibility-matrix) and [API](API.md) for more details.
-> All dependencies should be bundled for a `browser` platform and mark included `@aws-sdk` packages as external.
-
 ### Option 4: AWS SAM
 
 The following [example project](example/llrt-sam/) sets up a lambda
@@ -67,6 +61,12 @@ const handler = new LlrtFunction(this, "Handler", {
 ```
 
 See [Construct Hub](https://constructs.dev/packages/cdk-lambda-llrt/) and [its examples](https://github.com/tmokmss/cdk-lambda-llrt/tree/main/example) for more details.
+
+That's it 🎉
+
+> [!IMPORTANT]
+> Even though LLRT supports [ES2023](https://262.ecma-international.org/14.0/) it's **NOT** a drop in replacement for Node.js. Consult [Compatibility matrix](#compatibility-matrix) and [API](API.md) for more details.
+> All dependencies should be bundled for a `browser` platform and mark included `@aws-sdk` packages as external.
 
 ## Testing & ensuring compatibility
 
@@ -141,13 +141,13 @@ LLRT can work with any bundler of your choice. Below are some configurations for
 
 | Node.js         | LLRT      |
 | --------------- | --------- |
-| fast-xml-parser | llrt:xml  | 
+| fast-xml-parser | llrt:xml  |
 | uuid            | llrt:uuid |
 
 ### ESBuild
 
 ```shell
-esbuild index.js --platform=node --target=es2020 --format=esm --bundle --minify --external:@aws-sdk --external:@smithy
+esbuild index.js --platform=node --target=es2023 --format=esm --bundle --minify --external:@aws-sdk --external:@smithy
 ```
 
 ### Rollup
@@ -163,7 +163,7 @@ export default {
     file: "dist/bundle.js",
     format: "esm",
     sourcemap: true,
-    target: "es2020",
+    target: "es2023",
   },
   plugins: [resolve(), commonjs(), terser()],
   external: ["@aws-sdk", "@smithy"],
@@ -207,7 +207,7 @@ export default {
 LLRT includes many AWS SDK clients and utils as part of the runtime, built into the executable. These SDK Clients have been specifically fine-tuned to offer best performance while not compromising on compatibility. LLRT replaces some JavaScript dependencies used by the AWS SDK by native ones such as Hash calculations and XML parsing.
 V3 SDK packages not included in the list below have to be bundled with your source code. For an example on how to use a non-included SDK, see [this example build script (buildExternalSdkFunction)](example/functions/build.mjs)
 
-|         Bundled AWS SDK packages          |
+| Bundled AWS SDK packages                  |
 | ----------------------------------------- |
 | @aws-sdk/client-cloudwatch-events         |
 | @aws-sdk/client-cloudwatch-logs           |
@@ -247,7 +247,7 @@ V3 SDK packages not included in the list below have to be bundled with your sour
 
 ## Running TypeScript with LLRT
 
-Same principle as dependencies applies when using TypeScript. TypeScript must be bundled and transpiled into ES2020 JavaScript.
+Same principle as dependencies applies when using TypeScript. TypeScript must be bundled and transpiled into ES2023 JavaScript.
 
 > [!NOTE]
 > LLRT will not support running TypeScript without transpilation. This is by design for performance reasons. Transpiling requires CPU and memory that adds latency and cost during execution. This can be avoided if done ahead of time during deployment.
@@ -366,18 +366,23 @@ Then run llrt:
 ## Environment Variables
 
 ### `LLRT_EXTRA_CA_CERTS=file`
+
 Load extra certificate authorities from a PEM encoded file
 
 ### `LLRT_GC_THRESHOLD_MB=value`
+
 Set a memory threshold in MB for garbage collection. Default threshold is 20MB
 
 ### `LLRT_HTTP_VERSION=value`
+
 Restrict HTTP requests to use a specific version. By default HTTP 1.1 and 2 are enabled. Set this variable to `1.1` to only use HTTP 1.1
 
 ### `LLRT_LOG=[target][=][level][,...]`
+
 Filter the log output by target module, level, or both (using `=`). Log levels are case-insensitive and will also enable any higher priority logs.
 
 Log levels in descending priority order:
+
 - `Error`
 - `Warn | Warning`
 - `Info`
@@ -385,20 +390,25 @@ Log levels in descending priority order:
 - `Trace`
 
 Example filters:
+
 - `warn` will enable all warning and error logs
 - `llrt_core::vm=trace` will enable all logs in the `llrt_core::vm` module
 - `warn,llrt_core::vm=trace` will enable all logs in the `llrt_core::vm` module and all warning and error logs in other modules
 
 ### `LLRT_NET_ALLOW="host[ ...]"`
+
 Space-delimited list of hosts or socket paths which should be allowed for network connections. Network connections will be denied for any host or socket path missing from this list. Set an empty list to deny all connections
 
 ### `LLRT_NET_DENY="host[ ...]"`
+
 Space-delimited list of hosts or socket paths which should be denied for network connections
 
 ### `LLRT_NET_POOL_IDLE_TIMEOUT=value`
+
 Set a timeout in seconds for idle sockets being kept-alive. Default timeout is 15 seconds
 
 ### `LLRT_TLS_VERSION=value`
+
 Set the TLS version to be used for network connections. By default only TLS 1.2 is enabled. TLS 1.3 can also be enabled by setting this variable to `1.3`
 
 ## Benchmark Methodology

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ export default {
     minimizer: [
       new TerserPlugin({
         terserOptions: {
-          ecma: 2020,
+          ecma: 2023,
         },
       }),
     ],

--- a/build.mjs
+++ b/build.mjs
@@ -45,7 +45,7 @@ const ES_BUILD_OPTIONS = {
   splitting: MINIFY_JS,
   minify: MINIFY_JS,
   sourcemap: true,
-  target: "es2022",
+  target: "es2023",
   outdir: OUT_DIR,
   bundle: true,
   logLevel: "info",

--- a/example/functions/build.mjs
+++ b/example/functions/build.mjs
@@ -25,7 +25,7 @@ async function buildReact() {
       platform: "node",
     }),
     external: ["@aws-sdk"],
-    target: "es2020",
+    target: "es2023",
     format: devMode ? "cjs" : "esm",
     define: {
       "process.env.NODE_ENV": JSON.stringify("production"),
@@ -54,7 +54,7 @@ async function buildExternalSdkFunction() {
     },
     logLevel: "info",
     platform: "browser",
-    target: "es2020",
+    target: "es2023",
     format: "esm",
     bundle: true,
     minify: true,

--- a/example/infrastructure/tsconfig.json
+++ b/example/infrastructure/tsconfig.json
@@ -6,6 +6,6 @@
     "module": "CommonJS",
     "moduleResolution": "Node",
     "esModuleInterop": true,
-    "target": "ES2020"
+    "target": "ES2023"
   }
 }

--- a/example/llrt-sam/hello-world/tsconfig.json
+++ b/example/llrt-sam/hello-world/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2023",
     "strict": true,
     "preserveConstEnums": true,
     "noEmit": true,
     "sourceMap": false,
-    "module": "es2015",
+    "module": "es2022",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/example/llrt-sam/template.yaml
+++ b/example/llrt-sam/template.yaml
@@ -37,7 +37,7 @@ Resources:
           - "@smithy"
           - uuid
         Minify: false
-        Target: "es2020"
+        Target: "es2023"
         Sourcemap: false
         Format: esm
         OutExtension:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2022",
-    "lib": ["es2022"],
+    "target": "es2023",
+    "lib": ["es2023"],
     "module": "es2022",
     "esModuleInterop": true,
     "moduleResolution": "node",


### PR DESCRIPTION
### Description of changes

The target version has been revised as ES2023 is now supported in LLRT 0.2.0-beta.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
