### PR TITLE
fix: socket.destroy() & broken test

### DIFF
--- a/llrt_modules/src/modules/fs/open.rs
+++ b/llrt_modules/src/modules/fs/open.rs
@@ -29,7 +29,7 @@ pub async fn open(
         flags => {
             return Err(Exception::throw_message(
                 &ctx,
-                &format!("Invalid flags '{}'", flags),
+                &["Invalid flags '", flags, "'"].concat(),
             ))
         },
     };

--- a/tests/unit/socket.test.ts
+++ b/tests/unit/socket.test.ts
@@ -82,7 +82,12 @@ describe("error handling", () => {
   });
 
   it("should handle client destroy", (done) => {
-    const server = net.createServer((socket) => {
+    let closedResolve: () => void;
+    const closePromise = new Promise<void>((resolve) => {
+      closedResolve = resolve;
+    });
+    const server = net.createServer(async (socket) => {
+      await closePromise;
       setTimeout(() => {
         socket.write("hello", (err) => {
           expect(err).toBeTruthy();
@@ -95,6 +100,7 @@ describe("error handling", () => {
     server.listen(() => {
       const client = net.connect((server.address() as any).port, () => {
         client.destroy();
+        client.on("close", closedResolve);
       });
     });
   });


### PR DESCRIPTION
### Issue # (if available)

Fixes: https://github.com/awslabs/llrt/pull/536#issuecomment-2283467669

### Description of changes

Make sure socket is really closed before trying to send to it. Process is expected to crash with an exception if no error handler is attached to the incoming socket.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
