### PR TITLE
perf: Dynamic timer sleep

### DIFF
--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -14,11 +14,11 @@ use crate::modules::{
     path::PathModule,
     perf_hooks::PerfHooksModule,
     process::ProcessModule,
-    timers::TimersModule,
     url::UrlModule,
     util::UtilModule,
     zlib::ZlibModule,
 };
+use llrt_modules::timers::TimersModule;
 pub use llrt_modules::ModuleInfo;
 use rquickjs::{
     loader::{BuiltinResolver, ModuleLoader, Resolver},

--- a/llrt_core/src/modules/events/abort_signal.rs
+++ b/llrt_core/src/modules/events/abort_signal.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::sync::{Arc, RwLock};
 
+use llrt_modules::timers::set_timeout_interval;
 use rquickjs::{
     class::{Trace, Tracer},
     function::OnceFn,
@@ -10,10 +11,7 @@ use rquickjs::{
 };
 
 use super::{Emitter, EventEmitter, EventList};
-use crate::{
-    modules::{exceptions::DOMException, timers::set_timeout_interval},
-    utils::mc_oneshot,
-};
+use crate::{modules::exceptions::DOMException, utils::mc_oneshot};
 
 #[derive(Clone)]
 #[rquickjs::class]

--- a/llrt_core/src/modules/events/abort_signal.rs
+++ b/llrt_core/src/modules/events/abort_signal.rs
@@ -168,7 +168,7 @@ impl<'js> AbortSignal<'js> {
     }
 
     #[qjs(static)]
-    pub fn timeout(ctx: Ctx<'js>, milliseconds: usize) -> Result<Class<'js, Self>> {
+    pub fn timeout(ctx: Ctx<'js>, milliseconds: u64) -> Result<Class<'js, Self>> {
         let timeout_error = get_reason_or_dom_exception(&ctx, None, "TimeoutError")?;
 
         let signal = Self::new();

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -12,6 +12,5 @@ pub mod events;
 pub mod http;
 pub mod llrt;
 pub mod module;
-pub mod timers;
 pub mod url;
 pub mod util;

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -13,6 +13,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use llrt_modules::timers::{self, poll_timers};
 use llrt_utils::bytes::ObjectBytes;
 use once_cell::sync::Lazy;
 
@@ -38,7 +39,6 @@ use crate::modules::{
     console,
     crypto::SYSTEM_RANDOM,
     path::{dirname, join_path, resolve_path},
-    timers::{self, poll_timers},
 };
 
 use crate::{
@@ -641,7 +641,7 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
                 }
 
                 if deadline < Instant::now() {
-                    poll_timers(rt, &mut executing_timers, None, Some(&mut deadline));
+                    poll_timers(rt, &mut executing_timers, None, Some(&mut deadline))?;
                 }
 
                 ctx.execute_pending_job();

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -22,6 +22,7 @@ all = [
   "perf-hooks",
   "process",
   "zlib",
+  "timers",
 ]
 
 buffer = ["llrt_utils/encoding"]
@@ -41,6 +42,7 @@ os = [
 path = []
 process = []
 perf-hooks = []
+timers = []
 zlib = ["flate2", "brotlic"]
 
 __bytearray-buffer = ["tokio/sync"]

--- a/llrt_modules/src/modules/mod.rs
+++ b/llrt_modules/src/modules/mod.rs
@@ -22,5 +22,7 @@ pub mod path;
 pub mod perf_hooks;
 #[cfg(feature = "process")]
 pub mod process;
+#[cfg(feature = "timers")]
+pub mod timers;
 #[cfg(feature = "zlib")]
 pub mod zlib;

--- a/tests/unit/console.test.ts
+++ b/tests/unit/console.test.ts
@@ -37,8 +37,10 @@ it("should log module", () => {
     setTimeout: [function: (anonymous)],
     clearTimeout: [function: (anonymous)],
     setInterval: [function: (anonymous)],
-    clearInterval: [function: (anonymous)]
+    clearInterval: [function: (anonymous)],
+    setImmediate: [function: (anonymous)]
   },
+  setImmediate: [function: (anonymous)],
   setInterval: [function: (anonymous)],
   setTimeout: [function: (anonymous)]
 }


### PR DESCRIPTION
### Description of changes

Use dynamic sleep instead of fixed for timer & interval sleeps. This significantly reduces wakes in the async scheduler since timers are very likely to be above 4ms (previous min value).

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
