### PR TITLE
perf: Reduced copying of bytes from objects such as ArrayBuffer or TypedArrays

### DIFF
--- a/llrt_core/benches/json.rs
+++ b/llrt_core/benches/json.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(dead_code)]
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use llrt_core::json::{parse::json_parse, stringify::json_stringify};

--- a/llrt_core/benches/numbers.rs
+++ b/llrt_core/benches/numbers.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use llrt_core::number::i64_to_base_n;
 use rand::Rng;

--- a/llrt_core/src/bytecode.rs
+++ b/llrt_core/src/bytecode.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub const BYTECODE_VERSION: &str = "lrt01";
 pub const BYTECODE_COMPRESSED: u8 = b'c';
 pub const BYTECODE_UNCOMPRESSED: u8 = b'u';

--- a/llrt_core/src/environment.rs
+++ b/llrt_core/src/environment.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //network
 pub const ENV_LLRT_NET_ALLOW: &str = "LLRT_NET_ALLOW";
 pub const ENV_LLRT_NET_DENY: &str = "LLRT_NET_DENY";

--- a/llrt_core/src/json/parse.rs
+++ b/llrt_core/src/json/parse.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::utils::result::ResultExt;
 use rquickjs::{Array, Ctx, IntoJs, Null, Object, Result, Undefined, Value};
 use simd_json::{Node, StaticNode};

--- a/llrt_core/src/lib.rs
+++ b/llrt_core/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(clippy::new_without_default)]
 #![allow(clippy::inherent_to_string)]
 #![cfg_attr(rust_nightly, feature(portable_simd))]

--- a/llrt_core/src/modules/crypto/crc32.rs
+++ b/llrt_core/src/modules/crypto/crc32.rs
@@ -33,7 +33,7 @@ impl Crc32c {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        let mut bytes = ObjectBytes::from(&ctx, &value)?;
         this.0.borrow_mut().hasher.write(&bytes.get_bytes());
         Ok(this.0)
     }
@@ -66,7 +66,7 @@ impl Crc32 {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        let mut bytes = ObjectBytes::from(&ctx, &value)?;
         this.0.borrow_mut().hasher.write(&bytes.get_bytes());
         Ok(this.0)
     }

--- a/llrt_core/src/modules/crypto/crc32.rs
+++ b/llrt_core/src/modules/crypto/crc32.rs
@@ -33,8 +33,8 @@ impl Crc32c {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, &value)?;
-        this.0.borrow_mut().hasher.write(&bytes.get_bytes());
+        let bytes = ObjectBytes::from(&ctx, &value)?;
+        this.0.borrow_mut().hasher.write(bytes.as_bytes());
         Ok(this.0)
     }
 }
@@ -66,8 +66,8 @@ impl Crc32 {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, &value)?;
-        this.0.borrow_mut().hasher.write(&bytes.get_bytes());
+        let bytes = ObjectBytes::from(&ctx, &value)?;
+        this.0.borrow_mut().hasher.write(bytes.as_bytes());
         Ok(this.0)
     }
 }

--- a/llrt_core/src/modules/crypto/crc32.rs
+++ b/llrt_core/src/modules/crypto/crc32.rs
@@ -3,9 +3,8 @@
 use std::hash::Hasher;
 
 use crc32c::Crc32cHasher;
+use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{prelude::This, Class, Ctx, Result, Value};
-
-use crate::utils::object::get_bytes;
 
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace)]
@@ -34,8 +33,8 @@ impl Crc32c {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = get_bytes(&ctx, value)?;
-        this.0.borrow_mut().hasher.write(&bytes);
+        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        this.0.borrow_mut().hasher.write(&bytes.get_bytes());
         Ok(this.0)
     }
 }
@@ -67,8 +66,8 @@ impl Crc32 {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = get_bytes(&ctx, value)?;
-        this.0.borrow_mut().hasher.write(&bytes);
+        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        this.0.borrow_mut().hasher.write(&bytes.get_bytes());
         Ok(this.0)
     }
 }

--- a/llrt_core/src/modules/crypto/md5_hash.rs
+++ b/llrt_core/src/modules/crypto/md5_hash.rs
@@ -43,7 +43,7 @@ impl Md5 {
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
         let mut bytes = ObjectBytes::from(&ctx, value)?;
-        this.0.borrow_mut().hasher.update(&bytes.get_bytes());
+        this.0.borrow_mut().hasher.update(bytes.get_bytes());
         Ok(this.0)
     }
 }

--- a/llrt_core/src/modules/crypto/md5_hash.rs
+++ b/llrt_core/src/modules/crypto/md5_hash.rs
@@ -42,8 +42,8 @@ impl Md5 {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, &value)?;
-        this.0.borrow_mut().hasher.update(bytes.get_bytes());
+        let bytes = ObjectBytes::from(&ctx, &value)?;
+        this.0.borrow_mut().hasher.update(bytes.as_bytes());
         Ok(this.0)
     }
 }

--- a/llrt_core/src/modules/crypto/md5_hash.rs
+++ b/llrt_core/src/modules/crypto/md5_hash.rs
@@ -1,10 +1,11 @@
+use llrt_utils::bytes::ObjectBytes;
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use md5::{Digest as Md5Digest, Md5 as MdHasher};
 
 use rquickjs::{function::Opt, prelude::This, Class, Ctx, Result, Value};
 
-use crate::utils::object::{bytes_to_typed_array, get_bytes};
+use crate::utils::object::bytes_to_typed_array;
 
 use super::encoded_bytes;
 
@@ -41,8 +42,8 @@ impl Md5 {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = get_bytes(&ctx, value)?;
-        this.0.borrow_mut().hasher.update(&bytes);
+        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        this.0.borrow_mut().hasher.update(&bytes.get_bytes());
         Ok(this.0)
     }
 }

--- a/llrt_core/src/modules/crypto/md5_hash.rs
+++ b/llrt_core/src/modules/crypto/md5_hash.rs
@@ -42,7 +42,7 @@ impl Md5 {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        let mut bytes = ObjectBytes::from(&ctx, &value)?;
         this.0.borrow_mut().hasher.update(bytes.get_bytes());
         Ok(this.0)
     }

--- a/llrt_core/src/modules/crypto/mod.rs
+++ b/llrt_core/src/modules/crypto/mod.rs
@@ -5,7 +5,10 @@ mod md5_hash;
 mod sha_hash;
 use std::slice;
 
-use llrt_utils::bytes::ObjectBytes;
+use llrt_utils::{
+    bytes::ObjectBytes,
+    error_messages::{ERROR_MSG_ARRAY_BUFFER_DETACHED, ERROR_MSG_NOT_ARRAY_BUFFER},
+};
 use once_cell::sync::Lazy;
 use rand::prelude::ThreadRng;
 use rand::Rng;
@@ -78,9 +81,6 @@ fn get_random_int(_ctx: Ctx, first: i64, second: Opt<i64>) -> Result<i64> {
     Ok(random_number)
 }
 
