### PR TITLE
refactor: Improvement of ObjectBytes by implementing FromJs

### DIFF
--- a/llrt_core/src/modules/encoding/text_decoder.rs
+++ b/llrt_core/src/modules/encoding/text_decoder.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use llrt_utils::{bytes::ObjectBytes, encoding::Encoder, object::ObjectExt};
-use rquickjs::{function::Opt, Ctx, Object, Result, Value};
+use rquickjs::{function::Opt, Ctx, Object, Result};
 
 use crate::utils::result::ResultExt;
 
@@ -58,8 +58,7 @@ impl<'js> TextDecoder {
         self.ignore_bom
     }
 
-    pub fn decode(&self, ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let bytes = ObjectBytes::from(&ctx, &buffer)?;
+    pub fn decode(&self, ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<String> {
         let bytes = bytes.as_bytes();
         let start_pos = if !self.ignore_bom {
             match bytes.get(..3) {

--- a/llrt_core/src/modules/llrt/hex.rs
+++ b/llrt_core/src/modules/llrt/hex.rs
@@ -20,8 +20,7 @@ use self::encoder::{bytes_from_hex, bytes_to_hex_string};
 pub struct LlrtHexModule;
 
 impl LlrtHexModule {
-    pub fn encode<'js>(ctx: Ctx<'js>, buffer: Value<'js>) -> Result<String> {
-        let bytes = ObjectBytes::from(&ctx, &buffer)?;
+    pub fn encode(bytes: ObjectBytes<'_>) -> Result<String> {
         Ok(bytes_to_hex_string(bytes.as_bytes()))
     }
 

--- a/llrt_core/src/modules/llrt/xml.rs
+++ b/llrt_core/src/modules/llrt/xml.rs
@@ -114,8 +114,7 @@ impl<'js> XMLParser<'js> {
         self.entities.insert(key.into(), value.into());
     }
 
-    pub fn parse(&self, ctx: Ctx<'js>, xml: Value<'js>) -> Result<Object<'js>> {
-        let bytes = ObjectBytes::from(&ctx, &xml)?;
+    pub fn parse(&self, ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<Object<'js>> {
         let bytes = bytes.as_bytes();
         let mut reader = Reader::from_reader(bytes);
         let config = reader.config_mut();

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -489,8 +489,7 @@ impl Vm {
     }
 }
 
-fn json_parse_string<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<Value<'js>> {
-    let bytes = ObjectBytes::from(&ctx, &value)?;
+fn json_parse_string<'js>(ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<Value<'js>> {
     let bytes = bytes.as_bytes();
     json_parse(&ctx, bytes)
 }

--- a/llrt_modules/src/modules/crypto/crc32.rs
+++ b/llrt_modules/src/modules/crypto/crc32.rs
@@ -4,7 +4,7 @@ use std::hash::Hasher;
 
 use crc32c::Crc32cHasher;
 use llrt_utils::bytes::ObjectBytes;
-use rquickjs::{prelude::This, Class, Ctx, Result, Value};
+use rquickjs::{prelude::This, Class, Result};
 
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace)]
@@ -30,10 +30,8 @@ impl Crc32c {
     #[qjs(rename = "update")]
     fn crc32c_update<'js>(
         this: This<Class<'js, Self>>,
-        ctx: Ctx<'js>,
-        value: Value<'js>,
+        bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = ObjectBytes::from(&ctx, &value)?;
         this.0.borrow_mut().hasher.write(bytes.as_bytes());
         Ok(this.0)
     }
@@ -63,10 +61,8 @@ impl Crc32 {
     #[qjs(rename = "update")]
     fn crc32_update<'js>(
         this: This<Class<'js, Self>>,
-        ctx: Ctx<'js>,
-        value: Value<'js>,
+        bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = ObjectBytes::from(&ctx, &value)?;
         this.0.borrow_mut().hasher.write(bytes.as_bytes());
         Ok(this.0)
     }

--- a/llrt_modules/src/modules/crypto/md5_hash.rs
+++ b/llrt_modules/src/modules/crypto/md5_hash.rs
@@ -37,10 +37,8 @@ impl Md5 {
     #[qjs(rename = "update")]
     fn md5_update<'js>(
         this: This<Class<'js, Self>>,
-        ctx: Ctx<'js>,
-        value: Value<'js>,
+        bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = ObjectBytes::from(&ctx, &value)?;
         this.0.borrow_mut().hasher.update(bytes.as_bytes());
         Ok(this.0)
     }

--- a/llrt_modules/src/modules/crypto/mod.rs
+++ b/llrt_modules/src/modules/crypto/mod.rs
@@ -227,10 +227,9 @@ impl ModuleDef for CryptoModule {
                 let class_name: &str = sha_algorithm.class_name();
                 let algo = sha_algorithm;
 
-                let ctor =
-                    Constructor::new_class::<ShaHash, _, _>(ctx.clone(), move |ctx, secret| {
-                        ShaHash::new(ctx, algo, secret)
-                    })?;
+                let ctor = Constructor::new_class::<ShaHash, _, _>(ctx.clone(), move |secret| {
+                    ShaHash::new(algo, secret)
+                })?;
 
                 default.set(class_name, ctor)?;
             }

--- a/llrt_modules/src/modules/crypto/sha_hash.rs
+++ b/llrt_modules/src/modules/crypto/sha_hash.rs
@@ -19,9 +19,7 @@ pub struct Hmac {
 #[rquickjs::methods]
 impl Hmac {
     #[qjs(skip)]
-    pub fn new<'js>(ctx: Ctx<'js>, algorithm: String, secret: Value<'js>) -> Result<Self> {
-        let key_value = ObjectBytes::from(&ctx, &secret)?;
-
+    pub fn new<'js>(ctx: Ctx<'js>, algorithm: String, key_value: ObjectBytes<'js>) -> Result<Self> {
         let algorithm = match algorithm.to_lowercase().as_str() {
             "sha1" => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
             "sha256" => hmac::HMAC_SHA256,
@@ -52,10 +50,8 @@ impl Hmac {
 
     fn update<'js>(
         this: This<Class<'js, Self>>,
-        ctx: Ctx<'js>,
-        value: Value<'js>,
+        bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = ObjectBytes::from(&ctx, &value)?;
         let bytes = bytes.as_bytes();
         this.0.borrow_mut().context.update(bytes);
 
@@ -114,10 +110,8 @@ impl Hash {
     #[qjs(rename = "update")]
     fn hash_update<'js>(
         this: This<Class<'js, Self>>,
-        ctx: Ctx<'js>,
-        value: Value<'js>,
+        bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = ObjectBytes::from(&ctx, &value)?;
         let bytes = bytes.as_bytes();
         this.0.borrow_mut().context.update(bytes);
         Ok(this.0)
@@ -168,17 +162,8 @@ pub struct ShaHash {
 #[rquickjs::methods]
 impl ShaHash {
     #[qjs(skip)]
-    pub fn new<'js>(
-        ctx: Ctx<'js>,
-        algorithm: ShaAlgorithm,
-        secret: Opt<Value<'js>>,
-    ) -> Result<Self> {
-        let secret = if let Some(secret) = secret.0 {
-            let bytes = ObjectBytes::from(&ctx, &secret)?;
-            Some(bytes.into_bytes())
-        } else {
-            None
-        };
+    pub fn new(algorithm: ShaAlgorithm, secret: Opt<ObjectBytes<'_>>) -> Result<Self> {
+        let secret = secret.0.map(|bytes| bytes.into_bytes());
 
         Ok(ShaHash {
             secret,
@@ -205,10 +190,8 @@ impl ShaHash {
     #[qjs(rename = "update")]
     fn sha_update<'js>(
         this: This<Class<'js, Self>>,
-        ctx: Ctx<'js>,
-        value: Value<'js>,
+        bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = ObjectBytes::from(&ctx, &value)?;
         this.0.borrow_mut().bytes = bytes.into();
         Ok(this.0)
     }

--- a/llrt_modules/src/modules/fs/write_file.rs
+++ b/llrt_modules/src/modules/fs/write_file.rs
@@ -2,18 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
-use rquickjs::{Ctx, Result, Value};
+use rquickjs::{Ctx, Result};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
-pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> Result<()> {
+pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, bytes: ObjectBytes<'js>) -> Result<()> {
     let mut file = fs::File::create(&path)
         .await
         .or_throw_msg(&ctx, &["Can't create file \"", &path, "\""].concat())?;
 
     let write_error_message = &["Can't write file \"", &path, "\""].concat();
 
-    let bytes = ObjectBytes::from(&ctx, &data)?;
     file.write_all(bytes.as_bytes())
         .await
         .or_throw_msg(&ctx, write_error_message)?;
@@ -22,9 +21,7 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
     Ok(())
 }
 
-pub fn write_file_sync<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> Result<()> {
-    let bytes = ObjectBytes::from(&ctx, &data)?;
-
+pub fn write_file_sync<'js>(ctx: Ctx<'js>, path: String, bytes: ObjectBytes<'js>) -> Result<()> {
     std::fs::write(&path, bytes.as_bytes())
         .or_throw_msg(&ctx, &["Can't write \"{}\"", &path].concat())?;
 

--- a/llrt_modules/src/modules/fs/write_file.rs
+++ b/llrt_modules/src/modules/fs/write_file.rs
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
-use rquickjs::{Ctx, Result};
+use rquickjs::{Ctx, Result, Value};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
-pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, bytes: ObjectBytes<'js>) -> Result<()> {
-    let mut file = fs::File::create(&path)
-        .await
-        .or_throw_msg(&ctx, &["Can't create file \"", &path, "\""].concat())?;
-
+pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> Result<()> {
     let write_error_message = &["Can't write file \"", &path, "\""].concat();
 
+    let mut file = fs::File::create(&path)
+        .await
+        .or_throw_msg(&ctx, write_error_message)?;
+
+    let bytes = ObjectBytes::from(&ctx, &data)?;
     file.write_all(bytes.as_bytes())
         .await
         .or_throw_msg(&ctx, write_error_message)?;

--- a/llrt_modules/src/modules/zlib.rs
+++ b/llrt_modules/src/modules/zlib.rs
@@ -26,7 +26,7 @@ macro_rules! define_sync_function {
     ($fn_name:ident, $converter:expr, $command:expr) => {
         pub fn $fn_name<'js>(
             ctx: Ctx<'js>,
-            value: Value<'js>,
+            value: ObjectBytes<'js>,
             options: Opt<Value<'js>>,
         ) -> Result<Value<'js>> {
             $converter(ctx.clone(), value, options, $command)
@@ -38,7 +38,7 @@ macro_rules! define_cb_function {
     ($fn_name:ident, $converter:expr, $command:expr) => {
         pub fn $fn_name<'js>(
             ctx: Ctx<'js>,
-            value: Value<'js>,
+            value: ObjectBytes<'js>,
             args: Rest<Value<'js>>,
         ) -> Result<()> {
             let mut args_iter = args.0.into_iter().rev();
@@ -79,11 +79,10 @@ enum ZlibCommand {
 
 fn zlib_converter<'js>(
     ctx: Ctx<'js>,
-    value: Value<'js>,
+    bytes: ObjectBytes<'js>,
     options: Opt<Value<'js>>,
     command: ZlibCommand,
 ) -> Result<Value<'js>> {
-    let bytes = ObjectBytes::from(&ctx, &value)?;
     let src = bytes.as_bytes();
 
     let mut level = Compression::default();
@@ -132,11 +131,10 @@ enum BrotliCommand {
 
 fn brotli_converter<'js>(
     ctx: Ctx<'js>,
-    value: Value<'js>,
+    bytes: ObjectBytes<'js>,
     _options: Opt<Value<'js>>,
     command: BrotliCommand,
 ) -> Result<Value<'js>> {
-    let bytes = ObjectBytes::from(&ctx, &value)?;
     let src = bytes.as_bytes();
 
     let mut dst: Vec<u8> = Vec::with_capacity(src.len());

--- a/llrt_utils/src/bytes.rs
+++ b/llrt_utils/src/bytes.rs
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-use rquickjs::{ArrayBuffer, Coerced, Ctx, Exception, IntoJs, Object, Result, TypedArray, Value};
+use rquickjs::{
+    ArrayBuffer, Coerced, Ctx, Exception, FromJs, IntoJs, Object, Result, TypedArray, Value,
+};
 
 use crate::error_messages::ERROR_MSG_ARRAY_BUFFER_DETACHED;
 
@@ -30,6 +31,12 @@ impl<'js> From<ObjectBytes<'js>> for Vec<u8> {
 impl<'a, 'js> From<&'a ObjectBytes<'js>> for &'a [u8] {
     fn from(value: &'a ObjectBytes<'js>) -> Self {
         value.as_bytes()
+    }
+}
+
+impl<'js> FromJs<'js> for ObjectBytes<'js> {
+    fn from_js(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
+        Self::from_offset(ctx, &value, 0, None)
     }
 }
 


### PR DESCRIPTION
### Description of changes

- We organized the existing code by implementing `FromJs` for `ObjectBytes`.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
