### PR TITLE
chore: remove unused ctx params

### DIFF
--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -130,8 +130,8 @@ async fn main() -> StdResult<(), Box<dyn Error>> {
             info!("Done!");
 
             ph_map.entry(
-                module_name.replace("\\", "/"),
-                &format!("include_bytes!(\"{}\")", &lrt_filename).replace("\\", "/"),
+                module_name.replace('\\', "/"),
+                &format!("include_bytes!(\"{}\")", &lrt_filename).replace('\\', "/"),
             );
         }
 

--- a/llrt_core/src/modules/llrt/xml.rs
+++ b/llrt_core/src/modules/llrt/xml.rs
@@ -78,7 +78,7 @@ impl<'js> StackObject<'js> {
 #[rquickjs::methods(rename_all = "camelCase")]
 impl<'js> XMLParser<'js> {
     #[qjs(constructor)]
-    pub fn new(_ctx: Ctx<'js>, options: Opt<Object<'js>>) -> Result<Self> {
+    pub fn new(options: Opt<Object<'js>>) -> Result<Self> {
         let mut tag_value_processor = None;
         let mut attribute_value_processor = None;
         let mut attribute_name_prefix = String::from("@_");

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -563,7 +563,7 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
     js_bootstrap.set(
         "moduleExport",
         Func::from(move |ctx, obj, prop, value| {
-            let ExportArgs(_ctx, _, _, value) = ExportArgs(ctx, obj, prop, value);
+            let ExportArgs(_, _, _, value) = ExportArgs(ctx, obj, prop, value);
             let mut exports = require_exports.lock().unwrap();
             exports.replace(value);
             Result::Ok(true)

--- a/llrt_modules/src/modules/child_process.rs
+++ b/llrt_modules/src/modules/child_process.rs
@@ -155,7 +155,7 @@ impl<'js> ChildProcess<'js> {
         self.pid.into_js(&ctx)
     }
 
-    fn kill(&mut self, _ctx: Ctx<'js>, signal: Opt<Value<'js>>) -> Result<bool> {
+    fn kill(&mut self, signal: Opt<Value<'js>>) -> Result<bool> {
         #[cfg(unix)]
         let signal = if let Some(signal) = signal.0 {
             if signal.is_number() {

--- a/llrt_modules/src/modules/crypto/crc32.rs
+++ b/llrt_modules/src/modules/crypto/crc32.rs
@@ -23,7 +23,7 @@ impl Crc32c {
     }
 
     #[qjs(rename = "digest")]
-    fn crc32c_digest(&self, _ctx: Ctx<'_>) -> u64 {
+    fn crc32c_digest(&self) -> u64 {
         self.hasher.finish()
     }
 
@@ -56,7 +56,7 @@ impl Crc32 {
     }
 
     #[qjs(rename = "digest")]
-    fn crc32_digest(&self, _ctx: Ctx<'_>) -> u64 {
+    fn crc32_digest(&self) -> u64 {
         self.hasher.finish()
     }
 

--- a/llrt_modules/src/modules/crypto/mod.rs
+++ b/llrt_modules/src/modules/crypto/mod.rs
@@ -65,7 +65,7 @@ fn get_random_bytes(ctx: Ctx, length: usize) -> Result<Value> {
     Buffer(random_bytes).into_js(&ctx)
 }
 
-fn get_random_int(_ctx: Ctx, first: i64, second: Opt<i64>) -> Result<i64> {
+fn get_random_int(first: i64, second: Opt<i64>) -> Result<i64> {
     let mut rng = ThreadRng::default();
     let random_number = match second.0 {
         Some(max) => rng.gen_range(first..max),

--- a/llrt_modules/src/modules/events/custom_event.rs
+++ b/llrt_modules/src/modules/events/custom_event.rs
@@ -14,7 +14,7 @@ pub struct CustomEvent<'js> {
 #[rquickjs::methods]
 impl<'js> CustomEvent<'js> {
     #[qjs(constructor)]
-    pub fn new(_ctx: Ctx<'js>, event_type: String, options: Opt<Value<'js>>) -> Result<Self> {
+    pub fn new(event_type: String, options: Opt<Value<'js>>) -> Result<Self> {
         let mut detail = None;
         if let Some(options) = options.0 {
             if let Some(opt) = options.get_optional("detail")? {

--- a/llrt_modules/src/modules/fs/read_dir.rs
+++ b/llrt_modules/src/modules/fs/read_dir.rs
@@ -106,7 +106,7 @@ impl<'js> IntoJs<'js> for ReadDir {
     }
 }
 
-pub async fn read_dir<'js>(mut path: String, options: Opt<Object<'js>>) -> Result<ReadDir> {
+pub async fn read_dir(mut path: String, options: Opt<Object<'_>>) -> Result<ReadDir> {
     let (with_file_types, skip_root_pos, mut directory_walker) =
         process_options_and_create_directory_walker(&mut path, options);
 

--- a/llrt_modules/src/modules/fs/read_dir.rs
+++ b/llrt_modules/src/modules/fs/read_dir.rs
@@ -127,7 +127,7 @@ pub async fn read_dir<'js>(mut path: String, options: Opt<Object<'js>>) -> Resul
     Ok(ReadDir { items, root: path })
 }
 
-pub fn read_dir_sync<'js>(mut path: String, options: Opt<Object<'js>>) -> Result<ReadDir> {
+pub fn read_dir_sync(mut path: String, options: Opt<Object<'_>>) -> Result<ReadDir> {
     let (with_file_types, skip_root_pos, mut directory_walker) =
         process_options_and_create_directory_walker(&mut path, options);
 

--- a/llrt_modules/src/modules/fs/read_dir.rs
+++ b/llrt_modules/src/modules/fs/read_dir.rs
@@ -106,11 +106,7 @@ impl<'js> IntoJs<'js> for ReadDir {
     }
 }
 
-pub async fn read_dir<'js>(
-    _ctx: Ctx<'js>,
-    mut path: String,
-    options: Opt<Object<'js>>,
-) -> Result<ReadDir> {
+pub async fn read_dir<'js>(mut path: String, options: Opt<Object<'js>>) -> Result<ReadDir> {
     let (with_file_types, skip_root_pos, mut directory_walker) =
         process_options_and_create_directory_walker(&mut path, options);
 
@@ -131,11 +127,7 @@ pub async fn read_dir<'js>(
     Ok(ReadDir { items, root: path })
 }
 
-pub fn read_dir_sync<'js>(
-    _ctx: Ctx<'js>,
-    mut path: String,
-    options: Opt<Object<'js>>,
-) -> Result<ReadDir> {
+pub fn read_dir_sync<'js>(mut path: String, options: Opt<Object<'js>>) -> Result<ReadDir> {
     let (with_file_types, skip_root_pos, mut directory_walker) =
         process_options_and_create_directory_walker(&mut path, options);
 

--- a/llrt_modules/src/modules/fs/rm.rs
+++ b/llrt_modules/src/modules/fs/rm.rs
@@ -61,7 +61,7 @@ pub async fn rmfile<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>)
     Ok(())
 }
 
-pub fn rmfile_sync<'js>(_ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<()> {
+pub fn rmfile_sync<'js>(path: String, options: Opt<Object<'js>>) -> Result<()> {
     let (recursive, force) = get_params_rm(options);
 
     let res = (|| -> Result<()> {

--- a/llrt_modules/src/modules/fs/rm.rs
+++ b/llrt_modules/src/modules/fs/rm.rs
@@ -61,7 +61,7 @@ pub async fn rmfile<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>)
     Ok(())
 }
 
-pub fn rmfile_sync<'js>(path: String, options: Opt<Object<'js>>) -> Result<()> {
+pub fn rmfile_sync(path: String, options: Opt<Object<'_>>) -> Result<()> {
     let (recursive, force) = get_params_rm(options);
 
     let res = (|| -> Result<()> {

--- a/llrt_modules/src/modules/net/socket.rs
+++ b/llrt_modules/src/modules/net/socket.rs
@@ -139,14 +139,10 @@ impl<'js> Socket<'js> {
         Ok(())
     }
 
-    pub fn destroy(
-        this: This<Class<'js, Self>>,
-        ctx: Ctx<'js>,
-        error: Opt<Value<'js>>,
-    ) -> Class<'js, Self> {
+    pub fn destroy(this: This<Class<'js, Self>>, error: Opt<Value<'js>>) -> Class<'js, Self> {
         this.borrow_mut().destroyed = true;
-        ReadableStream::destroy(This(this.clone()), ctx.clone(), Opt(None));
-        WritableStream::destroy(This(this.clone()), ctx.clone(), error);
+        ReadableStream::destroy(This(this.clone()), Opt(None));
+        WritableStream::destroy(This(this.clone()), error);
         this.0
     }
 

--- a/llrt_modules/src/stream/readable.rs
+++ b/llrt_modules/src/stream/readable.rs
@@ -163,11 +163,7 @@ where
         Ok(())
     }
 
-    fn destroy(
-        this: This<Class<'js, Self>>,
-        _ctx: Ctx<'js>,
-        error: Opt<Value<'js>>,
-    ) -> Class<'js, Self> {
+    fn destroy(this: This<Class<'js, Self>>, error: Opt<Value<'js>>) -> Class<'js, Self> {
         let mut borrow = this.borrow_mut();
         let inner = borrow.inner_mut();
         inner.is_destroyed = true;

--- a/llrt_modules/src/stream/writable.rs
+++ b/llrt_modules/src/stream/writable.rs
@@ -127,11 +127,7 @@ where
         Ok(())
     }
 
-    fn destroy(
-        this: This<Class<'js, Self>>,
-        _ctx: Ctx<'js>,
-        error: Opt<Value<'js>>,
-    ) -> Class<'js, Self> {
+    fn destroy(this: This<Class<'js, Self>>, error: Opt<Value<'js>>) -> Class<'js, Self> {
         if !this.borrow().inner().is_finished {
             let mut borrow = this.borrow_mut();
             let inner = borrow.inner_mut();


### PR DESCRIPTION
### Description of changes

Removed unused ctx params

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
