### PR TITLE
Use unchecked_unwrap where safe

### DIFF
--- a/llrt_core/src/modules/http/headers.rs
+++ b/llrt_core/src/modules/http/headers.rs
@@ -32,7 +32,7 @@ impl Headers {
     pub fn new<'js>(ctx: Ctx<'js>, init: Opt<Value<'js>>) -> Result<Self> {
         if let Some(init) = init.into_inner() {
             if init.is_array() {
-                let array = init.into_array().unwrap();
+                let array = unsafe { init.into_array().unwrap_unchecked() };
                 let headers = Self::array_to_headers(array)?;
                 return Ok(Self { headers });
             } else if init.is_object() {
@@ -166,7 +166,7 @@ impl Headers {
 
     pub fn from_value<'js>(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
         if value.is_object() {
-            let headers_obj = value.as_object().unwrap();
+            let headers_obj = unsafe { value.as_object().unwrap_unchecked() };
             return if headers_obj.instance_of::<Headers>() {
                 Headers::from_js(ctx, value)
             } else {

--- a/llrt_core/src/modules/http/mod.rs
+++ b/llrt_core/src/modules/http/mod.rs
@@ -104,7 +104,7 @@ pub static TLS_CONFIG: Lazy<io::Result<ClientConfig>> = Lazy::new(|| {
             Ok("1.3") => builder.with_safe_default_protocol_versions(),
             _ => builder.with_protocol_versions(&[&version::TLS12]), //Use TLS 1.2 by default to increase compat and keep latency low
         }
-        .unwrap()
+        .expect("TLS configuration failed")
         .with_root_certificates(root_certificates)
         .with_no_client_auth(),
     )

--- a/llrt_core/src/modules/http/request.rs
+++ b/llrt_core/src/modules/http/request.rs
@@ -66,7 +66,9 @@ impl<'js> Request<'js> {
         if input.is_string() {
             request.url = input.get()?;
         } else if input.is_object() {
-            assign_request(&mut request, ctx.clone(), input.as_object().unwrap())?;
+            assign_request(&mut request, ctx.clone(), unsafe {
+                input.as_object().unwrap_unchecked()
+            })?;
         }
         if let Some(options) = options.0 {
             assign_request(&mut request, ctx.clone(), &options)?;

--- a/llrt_core/src/modules/http/url.rs
+++ b/llrt_core/src/modules/http/url.rs
@@ -169,7 +169,10 @@ impl<'js> URL<'js> {
     #[qjs(set, rename = "port")]
     pub fn set_port(&mut self, ctx: Ctx<'js>, port: Value<'js>) -> Value<'js> {
         // TODO: negative ports should be handled in Url
-        if port.is_null() || port.is_undefined() || (port.is_int() && port.as_int().unwrap() < 0) {
+        if port.is_null()
+            || port.is_undefined()
+            || (port.is_int() && unsafe { port.as_int().unwrap_unchecked() } < 0)
+        {
             return port;
         }
 
@@ -310,7 +313,9 @@ pub fn domain_to_ascii(domain: &str) -> String {
 
 //options are ignored, no windows support yet
 pub fn path_to_file_url<'js>(ctx: Ctx<'js>, path: String, _: Opt<Value>) -> Result<URL<'js>> {
-    let url = Url::from_file_path(path).unwrap();
+    let url = Url::from_file_path(&path)
+        .map_err(|_| Exception::throw_type(&ctx, &["Path is not absolute: ", &path].concat()))?;
+
     URL::from_url(ctx, url)
 }
 

--- a/llrt_core/src/modules/http/url_search_params.rs
+++ b/llrt_core/src/modules/http/url_search_params.rs
@@ -50,12 +50,12 @@ impl<'js> URLSearchParams {
                 let string: String = Coerced::from_js(&ctx, init)?.0;
                 return Ok(Self::from_str(string));
             } else if init.is_array() {
-                return Self::from_array(&ctx, init.into_array().unwrap());
+                return Self::from_array(&ctx, unsafe { init.into_array().unwrap_unchecked() });
             } else if init.is_object() {
-                return Self::from_object(&ctx, init.into_object().unwrap());
+                return Self::from_object(&ctx, unsafe { init.into_object().unwrap_unchecked() });
             }
         }
-        let url: Url = "http://example.com".parse().unwrap();
+        let url: Url = unsafe { "http://example.com".parse().unwrap_unchecked() };
 
         Ok(URLSearchParams {
             url: Rc::new(RefCell::new(url)),
@@ -264,11 +264,13 @@ impl<'js> URLSearchParams {
         } else {
             query
         };
-        let url = "http://example.com"
-            .parse::<Url>()
-            .unwrap()
-            .join(&query)
-            .unwrap();
+        let url = unsafe {
+            "http://example.com"
+                .parse::<Url>()
+                .unwrap_unchecked()
+                .join(&query)
+                .unwrap_unchecked()
+        };
         Self {
             url: Rc::new(RefCell::new(url)),
         }

--- a/llrt_core/src/utils/clone.rs
+++ b/llrt_core/src/utils/clone.rs
@@ -102,7 +102,8 @@ pub fn structured_clone<'js>(
                             continue;
                         }
 
-                        let object = value.as_object().unwrap();
+                        //unsafe OK since we're guaranteed to be object by the match
+                        let object = unsafe { value.as_object().unwrap_unchecked() };
 
                         if object.is_instance_of(&date_ctor) {
                             append_ctor_value(
@@ -202,7 +203,8 @@ pub fn structured_clone<'js>(
                             value: TapeValue::Array(new),
                         });
                         stack.push(StackItem::ObjectEnd);
-                        let array = value.as_array().unwrap();
+                        //unsafe OK since we're guaranteed to be object by the match
+                        let array = unsafe { value.as_array().unwrap_unchecked() };
 
                         //reverse for loop of items in array
                         for array_index in (0usize..array.len()).rev() {

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -106,15 +106,12 @@ impl BinaryResolver {
         }
         normalized
     }
-}
 
-impl Default for BinaryResolver {
-    fn default() -> Self {
-        let cwd = env::current_dir().unwrap();
-        Self {
-            cwd,
+    fn new() -> io::Result<Self> {
+        Ok(Self {
             paths: Vec::with_capacity(10),
-        }
+            cwd: env::current_dir()?,
+        })
     }
 }
 
@@ -366,7 +363,7 @@ impl Vm {
             .expect("Failed to initialize SystemRandom");
 
         let mut file_resolver = FileResolver::default();
-        let mut binary_resolver = BinaryResolver::default();
+        let mut binary_resolver = BinaryResolver::new()?;
         let mut paths: Vec<&str> = Vec::with_capacity(10);
 
         paths.push(".");


### PR DESCRIPTION
### Description of changes

Uses `unchecked_unwrap` where safe to do. Also improves some error handling.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
