### PR TITLE
fix: hyperfine argument error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ lib/x64/libzstd.a:
 
 bench:
 	cargo build -r
-	hyperfine -N --warm64up=100 "node fixtures/hello.js" "deno run fixtures/hello.js" "bun fixtures/hello.js" "$(BUILD_DIR)/llrt fixtures/hello.js" "qjs fixtures/hello.js"
+	hyperfine -N --warmup=100 "node fixtures/hello.js" "deno run fixtures/hello.js" "bun fixtures/hello.js" "$(BUILD_DIR)/llrt fixtures/hello.js" "qjs fixtures/hello.js"
 
 deploy:
 	cd example/infrastructure && yarn deploy --require-approval never


### PR DESCRIPTION
### Description of changes

Fixed an argument error in hyperfine when running `make bench`.

Before:
```shell
% make bench
# cargo build -r
hyperfine -N --warm64up=100 "node fixtures/hello.js" "deno run fixtures/hello.js" "bun fixtures/hello.js" "./target/release/llrt fixtures/hello.js" "qjs fixtures/hello.js"
error: unexpected argument '--warm64up' found

  tip: a similar argument exists: '--warmup'

Usage: hyperfine -N --warmup <NUM> <command>...

For more information, try '--help'.
make: *** [bench] Error 2
```

After:
```shell
% make bench
#cargo build -r
hyperfine -N --warmup=100 "node fixtures/hello.js" "deno run fixtures/hello.js" "bun fixtures/hello.js" "./target/release/llrt fixtures/hello.js" "qjs fixtures/hello.js"
Benchmark 1: node fixtures/hello.js
  Time (mean ± σ):      23.4 ms ±   0.4 ms    [User: 19.7 ms, System: 2.8 ms]
  Range (min … max):    22.4 ms …  24.4 ms    126 runs
 
Benchmark 2: deno run fixtures/hello.js
  Time (mean ± σ):      15.2 ms ±   3.1 ms    [User: 11.8 ms, System: 3.6 ms]
  Range (min … max):    14.0 ms …  42.0 ms    209 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 3: bun fixtures/hello.js
  Time (mean ± σ):       6.8 ms ±   0.3 ms    [User: 4.2 ms, System: 3.1 ms]
  Range (min … max):     6.4 ms …   9.5 ms    418 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 4: ./target/release/llrt fixtures/hello.js
  Time (mean ± σ):       3.0 ms ±   0.3 ms    [User: 1.8 ms, System: 1.3 ms]
  Range (min … max):     2.8 ms …  12.6 ms    1049 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 5: qjs fixtures/hello.js
  Time (mean ± σ):       3.6 ms ±   0.2 ms    [User: 1.1 ms, System: 1.5 ms]
  Range (min … max):     3.3 ms …   6.6 ms    880 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  ./target/release/llrt fixtures/hello.js ran
    1.19 ± 0.15 times faster than qjs fixtures/hello.js
    2.28 ± 0.27 times faster than bun fixtures/hello.js
    5.08 ± 1.17 times faster than deno run fixtures/hello.js
    7.79 ± 0.86 times faster than node fixtures/hello.js
```
### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
