### PR TITLE
fix: Place generated files in OUT_DIR

### DIFF
--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -17,7 +17,6 @@ use jwalk::WalkDir;
 use rquickjs::{CatchResultExt, CaughtError, Context, Module, Runtime};
 
 const BUNDLE_JS_DIR: &str = "../bundle/js";
-const BUNDLE_LRT_DIR: &str = "../bundle/lrt";
 
 include!("src/bytecode.rs");
 
@@ -52,7 +51,9 @@ async fn main() -> StdResult<(), Box<dyn Error>> {
     rt.set_loader(resolver, loader);
     let ctx = Context::full(&rt)?;
 
-    let sdk_bytecode_path = Path::new("src").join("bytecode_cache.rs");
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    let sdk_bytecode_path = Path::new(&out_dir).join("bytecode_cache.rs");
     let mut sdk_bytecode_file = BufWriter::new(File::create(sdk_bytecode_path)?);
 
     let mut ph_map = phf_codegen::Map::<String>::new();
@@ -100,7 +101,7 @@ async fn main() -> StdResult<(), Box<dyn Error>> {
 
             info!("Compiling module: {}", module_name);
 
-            let lrt_path = PathBuf::from(BUNDLE_LRT_DIR).join(path.with_extension(BYTECODE_EXT));
+            let lrt_path = PathBuf::from(&out_dir).join(path.with_extension(BYTECODE_EXT));
             let lrt_filename = lrt_path.to_string_lossy().to_string();
             lrt_filenames.push(lrt_filename.clone());
             let bytes = {
@@ -130,11 +131,7 @@ async fn main() -> StdResult<(), Box<dyn Error>> {
 
             ph_map.entry(
                 module_name,
-                &format!(
-                    "include_bytes!(\"..{}{}\")",
-                    MAIN_SEPARATOR_STR, &lrt_filename
-                )
-                .replace(MAIN_SEPARATOR_STR, "/"),
+                &format!("include_bytes!(\"{}\")", &lrt_filename),
             );
         }
 
@@ -154,7 +151,7 @@ async fn main() -> StdResult<(), Box<dyn Error>> {
         human_file_size(total_bytes)
     );
 
-    let compression_dictionary_path = Path::new(BUNDLE_LRT_DIR)
+    let compression_dictionary_path = Path::new(&out_dir)
         .join("compression.dict")
         .to_string_lossy()
         .to_string();

--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -6,7 +6,7 @@ use std::{
     error::Error,
     fs::{self, File},
     io::{self, BufWriter},
-    path::{Path, PathBuf, MAIN_SEPARATOR_STR},
+    path::{Path, PathBuf},
     process::Command,
     result::Result as StdResult,
 };

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -34,7 +34,7 @@ use rquickjs::{
 use tracing::trace;
 use zstd::{bulk::Decompressor, dict::DecoderDictionary};
 
-include!("./bytecode_cache.rs");
+include!(concat!(env!("OUT_DIR"), "/bytecode_cache.rs"));
 
 use crate::modules::{
     console,
@@ -60,7 +60,8 @@ pub fn uncompressed_size(input: &[u8]) -> StdResult<(usize, &[u8]), io::Error> {
     Ok((uncompressed_size, rest))
 }
 
-pub(crate) static COMPRESSION_DICT: &[u8] = include_bytes!("../../bundle/lrt/compression.dict");
+pub(crate) static COMPRESSION_DICT: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/compression.dict"));
 
 static DECOMPRESSOR_DICT: Lazy<DecoderDictionary> =
     Lazy::new(|| DecoderDictionary::copy(COMPRESSION_DICT));


### PR DESCRIPTION
### Description of changes

Cargo doesn't like when generated rust files are put in the `src` directory. This PR moves them to `OUT_DIR` environment (automatically set by cargo)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
