### PR TITLE
use mimalloc on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libnghttp2-sys"
 version = "0.1.10+1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,6 +2569,7 @@ version = "0.2.0-beta"
 dependencies = [
  "chrono",
  "llrt_core",
+ "mimalloc",
  "snmalloc-rs",
  "tokio",
  "tracing",
@@ -2707,6 +2718,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/llrt/Cargo.toml
+++ b/llrt/Cargo.toml
@@ -21,6 +21,9 @@ tokio = { version = "1", features = ["full"] }
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 snmalloc-rs = { version = "0.3.6", features = ["lto"] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+mimalloc = { version = "0.1.43" }
+
 [[bin]]
 name = "llrt"
 path = "src/main.rs"

--- a/llrt/src/main.rs
+++ b/llrt/src/main.rs
@@ -33,6 +33,10 @@ use llrt_core::compiler::compile_file;
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let now = Instant::now();


### PR DESCRIPTION
### Description of changes

In general, mimalloc has better performance

<img width="1914" alt="Snipaste_2024-08-12_11-21-46" src="https://github.com/user-attachments/assets/fcfee813-8f6b-4748-bc40-202d6a66b611">


### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
