### PR TITLE
Fixes: @definitelytyped/eslint-plugin@0.1,17 isn't supported by any available resolver.

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -15,7 +15,7 @@
   ],
   "devDependencies": {
     "@definitelytyped/dtslint": "^0.2.22",
-    "@definitelytyped/eslint-plugin": "^0.1,17",
+    "@definitelytyped/eslint-plugin": "^0.1.17",
     "typescript": "^5.5.3"
   },
   "scripts": {


### PR DESCRIPTION
### Issue # (if available)

When installing `NPM` packages through PNPM or other monorepo solutions the package.json errors with:

```sh
 ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER  @definitelytyped/eslint-plugin@0.1,17 isn't supported by any available resolver.
```

### Description of changes

This fixes the `package.json` so that it has the correct version as the one installed has a `,` instead of a `.` for a version number.

### Checklist

- [❌] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [❌] Ran `make fix` to format JS and apply Clippy auto fixes
- [❌] Made sure my code didn't add any additional warnings: `make check`
- [❌] Added relevant type info in `types/` directory
- [❌] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