-const NOT_ARRAY_BUFFER_ERROR: &str = "Not an ArrayBuffer";
-const ARRAY_BUFFER_DETACHED_ERROR: &str = "ArrayBuffer is detached";
-
 fn random_fill<'js>(ctx: Ctx<'js>, obj: Object<'js>, args: Rest<Value<'js>>) -> Result<()> {
     let args_iter = args.0.into_iter();
     let mut args_iter = args_iter.rev();
@@ -122,10 +122,10 @@ fn random_fill_sync<'js>(
     if let Some(object_bytes) = ObjectBytes::from_array_buffer(&obj)? {
         let (array_buffer, source_length, source_offset) = object_bytes
             .get_array_buffer()?
-            .expect(NOT_ARRAY_BUFFER_ERROR);
+            .expect(ERROR_MSG_NOT_ARRAY_BUFFER);
         let raw = array_buffer
             .as_raw()
-            .ok_or(ARRAY_BUFFER_DETACHED_ERROR)
+            .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED)
             .or_throw(&ctx)?;
 
         let (start, end) = get_start_end_indexes(source_length, size.0, offset);
@@ -151,10 +151,10 @@ fn get_random_values<'js>(ctx: Ctx<'js>, obj: Object<'js>) -> Result<Object<'js>
 
         let (array_buffer, source_length, source_offset) = object_bytes
             .get_array_buffer()?
-            .expect(NOT_ARRAY_BUFFER_ERROR);
+            .expect(ERROR_MSG_NOT_ARRAY_BUFFER);
         let raw = array_buffer
             .as_raw()
-            .ok_or(ARRAY_BUFFER_DETACHED_ERROR)
+            .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED)
             .or_throw(&ctx)?;
 
         if source_length > 0x10000 {

--- a/llrt_core/src/modules/crypto/mod.rs
+++ b/llrt_core/src/modules/crypto/mod.rs
@@ -78,8 +78,8 @@ fn get_random_int(_ctx: Ctx, first: i64, second: Opt<i64>) -> Result<i64> {
     Ok(random_number)
 }
 
-const NOT_ARRAY_BUFFER_ERROR: &'static str = "Not an ArrayBuffer";
-const ARRAY_BUFFER_DETACHED_ERROR: &'static str = "ArrayBuffer is detached";
+const NOT_ARRAY_BUFFER_ERROR: &str = "Not an ArrayBuffer";
+const ARRAY_BUFFER_DETACHED_ERROR: &str = "ArrayBuffer is detached";
 
 fn random_fill<'js>(ctx: Ctx<'js>, obj: Object<'js>, args: Rest<Value<'js>>) -> Result<()> {
     let args_iter = args.0.into_iter();

--- a/llrt_core/src/modules/crypto/sha_hash.rs
+++ b/llrt_core/src/modules/crypto/sha_hash.rs
@@ -22,7 +22,7 @@ pub struct Hmac {
 impl Hmac {
     #[qjs(skip)]
     pub fn new<'js>(ctx: Ctx<'js>, algorithm: String, secret: Value<'js>) -> Result<Self> {
-        let mut key_value = ObjectBytes::from(&ctx, secret)?;
+        let mut key_value = ObjectBytes::from(&ctx, &secret)?;
 
         let algorithm = match algorithm.to_lowercase().as_str() {
             "sha1" => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
@@ -57,7 +57,7 @@ impl Hmac {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        let mut bytes = ObjectBytes::from(&ctx, &value)?;
         let bytes = bytes.get_bytes();
         this.0.borrow_mut().context.update(&bytes);
 
@@ -118,7 +118,7 @@ impl Hash {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        let mut bytes = ObjectBytes::from(&ctx, &value)?;
         let bytes = bytes.get_bytes();
         this.0.borrow_mut().context.update(&bytes);
         Ok(this.0)
@@ -175,7 +175,7 @@ impl ShaHash {
         secret: Opt<Value<'js>>,
     ) -> Result<Self> {
         let secret = if let Some(secret) = secret.0 {
-            let mut bytes = ObjectBytes::from(&ctx, secret)?;
+            let mut bytes = ObjectBytes::from(&ctx, &secret)?;
             Some(bytes.get_bytes().to_vec())
         } else {
             None
@@ -209,7 +209,7 @@ impl ShaHash {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, value)?;
+        let mut bytes = ObjectBytes::from(&ctx, &value)?;
         this.0.borrow_mut().bytes = bytes.get_bytes().to_vec();
         Ok(this.0)
     }

--- a/llrt_core/src/modules/crypto/sha_hash.rs
+++ b/llrt_core/src/modules/crypto/sha_hash.rs
@@ -22,7 +22,7 @@ pub struct Hmac {
 impl Hmac {
     #[qjs(skip)]
     pub fn new<'js>(ctx: Ctx<'js>, algorithm: String, secret: Value<'js>) -> Result<Self> {
-        let mut key_value = ObjectBytes::from(&ctx, &secret)?;
+        let key_value = ObjectBytes::from(&ctx, &secret)?;
 
         let algorithm = match algorithm.to_lowercase().as_str() {
             "sha1" => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
@@ -38,7 +38,7 @@ impl Hmac {
         };
 
         Ok(Self {
-            context: HmacContext::with_key(&hmac::Key::new(algorithm, &key_value.get_bytes())),
+            context: HmacContext::with_key(&hmac::Key::new(algorithm, key_value.as_bytes())),
         })
     }
 
@@ -57,9 +57,9 @@ impl Hmac {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, &value)?;
-        let bytes = bytes.get_bytes();
-        this.0.borrow_mut().context.update(&bytes);
+        let bytes = ObjectBytes::from(&ctx, &value)?;
+        let bytes = bytes.as_bytes();
+        this.0.borrow_mut().context.update(bytes);
 
         Ok(this.0)
     }
@@ -118,9 +118,9 @@ impl Hash {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, &value)?;
-        let bytes = bytes.get_bytes();
-        this.0.borrow_mut().context.update(&bytes);
+        let bytes = ObjectBytes::from(&ctx, &value)?;
+        let bytes = bytes.as_bytes();
+        this.0.borrow_mut().context.update(bytes);
         Ok(this.0)
     }
 }
@@ -175,8 +175,8 @@ impl ShaHash {
         secret: Opt<Value<'js>>,
     ) -> Result<Self> {
         let secret = if let Some(secret) = secret.0 {
-            let mut bytes = ObjectBytes::from(&ctx, &secret)?;
-            Some(bytes.get_bytes().to_vec())
+            let bytes = ObjectBytes::from(&ctx, &secret)?;
+            Some(bytes.into_bytes())
         } else {
             None
         };
@@ -209,8 +209,8 @@ impl ShaHash {
         ctx: Ctx<'js>,
         value: Value<'js>,
     ) -> Result<Class<'js, Self>> {
-        let mut bytes = ObjectBytes::from(&ctx, &value)?;
-        this.0.borrow_mut().bytes = bytes.get_bytes().to_vec();
+        let bytes = ObjectBytes::from(&ctx, &value)?;
+        this.0.borrow_mut().bytes = bytes.into();
         Ok(this.0)
     }
 }

--- a/llrt_core/src/modules/encoding/text_decoder.rs
+++ b/llrt_core/src/modules/encoding/text_decoder.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use llrt_utils::{encoding::Encoder, object::ObjectExt};
+use llrt_utils::{bytes::ObjectBytes, encoding::Encoder, object::ObjectExt};
 use rquickjs::{function::Opt, Ctx, Object, Result, Value};
 
-use crate::utils::{object::get_bytes, result::ResultExt};
+use crate::utils::result::ResultExt;
 
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace)]
@@ -59,7 +59,8 @@ impl<'js> TextDecoder {
     }
 
     pub fn decode(&self, ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let bytes = get_bytes(&ctx, buffer)?;
+        let mut bytes = ObjectBytes::from(&ctx, buffer)?;
+        let bytes = bytes.get_bytes();
         let start_pos = if !self.ignore_bom {
             match bytes.get(..3) {
                 Some([0xFF, 0xFE, ..]) | Some([0xFE, 0xFF, ..]) => 2,

--- a/llrt_core/src/modules/encoding/text_decoder.rs
+++ b/llrt_core/src/modules/encoding/text_decoder.rs
@@ -59,7 +59,7 @@ impl<'js> TextDecoder {
     }
 
     pub fn decode(&self, ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let mut bytes = ObjectBytes::from(&ctx, buffer)?;
+        let mut bytes = ObjectBytes::from(&ctx, &buffer)?;
         let bytes = bytes.get_bytes();
         let start_pos = if !self.ignore_bom {
             match bytes.get(..3) {

--- a/llrt_core/src/modules/encoding/text_decoder.rs
+++ b/llrt_core/src/modules/encoding/text_decoder.rs
@@ -59,8 +59,8 @@ impl<'js> TextDecoder {
     }
 
     pub fn decode(&self, ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let mut bytes = ObjectBytes::from(&ctx, &buffer)?;
-        let bytes = bytes.get_bytes();
+        let bytes = ObjectBytes::from(&ctx, &buffer)?;
+        let bytes = bytes.as_bytes();
         let start_pos = if !self.ignore_bom {
             match bytes.get(..3) {
                 Some([0xFF, 0xFE, ..]) | Some([0xFE, 0xFF, ..]) => 2,

--- a/llrt_core/src/modules/http/body.rs
+++ b/llrt_core/src/modules/http/body.rs
@@ -152,14 +152,14 @@ impl<'js> Body<'js> {
                     .take()
                     .ok_or(Exception::throw_type(ctx, "Already read"))?;
                 let bytes = body.body_mut().collect().await.or_throw(ctx)?.to_bytes();
-                bytes.to_vec()
+                bytes.into()
             },
             BodyVariant::Provided(provided) => {
                 if let Some(blob) = provided.as_object().and_then(Class::<Blob>::from_object) {
                     let blob = blob.borrow();
                     blob.get_bytes()
                 } else {
-                    let mut bytes = ObjectBytes::from(ctx, provided.clone())?;
+                    let mut bytes = ObjectBytes::from(ctx, provided)?;
                     bytes.get_bytes().into()
                 }
             },

--- a/llrt_core/src/modules/http/body.rs
+++ b/llrt_core/src/modules/http/body.rs
@@ -159,8 +159,8 @@ impl<'js> Body<'js> {
                     let blob = blob.borrow();
                     blob.get_bytes()
                 } else {
-                    let mut bytes = ObjectBytes::from(ctx, provided)?;
-                    bytes.get_bytes().into()
+                    let bytes = ObjectBytes::from(ctx, provided)?;
+                    bytes.into()
                 }
             },
         };

--- a/llrt_core/src/modules/http/body.rs
+++ b/llrt_core/src/modules/http/body.rs
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 use http_body_util::BodyExt;
 use hyper::{body::Incoming, Response};
+use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{
     class::{Trace, Tracer},
     ArrayBuffer, Class, Ctx, Exception, IntoJs, Null, Result, TypedArray, Value,
 };
 
-use crate::{
-    json::parse::json_parse,
-    utils::{object::get_bytes, result::ResultExt},
-};
+use crate::{json::parse::json_parse, utils::result::ResultExt};
 
 use super::blob::Blob;
 
@@ -161,7 +159,8 @@ impl<'js> Body<'js> {
                     let blob = blob.borrow();
                     blob.get_bytes()
                 } else {
-                    get_bytes(ctx, provided.clone())?
+                    let mut bytes = ObjectBytes::from(ctx, provided.clone())?;
+                    bytes.get_bytes().into()
                 }
             },
         };

--- a/llrt_core/src/modules/http/fetch.rs
+++ b/llrt_core/src/modules/http/fetch.rs
@@ -223,6 +223,7 @@ fn is_cors_non_wildcard_request_header_name(key: &str) -> bool {
 }
 
 struct BodyBytes<'js> {
+    #[allow(dead_code)]
     object_bytes: ObjectBytes<'js>,
     body: Full<Bytes>,
 }

--- a/llrt_core/src/modules/http/fetch.rs
+++ b/llrt_core/src/modules/http/fetch.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{header::HeaderName, Method, Request, Uri};
 
+use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{
     atom::PredefinedAtom,
     function::{Opt, This},
@@ -18,7 +19,7 @@ use crate::{
     environment,
     modules::events::abort_signal::AbortSignal,
     security::{ensure_url_access, HTTP_DENY_LIST},
-    utils::{mc_oneshot, object::get_bytes, result::ResultExt},
+    utils::{mc_oneshot, result::ResultExt},
 };
 use crate::{security::HTTP_ALLOW_LIST, VERSION};
 
@@ -282,7 +283,8 @@ fn get_fetch_options<'js>(
         if let Some(body_opt) =
             get_option::<Value>("body", arg_opts.as_ref(), resource_opts.as_ref())?
         {
-            let bytes = get_bytes(ctx, body_opt)?;
+            let mut bytes = ObjectBytes::from(ctx, body_opt)?;
+            let bytes = bytes.get_bytes().to_vec();
             body = Some(Full::from(bytes));
         }
 

--- a/llrt_core/src/modules/http/request.rs
+++ b/llrt_core/src/modules/http/request.rs
@@ -1,3 +1,4 @@
+use llrt_utils::bytes::ObjectBytes;
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use rquickjs::{
@@ -8,7 +9,7 @@ use rquickjs::{
 use crate::{
     json::parse::json_parse,
     modules::events::abort_signal::AbortSignal,
-    utils::{class::get_class, object::get_bytes, object::ObjectExt},
+    utils::{class::get_class, object::ObjectExt},
 };
 
 use super::{blob::Blob, headers::Headers};
@@ -21,7 +22,8 @@ impl<'js> Request<'js> {
                     let blob = blob.borrow();
                     blob.get_bytes()
                 } else {
-                    get_bytes(ctx, provided.clone())?
+                    let mut bytes = ObjectBytes::from(ctx, provided.clone())?;
+                    bytes.get_bytes().to_vec()
                 }
             },
             None => return Ok(None),

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -8,6 +8,7 @@ use std::{
 
 use http_body_util::BodyExt;
 use hyper::{body::Incoming, header::HeaderName};
+use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{
     class::{Trace, Tracer},
     function::Opt,
@@ -18,7 +19,7 @@ use tokio::{runtime::Handle, select};
 use crate::{
     json::parse::json_parse,
     modules::events::abort_signal::AbortSignal,
-    utils::{mc_oneshot, object::get_bytes, result::ResultExt},
+    utils::{mc_oneshot, result::ResultExt},
 };
 
 use super::{blob::Blob, headers::Headers};
@@ -189,7 +190,8 @@ impl<'js> Response<'js> {
                     let blob = blob.borrow();
                     blob.get_bytes()
                 } else {
-                    get_bytes(ctx, provided.clone())?
+                    let mut bytes = ObjectBytes::from(ctx, provided.clone())?;
+                    bytes.get_bytes().to_vec()
                 }
             },
             None => return Ok(None),

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -190,8 +190,8 @@ impl<'js> Response<'js> {
                     let blob = blob.borrow();
                     blob.get_bytes()
                 } else {
-                    let mut bytes = ObjectBytes::from(ctx, provided)?;
-                    bytes.get_bytes().to_vec()
+                    let bytes = ObjectBytes::from(ctx, provided)?;
+                    bytes.as_bytes().to_vec()
                 }
             },
             None => return Ok(None),

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -190,7 +190,7 @@ impl<'js> Response<'js> {
                     let blob = blob.borrow();
                     blob.get_bytes()
                 } else {
-                    let mut bytes = ObjectBytes::from(ctx, provided.clone())?;
+                    let mut bytes = ObjectBytes::from(ctx, provided)?;
                     bytes.get_bytes().to_vec()
                 }
             },

--- a/llrt_core/src/modules/llrt/hex.rs
+++ b/llrt_core/src/modules/llrt/hex.rs
@@ -21,8 +21,8 @@ pub struct LlrtHexModule;
 
 impl LlrtHexModule {
     pub fn encode<'js>(ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let mut bytes = ObjectBytes::from(&ctx, &buffer)?;
-        Ok(bytes_to_hex_string(&bytes.get_bytes()))
+        let bytes = ObjectBytes::from(&ctx, &buffer)?;
+        Ok(bytes_to_hex_string(bytes.as_bytes()))
     }
 
     pub fn decode(ctx: Ctx, encoded: String) -> Result<Value> {

--- a/llrt_core/src/modules/llrt/hex.rs
+++ b/llrt_core/src/modules/llrt/hex.rs
@@ -21,7 +21,7 @@ pub struct LlrtHexModule;
 
 impl LlrtHexModule {
     pub fn encode<'js>(ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let mut bytes = ObjectBytes::from(&ctx, buffer)?;
+        let mut bytes = ObjectBytes::from(&ctx, &buffer)?;
         Ok(bytes_to_hex_string(&bytes.get_bytes()))
     }
 

--- a/llrt_core/src/modules/llrt/hex.rs
+++ b/llrt_core/src/modules/llrt/hex.rs
@@ -4,6 +4,7 @@ pub mod encoder {
     pub use llrt_utils::encoding::*;
 }
 
+use llrt_utils::bytes::{bytes_to_typed_array, ObjectBytes};
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
     prelude::Func,
@@ -11,12 +12,7 @@ use rquickjs::{
 };
 
 use crate::{
-    module_builder::ModuleInfo,
-    modules::module::export_default,
-    utils::{
-        object::{bytes_to_typed_array, get_bytes},
-        result::ResultExt,
-    },
+    module_builder::ModuleInfo, modules::module::export_default, utils::result::ResultExt,
 };
 
 use self::encoder::{bytes_from_hex, bytes_to_hex_string};
@@ -25,8 +21,8 @@ pub struct LlrtHexModule;
 
 impl LlrtHexModule {
     pub fn encode<'js>(ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let bytes = get_bytes(&ctx, buffer)?;
-        Ok(bytes_to_hex_string(&bytes))
+        let mut bytes = ObjectBytes::from(&ctx, buffer)?;
+        Ok(bytes_to_hex_string(&bytes.get_bytes()))
     }
 
     pub fn decode(ctx: Ctx, encoded: String) -> Result<Value> {

--- a/llrt_core/src/modules/llrt/uuid.rs
+++ b/llrt_core/src/modules/llrt/uuid.rs
@@ -33,9 +33,9 @@ fn from_value<'js>(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Uuid> {
     if value.is_string() {
         Uuid::try_parse(&value.as_string().unwrap().to_string()?)
     } else {
-        let mut bytes = ObjectBytes::from(ctx, &value)?;
-        let bytes = bytes.get_bytes();
-        Uuid::from_slice(bytes.as_ref())
+        let bytes = ObjectBytes::from(ctx, &value)?;
+        let bytes = bytes.as_bytes();
+        Uuid::from_slice(bytes)
     }
     .or_throw_msg(ctx, ERROR_MESSAGE)
 }
@@ -127,13 +127,13 @@ fn parse(ctx: Ctx<'_>, value: String) -> Result<TypedArray<u8>> {
 }
 
 fn stringify<'js>(ctx: Ctx<'js>, value: Value<'js>, offset: Opt<u8>) -> Result<String> {
-    let mut bytes = ObjectBytes::from_offset(
+    let bytes = ObjectBytes::from_offset(
         &ctx,
         &value,
         offset.0.map(|o| o.into()).unwrap_or_default(),
         None,
     )?;
-    let value = bytes_to_hex(&bytes.get_bytes());
+    let value = bytes_to_hex(bytes.as_bytes());
 
     let uuid = Uuid::try_parse_ascii(&value)
         .or_throw_msg(&ctx, ERROR_MESSAGE)?

--- a/llrt_core/src/modules/llrt/uuid.rs
+++ b/llrt_core/src/modules/llrt/uuid.rs
@@ -33,7 +33,7 @@ fn from_value<'js>(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Uuid> {
     if value.is_string() {
         Uuid::try_parse(&value.as_string().unwrap().to_string()?)
     } else {
-        let mut bytes = ObjectBytes::from(ctx, value)?;
+        let mut bytes = ObjectBytes::from(ctx, &value)?;
         let bytes = bytes.get_bytes();
         Uuid::from_slice(bytes.as_ref())
     }
@@ -129,7 +129,7 @@ fn parse(ctx: Ctx<'_>, value: String) -> Result<TypedArray<u8>> {
 fn stringify<'js>(ctx: Ctx<'js>, value: Value<'js>, offset: Opt<u8>) -> Result<String> {
     let mut bytes = ObjectBytes::from_offset(
         &ctx,
-        value,
+        &value,
         offset.0.map(|o| o.into()).unwrap_or_default(),
         None,
     )?;

--- a/llrt_core/src/modules/llrt/xml.rs
+++ b/llrt_core/src/modules/llrt/xml.rs
@@ -115,9 +115,9 @@ impl<'js> XMLParser<'js> {
     }
 
     pub fn parse(&self, ctx: Ctx<'js>, xml: Value<'js>) -> Result<Object<'js>> {
-        let mut bytes = ObjectBytes::from(&ctx, &xml)?;
-        let bytes = bytes.get_bytes();
-        let mut reader = Reader::from_reader(bytes.as_ref());
+        let bytes = ObjectBytes::from(&ctx, &xml)?;
+        let bytes = bytes.as_bytes();
+        let mut reader = Reader::from_reader(bytes);
         let config = reader.config_mut();
         config.trim_text(true);
 

--- a/llrt_core/src/modules/llrt/xml.rs
+++ b/llrt_core/src/modules/llrt/xml.rs
@@ -115,7 +115,7 @@ impl<'js> XMLParser<'js> {
     }
 
     pub fn parse(&self, ctx: Ctx<'js>, xml: Value<'js>) -> Result<Object<'js>> {
-        let mut bytes = ObjectBytes::from(&ctx, xml)?;
+        let mut bytes = ObjectBytes::from(&ctx, &xml)?;
         let bytes = bytes.get_bytes();
         let mut reader = Reader::from_reader(bytes.as_ref());
         let config = reader.config_mut();

--- a/llrt_core/src/modules/llrt/xml.rs
+++ b/llrt_core/src/modules/llrt/xml.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{collections::HashMap, rc::Rc};
 
+use llrt_utils::bytes::ObjectBytes;
 use quick_xml::{
     escape::resolve_xml_entity,
     events::{BytesStart, Event},
@@ -30,10 +31,7 @@ const LS: &str = "&#x2028;";
 use crate::{
     module_builder::ModuleInfo,
     modules::module::export_default,
-    utils::{
-        object::{get_bytes, ObjectExt},
-        result::ResultExt,
-    },
+    utils::{object::ObjectExt, result::ResultExt},
 };
 
 #[rquickjs::class]
@@ -117,7 +115,8 @@ impl<'js> XMLParser<'js> {
     }
 
     pub fn parse(&self, ctx: Ctx<'js>, xml: Value<'js>) -> Result<Object<'js>> {
-        let bytes = get_bytes(&ctx, xml)?;
+        let mut bytes = ObjectBytes::from(&ctx, xml)?;
+        let bytes = bytes.get_bytes();
         let mut reader = Reader::from_reader(bytes.as_ref());
         let config = reader.config_mut();
         config.trim_text(true);

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub use llrt_modules::{
     buffer, child_process, exceptions, fs, navigator, net, os, path, perf_hooks, process, zlib,
 };

--- a/llrt_core/src/modules/util.rs
+++ b/llrt_core/src/modules/util.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use rquickjs::function::Func;
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -516,8 +516,8 @@ impl Vm {
 }
 
 fn json_parse_string<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<Value<'js>> {
-    let mut bytes = ObjectBytes::from(&ctx, &value)?;
-    let bytes = bytes.get_bytes();
+    let bytes = ObjectBytes::from(&ctx, &value)?;
+    let bytes = bytes.as_bytes();
     json_parse(&ctx, bytes)
 }
 

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -516,7 +516,7 @@ impl Vm {
 }
 
 fn json_parse_string<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<Value<'js>> {
-    let mut bytes = ObjectBytes::from(&ctx, value)?;
+    let mut bytes = ObjectBytes::from(&ctx, &value)?;
     let bytes = bytes.get_bytes();
     json_parse(&ctx, bytes)
 }

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -16,6 +16,7 @@ use std::{
     task::Poll,
 };
 
+use llrt_utils::bytes::ObjectBytes;
 use once_cell::sync::Lazy;
 
 pub use llrt_utils::{ctx::CtxExtension, error::ErrorExtensions};
@@ -48,11 +49,7 @@ use crate::{
     json::{parse::json_parse, stringify::json_stringify_replacer_space},
     number::number_to_string,
     security,
-    utils::{
-        clone::structured_clone,
-        io::get_js_path,
-        object::{get_bytes, ObjectExt},
-    },
+    utils::{clone::structured_clone, io::get_js_path, object::ObjectExt},
 };
 #[inline]
 pub fn uncompressed_size(input: &[u8]) -> StdResult<(usize, &[u8]), io::Error> {
@@ -519,7 +516,8 @@ impl Vm {
 }
 
 fn json_parse_string<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<Value<'js>> {
-    let bytes = get_bytes(&ctx, value)?;
+    let mut bytes = ObjectBytes::from(&ctx, value)?;
+    let bytes = bytes.get_bytes();
     json_parse(&ctx, bytes)
 }
 

--- a/llrt_modules/src/modules/buffer.rs
+++ b/llrt_modules/src/modules/buffer.rs
@@ -71,9 +71,9 @@ fn byte_length<'js>(ctx: Ctx<'js>, value: Value<'js>, encoding: Opt<String>) -> 
     //slow path
     if let Some(encoding) = encoding.0 {
         let encoder = Encoder::from_str(&encoding).or_throw(&ctx)?;
-        let mut a = ObjectBytes::from(&ctx, value)?;
+        let mut a = ObjectBytes::from(&ctx, &value)?;
         let bytes = a.get_bytes();
-        return Ok(encoder.decode(&bytes).or_throw(&ctx)?.len());
+        return Ok(encoder.decode(bytes).or_throw(&ctx)?.len());
     }
     //fast path
     if let Some(val) = value.as_string() {

--- a/llrt_modules/src/modules/buffer.rs
+++ b/llrt_modules/src/modules/buffer.rs
@@ -71,8 +71,8 @@ fn byte_length<'js>(ctx: Ctx<'js>, value: Value<'js>, encoding: Opt<String>) -> 
     //slow path
     if let Some(encoding) = encoding.0 {
         let encoder = Encoder::from_str(&encoding).or_throw(&ctx)?;
-        let mut a = ObjectBytes::from(&ctx, &value)?;
-        let bytes = a.get_bytes();
+        let a = ObjectBytes::from(&ctx, &value)?;
+        let bytes = a.as_bytes();
         return Ok(encoder.decode(bytes).or_throw(&ctx)?.len());
     }
     //fast path
@@ -91,8 +91,8 @@ fn byte_length<'js>(ctx: Ctx<'js>, value: Value<'js>, encoding: Opt<String>) -> 
     }
 
     if let Some(obj) = value.as_object() {
-        if let Some(mut ob) = ObjectBytes::from_array_buffer(obj)? {
-            return Ok(ob.get_bytes().len());
+        if let Some(ob) = ObjectBytes::from_array_buffer(obj)? {
+            return Ok(ob.as_bytes().len());
         }
     }
 
@@ -135,9 +135,9 @@ fn alloc<'js>(
             return Buffer(bytes).into_js(&ctx);
         }
         if let Some(obj) = value.as_object() {
-            if let Some(mut ob) = ObjectBytes::from_array_buffer(obj)? {
-                let bytes = ob.get_bytes();
-                return alloc_byte_ref(&ctx, &bytes, length);
+            if let Some(ob) = ObjectBytes::from_array_buffer(obj)? {
+                let bytes = ob.as_bytes();
+                return alloc_byte_ref(&ctx, bytes, length);
             }
         }
     }
@@ -207,8 +207,8 @@ fn from<'js>(
     }
 
     if let Some(obj) = value.as_object() {
-        if let Some(mut ab_bytes) = ObjectBytes::from_array_buffer(obj)? {
-            let bytes = ab_bytes.get_bytes();
+        if let Some(ab_bytes) = ObjectBytes::from_array_buffer(obj)? {
+            let bytes = ab_bytes.as_bytes();
             let (start, end) = get_start_end_indexes(bytes.len(), length.0, offset);
 
             //buffers from buffer should be copied

--- a/llrt_modules/src/modules/fs/write_file.rs
+++ b/llrt_modules/src/modules/fs/write_file.rs
@@ -1,6 +1,6 @@
+use llrt_utils::bytes::ObjectBytes;
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use llrt_utils::bytes::get_bytes;
 use llrt_utils::result::ResultExt;
 use rquickjs::{Ctx, Result, Value};
 use tokio::fs;
@@ -13,8 +13,8 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
 
     let write_error_message = &["Can't write file \"", &path, "\""].concat();
 
-    let bytes = get_bytes(&ctx, data)?;
-    file.write_all(&bytes)
+    let mut bytes = ObjectBytes::from(&ctx, data)?;
+    file.write_all(&bytes.get_bytes())
         .await
         .or_throw_msg(&ctx, write_error_message)?;
     file.flush().await.or_throw_msg(&ctx, write_error_message)?;
@@ -23,9 +23,10 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
 }
 
 pub fn write_file_sync<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> Result<()> {
-    let bytes = get_bytes(&ctx, data)?;
+    let mut bytes = ObjectBytes::from(&ctx, data)?;
 
-    std::fs::write(&path, bytes).or_throw_msg(&ctx, &["Can't write \"{}\"", &path].concat())?;
+    std::fs::write(&path, bytes.get_bytes())
+        .or_throw_msg(&ctx, &["Can't write \"{}\"", &path].concat())?;
 
     Ok(())
 }

--- a/llrt_modules/src/modules/fs/write_file.rs
+++ b/llrt_modules/src/modules/fs/write_file.rs
@@ -1,7 +1,7 @@
-use llrt_utils::bytes::ObjectBytes;
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use llrt_utils::result::ResultExt;
+
+use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
 use rquickjs::{Ctx, Result, Value};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -13,7 +13,7 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
 
     let write_error_message = &["Can't write file \"", &path, "\""].concat();
 
-    let mut bytes = ObjectBytes::from(&ctx, data)?;
+    let mut bytes = ObjectBytes::from(&ctx, &data)?;
     file.write_all(&bytes.get_bytes())
         .await
         .or_throw_msg(&ctx, write_error_message)?;
@@ -23,7 +23,7 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
 }
 
 pub fn write_file_sync<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> Result<()> {
-    let mut bytes = ObjectBytes::from(&ctx, data)?;
+    let mut bytes = ObjectBytes::from(&ctx, &data)?;
 
     std::fs::write(&path, bytes.get_bytes())
         .or_throw_msg(&ctx, &["Can't write \"{}\"", &path].concat())?;

--- a/llrt_modules/src/modules/fs/write_file.rs
+++ b/llrt_modules/src/modules/fs/write_file.rs
@@ -13,8 +13,8 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
 
     let write_error_message = &["Can't write file \"", &path, "\""].concat();
 
-    let mut bytes = ObjectBytes::from(&ctx, &data)?;
-    file.write_all(&bytes.get_bytes())
+    let bytes = ObjectBytes::from(&ctx, &data)?;
+    file.write_all(bytes.as_bytes())
         .await
         .or_throw_msg(&ctx, write_error_message)?;
     file.flush().await.or_throw_msg(&ctx, write_error_message)?;
@@ -23,9 +23,9 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
 }
 
 pub fn write_file_sync<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> Result<()> {
-    let mut bytes = ObjectBytes::from(&ctx, &data)?;
+    let bytes = ObjectBytes::from(&ctx, &data)?;
 
-    std::fs::write(&path, bytes.get_bytes())
+    std::fs::write(&path, bytes.as_bytes())
         .or_throw_msg(&ctx, &["Can't write \"{}\"", &path].concat())?;
 
     Ok(())

--- a/llrt_modules/src/modules/zlib.rs
+++ b/llrt_modules/src/modules/zlib.rs
@@ -83,7 +83,7 @@ fn zlib_converter<'js>(
     options: Opt<Value<'js>>,
     command: ZlibCommand,
 ) -> Result<Value<'js>> {
-    let mut bytes = ObjectBytes::from(&ctx, value)?;
+    let mut bytes = ObjectBytes::from(&ctx, &value)?;
     let src = bytes.get_bytes();
 
     let mut level = Compression::default();
@@ -136,7 +136,7 @@ fn brotli_converter<'js>(
     _options: Opt<Value<'js>>,
     command: BrotliCommand,
 ) -> Result<Value<'js>> {
-    let mut bytes = ObjectBytes::from(&ctx, value)?;
+    let mut bytes = ObjectBytes::from(&ctx, &value)?;
     let src = bytes.get_bytes();
 
     let mut dst: Vec<u8> = Vec::with_capacity(src.len());

--- a/llrt_modules/src/modules/zlib.rs
+++ b/llrt_modules/src/modules/zlib.rs
@@ -8,7 +8,7 @@ use flate2::{
     Compression,
 };
 use llrt_utils::{
-    bytes::get_bytes, ctx::CtxExtension, module::export_default, object::ObjectExt,
+    bytes::ObjectBytes, ctx::CtxExtension, module::export_default, object::ObjectExt,
     result::ResultExt,
 };
 use rquickjs::function::Func;
@@ -83,7 +83,8 @@ fn zlib_converter<'js>(
     options: Opt<Value<'js>>,
     command: ZlibCommand,
 ) -> Result<Value<'js>> {
-    let src = get_bytes(&ctx, value)?;
+    let mut bytes = ObjectBytes::from(&ctx, value)?;
+    let src = bytes.get_bytes();
 
     let mut level = Compression::default();
     if let Some(options) = options.0 {
@@ -135,7 +136,8 @@ fn brotli_converter<'js>(
     _options: Opt<Value<'js>>,
     command: BrotliCommand,
 ) -> Result<Value<'js>> {
-    let src = get_bytes(&ctx, value)?;
+    let mut bytes = ObjectBytes::from(&ctx, value)?;
+    let src = bytes.get_bytes();
 
     let mut dst: Vec<u8> = Vec::with_capacity(src.len());
 

--- a/llrt_modules/src/modules/zlib.rs
+++ b/llrt_modules/src/modules/zlib.rs
@@ -83,8 +83,8 @@ fn zlib_converter<'js>(
     options: Opt<Value<'js>>,
     command: ZlibCommand,
 ) -> Result<Value<'js>> {
-    let mut bytes = ObjectBytes::from(&ctx, &value)?;
-    let src = bytes.get_bytes();
+    let bytes = ObjectBytes::from(&ctx, &value)?;
+    let src = bytes.as_bytes();
 
     let mut level = Compression::default();
     if let Some(options) = options.0 {
@@ -96,12 +96,12 @@ fn zlib_converter<'js>(
     let mut dst: Vec<u8> = Vec::with_capacity(src.len());
 
     let _ = match command {
-        ZlibCommand::Deflate => ZlibEncoder::new(&src[..], level).read_to_end(&mut dst)?,
-        ZlibCommand::DeflateRaw => DeflateEncoder::new(&src[..], level).read_to_end(&mut dst)?,
-        ZlibCommand::Gzip => GzEncoder::new(&src[..], level).read_to_end(&mut dst)?,
-        ZlibCommand::Inflate => ZlibDecoder::new(&src[..]).read_to_end(&mut dst)?,
-        ZlibCommand::InflateRaw => DeflateDecoder::new(&src[..]).read_to_end(&mut dst)?,
-        ZlibCommand::Gunzip => GzDecoder::new(&src[..]).read_to_end(&mut dst)?,
+        ZlibCommand::Deflate => ZlibEncoder::new(src, level).read_to_end(&mut dst)?,
+        ZlibCommand::DeflateRaw => DeflateEncoder::new(src, level).read_to_end(&mut dst)?,
+        ZlibCommand::Gzip => GzEncoder::new(src, level).read_to_end(&mut dst)?,
+        ZlibCommand::Inflate => ZlibDecoder::new(src).read_to_end(&mut dst)?,
+        ZlibCommand::InflateRaw => DeflateDecoder::new(src).read_to_end(&mut dst)?,
+        ZlibCommand::Gunzip => GzDecoder::new(src).read_to_end(&mut dst)?,
     };
 
     Buffer(dst).into_js(&ctx)
@@ -136,14 +136,14 @@ fn brotli_converter<'js>(
     _options: Opt<Value<'js>>,
     command: BrotliCommand,
 ) -> Result<Value<'js>> {
-    let mut bytes = ObjectBytes::from(&ctx, &value)?;
-    let src = bytes.get_bytes();
+    let bytes = ObjectBytes::from(&ctx, &value)?;
+    let src = bytes.as_bytes();
 
     let mut dst: Vec<u8> = Vec::with_capacity(src.len());
 
     let _ = match command {
-        BrotliCommand::Compress => BrotliEncoder::new(&src[..]).read_to_end(&mut dst)?,
-        BrotliCommand::Decompress => BrotliDecoder::new(&src[..]).read_to_end(&mut dst)?,
+        BrotliCommand::Compress => BrotliEncoder::new(src).read_to_end(&mut dst)?,
+        BrotliCommand::Decompress => BrotliDecoder::new(src).read_to_end(&mut dst)?,
     };
 
     Buffer(dst).into_js(&ctx)

--- a/llrt_modules/src/stream/writable.rs
+++ b/llrt_modules/src/stream/writable.rs
@@ -246,10 +246,10 @@ where
                             command = command_rx.recv() => {
                                  match command {
                                     Some(WriteCommand::Write(value, cb, flush)) => {
-                                        let mut bytes = ObjectBytes::from(&ctx3, &value)?;
-                                        let data = bytes.get_bytes();
+                                        let bytes = ObjectBytes::from(&ctx3, &value)?;
+                                        let data = bytes.as_bytes();
                                         let result = async {
-                                            writer.write_all(&data).await?;
+                                            writer.write_all(data).await?;
                                             if flush {
                                                 writer.flush().await.or_throw(&ctx3)?;
                                             }

--- a/llrt_modules/src/stream/writable.rs
+++ b/llrt_modules/src/stream/writable.rs
@@ -246,7 +246,7 @@ where
                             command = command_rx.recv() => {
                                  match command {
                                     Some(WriteCommand::Write(value, cb, flush)) => {
-                                        let mut bytes = ObjectBytes::from(&ctx3, value)?;
+                                        let mut bytes = ObjectBytes::from(&ctx3, &value)?;
                                         let data = bytes.get_bytes();
                                         let result = async {
                                             writer.write_all(&data).await?;

--- a/llrt_utils/src/bytes.rs
+++ b/llrt_utils/src/bytes.rs
@@ -3,6 +3,8 @@
 
 use rquickjs::{ArrayBuffer, Coerced, Ctx, Exception, IntoJs, Object, Result, TypedArray, Value};
 
+use crate::error_messages::ERROR_MSG_ARRAY_BUFFER_DETACHED;
+
 #[derive(Clone)]
 pub enum ObjectBytes<'js> {
     U8Array(TypedArray<'js, u8>),
@@ -32,8 +34,6 @@ impl<'a, 'js> From<&'a ObjectBytes<'js>> for &'a [u8] {
 }
 
 impl<'js> ObjectBytes<'js> {
-    const DETACHED_ERROR: &'static str = "ArrayBuffer is detached";
-
     pub fn from(ctx: &Ctx<'js>, value: &Value<'js>) -> Result<Self> {
         Self::from_offset(ctx, value, 0, None)
     }
@@ -72,19 +72,35 @@ impl<'js> ObjectBytes<'js> {
 
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            ObjectBytes::U8Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::I8Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::U16Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::I16Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::U32Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::I32Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::U64Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::I64Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::F32Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::F64Array(array) => array.as_bytes().expect(Self::DETACHED_ERROR),
-            ObjectBytes::DataView(array_buffer) => {
-                array_buffer.as_bytes().expect(Self::DETACHED_ERROR)
+            ObjectBytes::U8Array(array) => array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED),
+            ObjectBytes::I8Array(array) => array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED),
+            ObjectBytes::U16Array(array) => {
+                array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED)
             },
+            ObjectBytes::I16Array(array) => {
+                array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED)
+            },
+            ObjectBytes::U32Array(array) => {
+                array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED)
+            },
+            ObjectBytes::I32Array(array) => {
+                array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED)
+            },
+            ObjectBytes::U64Array(array) => {
+                array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED)
+            },
+            ObjectBytes::I64Array(array) => {
+                array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED)
+            },
+            ObjectBytes::F32Array(array) => {
+                array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED)
+            },
+            ObjectBytes::F64Array(array) => {
+                array.as_bytes().expect(ERROR_MSG_ARRAY_BUFFER_DETACHED)
+            },
+            ObjectBytes::DataView(array_buffer) => array_buffer
+                .as_bytes()
+                .expect(ERROR_MSG_ARRAY_BUFFER_DETACHED),
             ObjectBytes::Vec(bytes) => bytes.as_ref(),
         }
     }

--- a/llrt_utils/src/bytes.rs
+++ b/llrt_utils/src/bytes.rs
@@ -1,8 +1,247 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+use std::borrow::Cow;
+
 use rquickjs::{ArrayBuffer, Coerced, Ctx, Exception, IntoJs, Object, Result, TypedArray, Value};
 
-use super::result::ResultExt;
+#[derive(Clone)]
+pub enum ObjectBytes<'js> {
+    U8Array(TypedArray<'js, u8>),
+    I8Array(TypedArray<'js, i8>),
+    U16Array(TypedArray<'js, u16>),
+    I16Array(TypedArray<'js, i16>),
+    U32Array(TypedArray<'js, u32>),
+    I32Array(TypedArray<'js, i32>),
+    U64Array(TypedArray<'js, u64>),
+    I64Array(TypedArray<'js, i64>),
+    F32Array(TypedArray<'js, f32>),
+    F64Array(TypedArray<'js, f64>),
+    DataView(ArrayBuffer<'js>),
+    Vec(Option<Vec<u8>>),
+}
+
+impl<'js> ObjectBytes<'js> {
+    const DETACHED_ERROR: &'static str = "ArrayBuffer is detached";
+
+    pub fn from(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
+        Self::from_offset(ctx, value, 0, None)
+    }
+
+    pub fn from_offset(
+        ctx: &Ctx<'js>,
+        value: Value<'js>,
+        offset: usize,
+        length: Option<usize>,
+    ) -> Result<Self> {
+        if value.is_undefined() {
+            return Ok(ObjectBytes::Vec(Some(vec![])));
+        }
+        if let Some(bytes) = get_string_bytes(&value, offset, length)? {
+            return Ok(ObjectBytes::Vec(Some(bytes)));
+        }
+        if let Some(bytes) = get_array_bytes(&value, offset, length)? {
+            return Ok(ObjectBytes::Vec(Some(bytes)));
+        }
+
+        if let Some(obj) = value.as_object() {
+            if let Some(bytes) = Self::from_array_buffer(obj)? {
+                return Ok(bytes);
+            }
+        }
+
+        if let Some(bytes) = get_coerced_string_bytes(&value, offset, length) {
+            return Ok(ObjectBytes::Vec(Some(bytes)));
+        }
+
+        Err(Exception::throw_message(
+        ctx,
+        "value must be typed DataView, Buffer, ArrayBuffer, Uint8Array or interpretable as string",
+    ))
+    }
+
+    pub fn get_bytes(&mut self) -> Cow<'_, [u8]> {
+        let cow = match self {
+            ObjectBytes::U8Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::I8Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::U16Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::I16Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::U32Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::I32Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::U64Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::I64Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::F32Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::F64Array(array) => {
+                Cow::Borrowed(array.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::DataView(array_buffer) => {
+                Cow::Borrowed(array_buffer.as_bytes().expect(Self::DETACHED_ERROR))
+            },
+            ObjectBytes::Vec(bytes) => Cow::Owned(bytes.take().expect("Bytes already taken")),
+        };
+        cow
+    }
+
+    pub fn from_array_buffer(obj: &Object<'js>) -> Result<Option<ObjectBytes<'js>>> {
+        //most common
+        if let Ok(typed_array) = TypedArray::<u8>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::U8Array(typed_array)));
+        }
+        //second most common
+        if let Some(array_buffer) = ArrayBuffer::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::DataView(array_buffer)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<i8>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::I8Array(typed_array)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<u16>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::U16Array(typed_array)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<i16>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::I16Array(typed_array)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<u32>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::U32Array(typed_array)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<i32>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::I32Array(typed_array)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<u64>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::U64Array(typed_array)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<i64>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::I64Array(typed_array)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<f32>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::F32Array(typed_array)));
+        }
+
+        if let Ok(typed_array) = TypedArray::<f64>::from_object(obj.clone()) {
+            return Ok(Some(ObjectBytes::F64Array(typed_array)));
+        }
+
+        if let Ok(array_buffer) = obj.get::<_, ArrayBuffer>("buffer") {
+            return Ok(Some(ObjectBytes::DataView(array_buffer)));
+        }
+
+        Ok(None)
+    }
+
+    pub fn get_array_buffer(&self) -> Result<Option<(ArrayBuffer<'js>, usize, usize)>> {
+        let buffer = match self {
+            ObjectBytes::DataView(array_buffer) => (array_buffer.clone(), array_buffer.len(), 0),
+            ObjectBytes::U8Array(typed_array) => {
+                let byte_length = typed_array.len();
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::I8Array(typed_array) => {
+                let byte_length = typed_array.len();
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::U16Array(typed_array) => {
+                let byte_length = typed_array.len() * 2;
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::I16Array(typed_array) => {
+                let byte_length = typed_array.len() * 2;
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::U32Array(typed_array) => {
+                let byte_length = typed_array.len() * 4;
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::I32Array(typed_array) => {
+                let byte_length = typed_array.len() * 4;
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::U64Array(typed_array) => {
+                let byte_length = typed_array.len() * 8;
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::I64Array(typed_array) => {
+                let byte_length = typed_array.len() * 8;
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::F32Array(typed_array) => {
+                let byte_length = typed_array.len() * 4;
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            ObjectBytes::F64Array(typed_array) => {
+                let byte_length = typed_array.len() * 8;
+                (
+                    typed_array.arraybuffer()?,
+                    byte_length,
+                    typed_array.get("byteOffset")?,
+                )
+            },
+            _ => return Ok(None),
+        };
+
+        Ok(Some(buffer))
+    }
+}
 
 pub fn get_start_end_indexes(
     source_len: usize,
@@ -22,43 +261,8 @@ pub fn get_start_end_indexes(
     (offset, target_len + offset)
 }
 
-pub fn get_bytes_offset_length<'js>(
-    ctx: &Ctx<'js>,
-    value: Value<'js>,
-    offset: usize,
-    length: Option<usize>,
-) -> Result<Vec<u8>> {
-    if value.is_undefined() {
-        return Ok(vec![]);
-    }
-    if let Some(bytes) = get_string_bytes(&value, offset, length)? {
-        return Ok(bytes);
-    }
-    if let Some(bytes) = get_array_bytes(ctx, &value, offset, length)? {
-        return Ok(bytes);
-    }
-
-    if let Some(obj) = value.as_object() {
-        if let Some((array_buffer, source_length, source_offset)) = obj_to_array_buffer(obj)? {
-            let (start, end) = get_start_end_indexes(source_length, length, offset);
-            let bytes: &[u8] = array_buffer.as_ref();
-            return Ok(bytes[(start + source_offset)..(end + source_offset)].to_vec());
-        }
-    }
-
-    if let Some(bytes) = get_coerced_string_bytes(&value, offset, length) {
-        return Ok(bytes);
-    }
-
-    Err(Exception::throw_message(
-        ctx,
-        "value must be typed DataView, Buffer, ArrayBuffer, Uint8Array or interpretable as string",
-    ))
-}
-
-pub fn get_array_bytes<'js>(
-    ctx: &Ctx<'js>,
-    value: &Value<'js>,
+pub fn get_array_bytes(
+    value: &Value<'_>,
     offset: usize,
     length: Option<usize>,
 ) -> Result<Option<Vec<u8>>> {
@@ -69,7 +273,7 @@ pub fn get_array_bytes<'js>(
         let mut bytes: Vec<u8> = Vec::with_capacity(size);
 
         for val in array.iter::<u8>().skip(start).take(size) {
-            let val: u8 = val.or_throw_msg(ctx, "array value is not u8")?;
+            let val: u8 = val?;
             bytes.push(val);
         }
 
@@ -90,6 +294,11 @@ pub fn get_coerced_string_bytes(
     None
 }
 
+fn bytes_from_js_string(string: String, offset: usize, length: Option<usize>) -> Vec<u8> {
+    let (start, end) = get_start_end_indexes(string.len(), length, offset);
+    string.as_bytes()[start..end].to_vec()
+}
+
 #[inline]
 pub fn get_string_bytes(
     value: &Value<'_>,
@@ -101,101 +310,6 @@ pub fn get_string_bytes(
         return Ok(Some(bytes_from_js_string(string, offset, length)));
     }
     Ok(None)
-}
-
-fn bytes_from_js_string(string: String, offset: usize, length: Option<usize>) -> Vec<u8> {
-    let (start, end) = get_start_end_indexes(string.len(), length, offset);
-    string.as_bytes()[start..end].to_vec()
-}
-
-pub fn obj_to_array_buffer<'js>(
-    obj: &Object<'js>,
-) -> Result<Option<(ArrayBuffer<'js>, usize, usize)>> {
-    //most common
-    if let Ok(typed_array) = TypedArray::<u8>::from_object(obj.clone()) {
-        let byte_length = typed_array.len();
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-    //second most common
-    if let Some(array_buffer) = ArrayBuffer::from_object(obj.clone()) {
-        let byte_length = array_buffer.len();
-        return Ok(Some((array_buffer, byte_length, 0)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<i8>::from_object(obj.clone()) {
-        let byte_length = typed_array.len();
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<u16>::from_object(obj.clone()) {
-        let byte_length = typed_array.len() * 2;
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<i16>::from_object(obj.clone()) {
-        let byte_length = typed_array.len() * 2;
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<u32>::from_object(obj.clone()) {
-        let byte_length = typed_array.len() * 4;
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<i32>::from_object(obj.clone()) {
-        let byte_length = typed_array.len() * 4;
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<u64>::from_object(obj.clone()) {
-        let byte_length = typed_array.len() * 8;
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<i64>::from_object(obj.clone()) {
-        let byte_length = typed_array.len() * 8;
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<f32>::from_object(obj.clone()) {
-        let byte_length = typed_array.len() * 4;
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(typed_array) = TypedArray::<f64>::from_object(obj.clone()) {
-        let byte_length = typed_array.len() * 8;
-        let offset: usize = typed_array.get("byteOffset")?;
-        return Ok(Some((typed_array.arraybuffer()?, byte_length, offset)));
-    }
-
-    if let Ok(array_buffer) = obj.get::<_, ArrayBuffer>("buffer") {
-        let length = array_buffer.len();
-        return Ok(Some((array_buffer, length, 0)));
-    }
-
-    Ok(None)
-}
-
-pub fn get_array_buffer_bytes(
-    array_buffer: ArrayBuffer<'_>,
-    start: usize,
-    end_end: usize,
-) -> Vec<u8> {
-    let bytes: &[u8] = array_buffer.as_ref();
-    bytes[start..end_end].to_vec()
-}
-
-pub fn get_bytes<'js>(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Vec<u8>> {
-    get_bytes_offset_length(ctx, value, 0, None)
 }
 
 pub fn bytes_to_typed_array<'js>(ctx: Ctx<'js>, bytes: &[u8]) -> Result<Value<'js>> {

--- a/llrt_utils/src/bytes.rs
+++ b/llrt_utils/src/bytes.rs
@@ -24,13 +24,13 @@ pub enum ObjectBytes<'js> {
 impl<'js> ObjectBytes<'js> {
     const DETACHED_ERROR: &'static str = "ArrayBuffer is detached";
 
-    pub fn from(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
+    pub fn from(ctx: &Ctx<'js>, value: &Value<'js>) -> Result<Self> {
         Self::from_offset(ctx, value, 0, None)
     }
 
     pub fn from_offset(
         ctx: &Ctx<'js>,
-        value: Value<'js>,
+        value: &Value<'js>,
         offset: usize,
         length: Option<usize>,
     ) -> Result<Self> {

--- a/llrt_utils/src/encoding.rs
+++ b/llrt_utils/src/encoding.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use hex_simd::AsciiCase;
@@ -71,11 +73,13 @@ impl Encoder {
         }
     }
 
-    pub fn decode(&self, bytes: &[u8]) -> Result<Vec<u8>, String> {
+    pub fn decode<'a, T: Into<Cow<'a, [u8]>>>(&self, bytes: T) -> Result<Vec<u8>, String> {
         match self {
-            Self::Hex => bytes_from_hex(bytes),
-            Self::Base64 => bytes_from_b64(bytes),
-            Self::Utf8 | Self::Windows1252 | Self::Utf16le | Self::Utf16be => Ok(bytes.to_vec()),
+            Self::Hex => bytes_from_hex(&bytes.into()),
+            Self::Base64 => bytes_from_b64(&bytes.into()),
+            Self::Utf8 | Self::Windows1252 | Self::Utf16le | Self::Utf16be => {
+                Ok(bytes.into().into())
+            },
         }
     }
 

--- a/llrt_utils/src/encoding.rs
+++ b/llrt_utils/src/encoding.rs
@@ -71,11 +71,11 @@ impl Encoder {
         }
     }
 
-    pub fn decode(&self, bytes: Vec<u8>) -> Result<Vec<u8>, String> {
+    pub fn decode(&self, bytes: &[u8]) -> Result<Vec<u8>, String> {
         match self {
-            Self::Hex => bytes_from_hex(&bytes),
-            Self::Base64 => bytes_from_b64(&bytes),
-            Self::Utf8 | Self::Windows1252 | Self::Utf16le | Self::Utf16be => Ok(bytes),
+            Self::Hex => bytes_from_hex(bytes),
+            Self::Base64 => bytes_from_b64(bytes),
+            Self::Utf8 | Self::Windows1252 | Self::Utf16le | Self::Utf16be => Ok(bytes.to_vec()),
         }
     }
 

--- a/llrt_utils/src/error_messages.rs
+++ b/llrt_utils/src/error_messages.rs
@@ -1,0 +1,2 @@
+pub const ERROR_MSG_NOT_ARRAY_BUFFER: &str = "Not an ArrayBuffer";
+pub const ERROR_MSG_ARRAY_BUFFER_DETACHED: &str = "ArrayBuffer is detached";

--- a/llrt_utils/src/lib.rs
+++ b/llrt_utils/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #![cfg_attr(rust_nightly, feature(array_chunks))]
-
 pub mod bytes;
+pub mod error_messages;
 
 #[cfg(feature = "ctx")]
 pub mod ctx;


### PR DESCRIPTION
### Description of changes

Introduces `ObjectBytes` util as a replacement for `get_bytes`. `ObjectBytes` is created from any JS value and owns that value as its true type (for example a `TypedArray` or `ArrayBuffer`). Since it owns its data it can also return a shared slice or Cow, leading to reduced copies for buffer based data types. This should increase performance and lower memory as less data is copied/duplicated/allocated.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
