### PR TITLE
refactor: typing for buffer

### DIFF
--- a/types/buffer.d.ts
+++ b/types/buffer.d.ts
@@ -83,7 +83,7 @@ declare module "buffer" {
      * // Prints: <Buffer 00 00 00 00 00>
      * ```
      *
-     * If `fill` is specified, the allocated `Buffer` will be initialized by calling `buf.fill(fill)`.
+     * If `fill` is specified, the allocated `Buffer` will be initialized by calling `Buffer.alloc(size, fill)`.
      *
      * ```js
      * import { Buffer } from 'buffer';
@@ -95,7 +95,7 @@ declare module "buffer" {
      * ```
      *
      * If both `fill` and `encoding` are specified, the allocated `Buffer` will be
-     * initialized by calling `buf.fill(fill, encoding)`.
+     * initialized by calling `Buffer.aloc(size, fill, encoding)`.
      *
      * ```js
      * import { Buffer } from 'buffer';

--- a/types/buffer.d.ts
+++ b/types/buffer.d.ts
@@ -1,3 +1,40 @@
+/**
+ * `Buffer` objects are used to represent a fixed-length sequence of bytes. Many
+ * LLRT APIs support `Buffer`s.
+ *
+ * The `Buffer` class is a subclass of JavaScript's [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) class and
+ * extends it with methods that cover additional use cases. LLRT APIs accept
+ * plain [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) s wherever `Buffer`s are supported as well.
+ *
+ * While the `Buffer` class is available within the global scope, it is still
+ * recommended to explicitly reference it via an import or require statement.
+ *
+ * ```js
+ * import { Buffer } from 'buffer';
+ *
+ * // Creates a zero-filled Buffer of length 10.
+ * const buf1 = Buffer.alloc(10);
+ *
+ * // Creates a Buffer of length 10,
+ * // filled with bytes which all have the value `1`.
+ * const buf2 = Buffer.alloc(10, 1);
+ *
+ * // Creates a Buffer containing the bytes [1, 2, 3].
+ * const buf4 = Buffer.from([1, 2, 3]);
+ *
+ * // Creates a Buffer containing the bytes [1, 1, 1, 1] – the entries
+ * // are all truncated using `(value &#x26; 255)` to fit into the range 0–255.
+ * const buf5 = Buffer.from([257, 257.5, -255, '1']);
+ *
+ * // Creates a Buffer containing the UTF-8-encoded bytes for the string 'tést':
+ * // [0x74, 0xc3, 0xa9, 0x73, 0x74] (in hexadecimal notation)
+ * // [116, 195, 169, 115, 116] (in decimal notation)
+ * const buf6 = Buffer.from('tést');
+ *
+ * // Creates a Buffer containing the Latin-1 bytes [0x74, 0xe9, 0x73, 0x74].
+ * const buf7 = Buffer.from('tést', 'latin1');
+ * ```
+ */
 declare module "buffer" {
   export type BufferEncoding =
     | "hex"
@@ -33,109 +70,7 @@ declare module "buffer" {
     | {
         valueOf(): T;
       };
-
   interface BufferConstructor {
-    /**
-     * Allocates a new `Buffer` using an `array` of bytes in the range `0` – `255`.
-     */
-    from(
-      arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
-      byteOffset?: number,
-      length?: number
-    ): Buffer;
-    /**
-     * Creates a new Buffer using the passed {data}
-     * @param data data to create a new Buffer
-     */
-    from(data: Uint8Array | readonly number[]): Buffer;
-    from(
-      data: WithImplicitCoercion<Uint8Array | readonly number[] | string>
-    ): Buffer;
-    /**
-     * Creates a new Buffer containing the given JavaScript string {str}.
-     * If provided, the {encoding} parameter identifies the character encoding.
-     * If not provided, {encoding} defaults to 'utf8'.
-     */
-    from(
-      str:
-        | WithImplicitCoercion<string>
-        | {
-            [Symbol.toPrimitive](hint: "string"): string;
-          },
-      encoding?: BufferEncoding
-    ): Buffer;
-
-    /**
-     * Returns the byte length of a string when encoded using `encoding`.
-     * This is not the same as [`String.prototype.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length), which does not account
-     * for the encoding that is used to convert the string into bytes.
-     *
-     * ```js
-     * import { Buffer } from 'buffer';
-     *
-     * const str = '\u00bd + \u00bc = \u00be';
-     *
-     * console.log(`${str}: ${str.length} characters, ` +
-     *             `${Buffer.byteLength(str, 'utf8')} bytes`);
-     * // Prints: ½ + ¼ = ¾: 9 characters, 12 bytes
-     * ```
-     *
-     * When `string` is a
-     * `Buffer`/[`DataView`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)/[`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/-
-     * Reference/Global_Objects/TypedArray)/[`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)/[`SharedArrayBuffer`](https://develop-
-     * er.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), the byte length as reported by `.byteLength`is returned.
-     * @param string A value to calculate the length of.
-     * @param [encoding='utf8'] If `string` is a string, this is its encoding.
-     * @return The number of bytes contained within `string`.
-     */
-    byteLength(
-      string:
-        | string
-        | Buffer
-        | QuickJS.ArrayBufferView
-        | ArrayBuffer
-        | SharedArrayBuffer,
-      encoding?: BufferEncoding
-    ): number;
-
-    /**
-     * Returns a new `Buffer` which is the result of concatenating all the `Buffer` instances in the `list` together.
-     *
-     * If the list has no items, or if the `totalLength` is 0, then a new zero-length `Buffer` is returned.
-     *
-     * If `totalLength` is not provided, it is calculated from the `Buffer` instances
-     * in `list` by adding their lengths.
-     *
-     * If `totalLength` is provided, it is coerced to an unsigned integer. If the
-     * combined length of the `Buffer`s in `list` exceeds `totalLength`, the result is
-     * truncated to `totalLength`.
-     *
-     * ```js
-     * import { Buffer } from 'buffer';
-     *
-     * // Create a single `Buffer` from a list of three `Buffer` instances.
-     *
-     * const buf1 = Buffer.alloc(10);
-     * const buf2 = Buffer.alloc(14);
-     * const buf3 = Buffer.alloc(18);
-     * const totalLength = buf1.length + buf2.length + buf3.length;
-     *
-     * console.log(totalLength);
-     * // Prints: 42
-     *
-     * const bufA = Buffer.concat([buf1, buf2, buf3], totalLength);
-     *
-     * console.log(bufA);
-     * // Prints: <Buffer 00 00 00 00 ...>
-     * console.log(bufA.length);
-     * // Prints: 42
-     * ```
-     *
-     * @param list List of `Buffer` or {@link Uint8Array} instances to concatenate.
-     * @param totalLength Total length of the `Buffer` instances in `list` when concatenated.
-     */
-    concat(list: readonly Uint8Array[], totalLength?: number): Buffer;
-
     /**
      * Allocates a new `Buffer` of `size` bytes. If `fill` is `undefined`, the `Buffer` will be zero-filled.
      *
@@ -180,10 +115,194 @@ declare module "buffer" {
       fill?: string | Uint8Array | number,
       encoding?: BufferEncoding
     ): Buffer;
+    /**
+     * Returns the byte length of a string when encoded using `encoding`.
+     * This is not the same as [`String.prototype.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length), which does not account
+     * for the encoding that is used to convert the string into bytes.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const str = '\u00bd + \u00bc = \u00be';
+     *
+     * console.log(`${str}: ${str.length} characters, ` +
+     *             `${Buffer.byteLength(str, 'utf8')} bytes`);
+     * // Prints: ½ + ¼ = ¾: 9 characters, 12 bytes
+     * ```
+     *
+     * When `string` is a
+     * `Buffer`/[`DataView`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)/[`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/-
+     * Reference/Global_Objects/TypedArray)/[`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)/[`SharedArrayBuffer`](https://develop-
+     * er.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), the byte length as reported by `.byteLength`is returned.
+     * @param string A value to calculate the length of.
+     * @param [encoding='utf8'] If `string` is a string, this is its encoding.
+     * @return The number of bytes contained within `string`.
+     */
+    byteLength(
+      string:
+        | string
+        | Buffer
+        | QuickJS.ArrayBufferView
+        | ArrayBuffer
+        | SharedArrayBuffer,
+      encoding?: BufferEncoding
+    ): number;
+    /**
+     * Returns a new `Buffer` which is the result of concatenating all the `Buffer` instances in the `list` together.
+     *
+     * If the list has no items, or if the `totalLength` is 0, then a new zero-length `Buffer` is returned.
+     *
+     * If `totalLength` is not provided, it is calculated from the `Buffer` instances
+     * in `list` by adding their lengths.
+     *
+     * If `totalLength` is provided, it is coerced to an unsigned integer. If the
+     * combined length of the `Buffer`s in `list` exceeds `totalLength`, the result is
+     * truncated to `totalLength`.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * // Create a single `Buffer` from a list of three `Buffer` instances.
+     *
+     * const buf1 = Buffer.alloc(10);
+     * const buf2 = Buffer.alloc(14);
+     * const buf3 = Buffer.alloc(18);
+     * const totalLength = buf1.length + buf2.length + buf3.length;
+     *
+     * console.log(totalLength);
+     * // Prints: 42
+     *
+     * const bufA = Buffer.concat([buf1, buf2, buf3], totalLength);
+     *
+     * console.log(bufA);
+     * // Prints: <Buffer 00 00 00 00 ...>
+     * console.log(bufA.length);
+     * // Prints: 42
+     * ```
+     *
+     * @param list List of `Buffer` or {@link Uint8Array} instances to concatenate.
+     * @param totalLength Total length of the `Buffer` instances in `list` when concatenated.
+     */
+    concat(list: readonly Uint8Array[], totalLength?: number): Buffer;
+    /**
+     * Allocates a new `Buffer` using an `array` of bytes in the range `0` – `255`.
+     */
+    from(
+      arrayBuffer: WithImplicitCoercion<ArrayBuffer | SharedArrayBuffer>,
+      byteOffset?: number,
+      length?: number
+    ): Buffer;
+    /**
+     * Creates a new Buffer using the passed {data}
+     * @param data data to create a new Buffer
+     */
+    from(data: Uint8Array | readonly number[]): Buffer;
+    from(
+      data: WithImplicitCoercion<Uint8Array | readonly number[] | string>
+    ): Buffer;
+    /**
+     * Creates a new Buffer containing the given JavaScript string {str}.
+     * If provided, the {encoding} parameter identifies the character encoding.
+     * If not provided, {encoding} defaults to 'utf8'.
+     */
+    from(
+      str:
+        | WithImplicitCoercion<string>
+        | {
+            [Symbol.toPrimitive](hint: "string"): string;
+          },
+      encoding?: BufferEncoding
+    ): Buffer;
   }
-  interface Buffer extends Uint8Array {}
+  interface Buffer extends Uint8Array {
+    /**
+     * Returns a new `Buffer` that references the same memory as the original, but
+     * offset and cropped by the `start` and `end` indices.
+     *
+     * Specifying `end` greater than `buf.length` will return the same result as
+     * that of `end` equal to `buf.length`.
+     *
+     * This method is inherited from [`TypedArray.prototype.subarray()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray).
+     *
+     * Modifying the new `Buffer` slice will modify the memory in the original `Buffer`because the allocated memory of the two objects overlap.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * // Create a `Buffer` with the ASCII alphabet, take a slice, and modify one byte
+     * // from the original `Buffer`.
+     *
+     * const buf1 = Buffer.alloc(26);
+     *
+     * for (let i = 0; i < 26; i++) {
+     *   // 97 is the decimal ASCII value for 'a'.
+     *   buf1[i] = i + 97;
+     * }
+     *
+     * const buf2 = buf1.subarray(0, 3);
+     *
+     * console.log(buf2.toString('ascii', 0, buf2.length));
+     * // Prints: abc
+     *
+     * buf1[0] = 33;
+     *
+     * console.log(buf2.toString('ascii', 0, buf2.length));
+     * // Prints: !bc
+     * ```
+     *
+     * Specifying negative indexes causes the slice to be generated relative to the
+     * end of `buf` rather than the beginning.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.from('buffer');
+     *
+     * console.log(buf.subarray(-6, -1).toString());
+     * // Prints: buffe
+     * // (Equivalent to buf.subarray(0, 5).)
+     *
+     * console.log(buf.subarray(-6, -2).toString());
+     * // Prints: buff
+     * // (Equivalent to buf.subarray(0, 4).)
+     *
+     * console.log(buf.subarray(-5, -2).toString());
+     * // Prints: uff
+     * // (Equivalent to buf.subarray(1, 4).)
+     * ```
+     * @param [start=0] Where the new `Buffer` will start.
+     * @param [end=buf.length] Where the new `Buffer` will end (not inclusive).
+     */
+    subarray(start?: number, end?: number): Buffer;
+    /**
+     * Decodes `buf` to a string according to the specified character encoding in`encoding`.
+     *
+     * If `encoding` is `'utf8'` and a byte sequence in the input is not valid UTF-8,
+     * then each invalid byte is replaced with the replacement character `U+FFFD`.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf1 = Buffer.alloc(26);
+     *
+     * for (let i = 0; i < 26; i++) {
+     *   // 97 is the decimal ASCII value for 'a'.
+     *   buf1[i] = i + 97;
+     * }
+     *
+     * console.log(buf1.toString('utf8'));
+     * // Prints: abcdefghijklmnopqrstuvwxyz
+     *
+     * const buf2 = Buffer.from('tést');
+     *
+     * console.log(buf2.toString('hex'));
+     * // Prints: 74c3a97374
+     * ```
+     * @param [encoding='utf8'] The character encoding to use.
+     */
+    toString(encoding?: BufferEncoding): string;
+  }
   var Buffer: BufferConstructor;
-
   /**
    * Decodes a string of Base64-encoded data into bytes, and encodes those bytes
    * into a string using UTF-8.
@@ -194,7 +313,6 @@ declare module "buffer" {
    * @param data The Base64-encoded input string.
    */
   function atob(data: string): string;
-
   /**
    * Decodes a string into bytes using UTF-8, and encodes those bytes
    * into a string using Base64.


### PR DESCRIPTION
### Issue # (if available)

https://github.com/awslabs/llrt/pull/559#issuecomment-2319564485

### Description of changes

- Buffer typing has been added and reorganized.
- I have confirmed that the example code given in the comments works approximately (though a little less confidently) within the scope of the current implementation.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
