### PR TITLE
feat(fetch): support data: URLs

### DIFF
--- a/llrt_core/src/modules/http/fetch.rs
+++ b/llrt_core/src/modules/http/fetch.rs
@@ -1,29 +1,28 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use std::{collections::HashSet, time::Instant};
+
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::{header::HeaderName, Method, Request, Uri};
-
-use llrt_utils::bytes::ObjectBytes;
+use llrt_utils::{bytes::ObjectBytes, encoding::bytes_from_b64};
 use rquickjs::{
     atom::PredefinedAtom,
     function::{Opt, This},
     prelude::{Async, Func},
-    Class, Coerced, Ctx, Exception, FromJs, Function, Object, Result, Value,
+    Class, Coerced, Ctx, Exception, FromJs, Function, IntoJs, Object, Result, Value,
 };
 use tokio::select;
-
-use std::{collections::HashSet, time::Instant};
 
 use crate::{
     environment,
     modules::events::abort_signal::AbortSignal,
-    security::{ensure_url_access, HTTP_DENY_LIST},
+    security::{ensure_url_access, HTTP_ALLOW_LIST, HTTP_DENY_LIST},
     utils::{mc_oneshot, result::ResultExt},
+    VERSION,
 };
-use crate::{security::HTTP_ALLOW_LIST, VERSION};
 
-use super::{headers::Headers, response::Response, HTTP_CLIENT};
+use super::{blob::Blob, headers::Headers, response::Response, HTTP_CLIENT};
 
 const MAX_REDIRECT_COUNT: u32 = 20;
 
@@ -61,6 +60,10 @@ pub(crate) fn init(ctx: &Ctx<'_>, globals: &Object) -> Result<()> {
 
             async move {
                 let options = options?;
+
+                if options.url.starts_with("data:") {
+                    return parse_data_url(&ctx, &options.url);
+                }
 
                 let initial_uri: Uri = options.url.parse().or_throw(&ctx)?;
                 let mut uri: Uri = initial_uri.clone();
@@ -129,6 +132,51 @@ pub(crate) fn init(ctx: &Ctx<'_>, globals: &Object) -> Result<()> {
         })),
     )?;
     Ok(())
+}
+
+fn parse_data_url<'js>(ctx: &Ctx<'js>, data_url: &String) -> Result<Response<'js>> {
+    let url = data_url.trim_start_matches("data:");
+
+    let (mime_type, data) = url
+        .split_once(',')
+        .ok_or_else(|| Exception::throw_type(ctx, "Invalid data URL format"))?;
+
+    let (is_base64, mime_type) = if mime_type.contains("base64") {
+        (
+            true,
+            mime_type
+                .trim()
+                .trim_end_matches("base64")
+                .trim_end_matches(|c| c == ' ' || c == ';'),
+        )
+    } else {
+        (false, mime_type.trim())
+    };
+
+    let mime_type = if mime_type.starts_with(';') {
+        ["text/plain", mime_type].concat()
+    } else if mime_type.is_empty() {
+        "text/plain;charset=US-ASCII".to_string()
+    } else {
+        mime_type.to_string()
+    };
+
+    let body = if is_base64 {
+        bytes_from_b64(data.as_bytes()).map_err(|err| Exception::throw_message(ctx, &err))?
+    } else {
+        data.as_bytes().to_vec()
+    };
+
+    let blob = Blob::from_bytes(body, Some(mime_type.clone())).into_js(ctx)?;
+
+    let headers = Object::new(ctx.clone())?;
+    headers.set("content-type", mime_type)?;
+
+    let options = Object::new(ctx.clone())?;
+    options.set("url", data_url)?;
+    options.set("headers", headers)?;
+
+    Response::new(ctx.clone(), Opt(Some(blob)), Opt(Some(options)))
 }
 
 fn build_request(

--- a/llrt_core/src/modules/http/fetch.rs
+++ b/llrt_core/src/modules/http/fetch.rs
@@ -135,9 +135,8 @@ pub(crate) fn init(ctx: &Ctx<'_>, globals: &Object) -> Result<()> {
 }
 
 fn parse_data_url<'js>(ctx: &Ctx<'js>, data_url: &String) -> Result<Response<'js>> {
-    let url = data_url.trim_start_matches("data:");
-
-    let (mime_type, data) = url
+    let (mime_type, data) = data_url
+        .trim_start_matches("data:")
         .split_once(',')
         .ok_or_else(|| Exception::throw_type(ctx, "Invalid data URL format"))?;
 
@@ -153,7 +152,7 @@ fn parse_data_url<'js>(ctx: &Ctx<'js>, data_url: &String) -> Result<Response<'js
         (false, mime_type.trim())
     };
 
-    let mime_type = if mime_type.starts_with(';') {
+    let content_type = if mime_type.starts_with(';') {
         ["text/plain", mime_type].concat()
     } else if mime_type.is_empty() {
         "text/plain;charset=US-ASCII".to_string()
@@ -167,10 +166,10 @@ fn parse_data_url<'js>(ctx: &Ctx<'js>, data_url: &String) -> Result<Response<'js
         data.as_bytes().to_vec()
     };
 
-    let blob = Blob::from_bytes(body, Some(mime_type.clone())).into_js(ctx)?;
+    let blob = Blob::from_bytes(body, Some(content_type.clone())).into_js(ctx)?;
 
     let headers = Object::new(ctx.clone())?;
-    headers.set("content-type", mime_type)?;
+    headers.set("content-type", content_type)?;
 
     let options = Object::new(ctx.clone())?;
     options.set("url", data_url)?;

--- a/llrt_core/src/modules/http/fetch.rs
+++ b/llrt_core/src/modules/http/fetch.rs
@@ -134,9 +134,8 @@ pub(crate) fn init(ctx: &Ctx<'_>, globals: &Object) -> Result<()> {
     Ok(())
 }
 
-fn parse_data_url<'js>(ctx: &Ctx<'js>, data_url: &String) -> Result<Response<'js>> {
-    let (mime_type, data) = data_url
-        .trim_start_matches("data:")
+fn parse_data_url<'js>(ctx: &Ctx<'js>, data_url: &str) -> Result<Response<'js>> {
+    let (mime_type, data) = data_url["data:".len()..]
         .split_once(',')
         .ok_or_else(|| Exception::throw_type(ctx, "Invalid data URL format"))?;
 

--- a/llrt_core/src/modules/http/request.rs
+++ b/llrt_core/src/modules/http/request.rs
@@ -156,13 +156,10 @@ impl<'js> Request<'js> {
 
     async fn blob(&mut self, ctx: Ctx<'js>) -> Result<Blob> {
         let headers = Headers::from_value(&ctx, self.headers().unwrap().as_value().clone())?;
-        let mime_type = headers.iter().find_map(|(k, v)| {
-            if k == "content-type" {
-                Some(v.to_string())
-            } else {
-                None
-            }
-        });
+        let mime_type = headers
+            .iter()
+            .find(|(k, _)| k == &"content-type")
+            .map(|(_, v)| v.to_string());
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             return Ok(Blob::from_bytes(bytes.into(), mime_type));
         }

--- a/llrt_core/src/modules/http/request.rs
+++ b/llrt_core/src/modules/http/request.rs
@@ -158,8 +158,7 @@ impl<'js> Request<'js> {
         let headers = Headers::from_value(&ctx, self.headers().unwrap().as_value().clone())?;
         let mime_type = headers
             .iter()
-            .find(|(k, _)| k == &"content-type")
-            .map(|(_, v)| v.to_string());
+            .find_map(|(k, v)| (k == "content-type").then(|| v.to_string()));
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             return Ok(Blob::from_bytes(bytes.into(), mime_type));
         }

--- a/llrt_core/src/modules/http/request.rs
+++ b/llrt_core/src/modules/http/request.rs
@@ -155,14 +155,14 @@ impl<'js> Request<'js> {
     }
 
     async fn blob(&mut self, ctx: Ctx<'js>) -> Result<Blob> {
-        let headers = Headers::from_value(&ctx, self.headers().unwrap().as_value().clone())?;
-        let mime_type = headers
-            .iter()
-            .find_map(|(k, v)| (k == "content-type").then(|| v.to_string()));
         if let Some(bytes) = self.take_bytes(&ctx).await? {
+            let headers = Headers::from_value(&ctx, self.headers().unwrap().as_value().clone())?;
+            let mime_type = headers
+                .iter()
+                .find_map(|(k, v)| (k == "content-type").then(|| v.to_string()));
             return Ok(Blob::from_bytes(bytes.into(), mime_type));
         }
-        Ok(Blob::from_bytes(Vec::<u8>::new(), mime_type))
+        Ok(Blob::from_bytes(Vec::<u8>::new(), None))
     }
 
     fn clone(&mut self, ctx: Ctx<'js>) -> Result<Self> {

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -6,15 +6,19 @@ use std::{
     time::Instant,
 };
 
+use brotlic::DecompressorReader as BrotliDecoder;
+use flate2::read::{GzDecoder, ZlibDecoder};
 use http_body_util::BodyExt;
 use hyper::{body::Incoming, header::HeaderName};
 use llrt_utils::bytes::ObjectBytes;
+use once_cell::sync::Lazy;
 use rquickjs::{
     class::{Trace, Tracer},
     function::Opt,
     ArrayBuffer, Class, Coerced, Ctx, Exception, Null, Object, Result, TypedArray, Value,
 };
 use tokio::{runtime::Handle, select};
+use zstd::stream::read::Decoder as ZstdDecoder;
 
 use crate::{
     json::parse::json_parse,
@@ -23,12 +27,6 @@ use crate::{
 };
 
 use super::{blob::Blob, headers::Headers};
-
-use once_cell::sync::Lazy;
-
-use brotlic::DecompressorReader as BrotliDecoder;
-use flate2::read::{GzDecoder, ZlibDecoder};
-use zstd::stream::read::Decoder as ZstdDecoder;
 
 static STATUS_TEXTS: Lazy<HashMap<u16, &'static str>> = Lazy::new(|| {
     let mut map = HashMap::new();
@@ -114,14 +112,6 @@ impl<'js> Response<'js> {
         abort_receiver: Option<mc_oneshot::Receiver<Value<'js>>>,
     ) -> Result<Self> {
         let response_headers = response.headers();
-        let mut content_type = None;
-        if let Some(content_type_header) =
-            response_headers.get(HeaderName::from_static("content-type"))
-        {
-            if let Ok(content_type_header) = content_type_header.to_str() {
-                content_type = Some(content_type_header.to_owned())
-            }
-        }
 
         let mut content_encoding = None;
         if let Some(content_encoding_header) =
@@ -137,11 +127,6 @@ impl<'js> Response<'js> {
 
         let status = response.status();
 
-        let body_attributes = BodyAttributes {
-            content_type,
-            content_encoding,
-        };
-
         Ok(Self {
             body: Some(BodyVariant::Incoming(Some(response))),
             method,
@@ -151,7 +136,7 @@ impl<'js> Response<'js> {
             status_text: None,
             redirected,
             headers,
-            body_attributes,
+            content_encoding,
             abort_receiver,
         })
     }
@@ -171,7 +156,7 @@ impl<'js> Response<'js> {
                     body.body_mut().collect().await.or_throw(ctx)?.to_bytes()
                 };
 
-                if let Some(content_encoding) = &self.body_attributes.content_encoding {
+                if let Some(content_encoding) = &self.content_encoding {
                     let mut data: Vec<u8> = Vec::with_capacity(bytes.len());
                     match content_encoding.as_str() {
                         "zstd" => ZstdDecoder::new(&bytes[..])?.read_to_end(&mut data)?,
@@ -211,14 +196,8 @@ pub struct Response<'js> {
     status_text: Option<String>,
     redirected: bool,
     headers: Class<'js, Headers>,
-    body_attributes: BodyAttributes,
-    abort_receiver: Option<mc_oneshot::Receiver<Value<'js>>>,
-}
-
-#[derive(Clone, Debug)]
-struct BodyAttributes {
-    content_type: Option<String>,
     content_encoding: Option<String>,
+    abort_receiver: Option<mc_oneshot::Receiver<Value<'js>>>,
 }
 
 #[rquickjs::methods(rename_all = "camelCase")]
@@ -251,6 +230,7 @@ impl<'js> Response<'js> {
         }
 
         let headers = Class::instance(ctx.clone(), headers.unwrap_or_default())?;
+        let content_encoding = headers.get("content-encoding")?;
 
         let body = body.0.and_then(|body| {
             if body.is_null() || body.is_undefined() {
@@ -259,11 +239,6 @@ impl<'js> Response<'js> {
                 Some(BodyVariant::Provided(body))
             }
         });
-
-        let body_attributes = BodyAttributes {
-            content_type: headers.get("content-type")?,
-            content_encoding: headers.get("content-encoding")?,
-        };
 
         Ok(Self {
             body,
@@ -274,7 +249,7 @@ impl<'js> Response<'js> {
             status_text,
             redirected: false,
             headers,
-            body_attributes,
+            content_encoding,
             abort_receiver,
         })
     }
@@ -363,13 +338,15 @@ impl<'js> Response<'js> {
     }
 
     async fn blob(&mut self, ctx: Ctx<'js>) -> Result<Blob> {
+        let headers = Headers::from_value(&ctx, self.headers().as_value().clone())?;
+        let mime_type = headers
+            .iter()
+            .find(|(k, _)| k == &"content-type")
+            .map(|(_, v)| v.to_string());
         if let Some(bytes) = self.take_bytes(&ctx).await? {
-            return Ok(Blob::from_bytes(
-                bytes,
-                self.body_attributes.content_type.clone(),
-            ));
+            return Ok(Blob::from_bytes(bytes, mime_type));
         }
-        Ok(Blob::from_bytes(Vec::<u8>::new(), None))
+        Ok(Blob::from_bytes(Vec::<u8>::new(), mime_type))
     }
 
     fn clone(&mut self, ctx: Ctx<'js>) -> Result<Self> {
@@ -392,7 +369,7 @@ impl<'js> Response<'js> {
             status_text: self.status_text.clone(),
             redirected: self.redirected,
             headers: Class::<Headers>::instance(ctx, self.headers.borrow().clone())?,
-            body_attributes: self.body_attributes.clone(),
+            content_encoding: self.content_encoding.clone(),
             abort_receiver: self.abort_receiver.clone(),
         })
     }
@@ -408,10 +385,7 @@ impl<'js> Response<'js> {
             status_text: None,
             redirected: false,
             headers: Class::instance(ctx.clone(), Headers::default())?,
-            body_attributes: BodyAttributes {
-                content_type: None,
-                content_encoding: None,
-            },
+            content_encoding: None,
             abort_receiver: None,
         })
     }
@@ -435,13 +409,9 @@ impl<'js> Response<'js> {
         }
 
         let headers = Class::instance(ctx.clone(), headers.unwrap_or_default())?;
+        let content_encoding = headers.get("content-encoding")?;
 
         let body = Some(BodyVariant::Provided(body));
-
-        let body_attributes = BodyAttributes {
-            content_type: headers.get("content-type")?,
-            content_encoding: headers.get("content-encoding")?,
-        };
 
         Ok(Self {
             body,
@@ -452,7 +422,7 @@ impl<'js> Response<'js> {
             status_text,
             redirected: false,
             headers,
-            body_attributes,
+            content_encoding,
             abort_receiver: None,
         })
     }
@@ -475,10 +445,7 @@ impl<'js> Response<'js> {
             status_text: None,
             redirected: false,
             headers,
-            body_attributes: BodyAttributes {
-                content_type: None,
-                content_encoding: None,
-            },
+            content_encoding: None,
             abort_receiver: None,
         })
     }

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -225,12 +225,16 @@ struct BodyAttributes {
 impl<'js> Response<'js> {
     #[qjs(constructor)]
     pub fn new(ctx: Ctx<'js>, body: Opt<Value<'js>>, options: Opt<Object<'js>>) -> Result<Self> {
+        let mut url = String::from("");
         let mut status = 200;
         let mut headers = None;
         let mut status_text = None;
         let mut abort_receiver = None;
 
         if let Some(opt) = options.0 {
+            if let Some(url_opt) = opt.get("url")? {
+                url = url_opt;
+            }
             if let Some(status_opt) = opt.get("status")? {
                 status = status_opt;
             }
@@ -264,7 +268,7 @@ impl<'js> Response<'js> {
         Ok(Self {
             body,
             method: "GET".into(),
-            url: "".into(),
+            url,
             start: Instant::now(),
             status,
             status_text,

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -341,8 +341,7 @@ impl<'js> Response<'js> {
         let headers = Headers::from_value(&ctx, self.headers().as_value().clone())?;
         let mime_type = headers
             .iter()
-            .find(|(k, _)| k == &"content-type")
-            .map(|(_, v)| v.to_string());
+            .find_map(|(k, v)| (k == "content-type").then(|| v.to_string()));
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             return Ok(Blob::from_bytes(bytes, mime_type));
         }

--- a/llrt_core/src/modules/http/response.rs
+++ b/llrt_core/src/modules/http/response.rs
@@ -338,14 +338,14 @@ impl<'js> Response<'js> {
     }
 
     async fn blob(&mut self, ctx: Ctx<'js>) -> Result<Blob> {
-        let headers = Headers::from_value(&ctx, self.headers().as_value().clone())?;
-        let mime_type = headers
-            .iter()
-            .find_map(|(k, v)| (k == "content-type").then(|| v.to_string()));
         if let Some(bytes) = self.take_bytes(&ctx).await? {
+            let headers = Headers::from_value(&ctx, self.headers().as_value().clone())?;
+            let mime_type = headers
+                .iter()
+                .find_map(|(k, v)| (k == "content-type").then(|| v.to_string()));
             return Ok(Blob::from_bytes(bytes, mime_type));
         }
-        Ok(Blob::from_bytes(Vec::<u8>::new(), mime_type))
+        Ok(Blob::from_bytes(Vec::<u8>::new(), None))
     }
 
     fn clone(&mut self, ctx: Ctx<'js>) -> Result<Self> {

--- a/tests/unit/fetch.test.ts
+++ b/tests/unit/fetch.test.ts
@@ -158,4 +158,14 @@ describe("fetch", () => {
       expect(abortController.signal.reason).toBe("aborted");
     }
   });
+  it("should be processing data-url", async () => {
+    const s = "hello";
+    const base64 = Buffer.from(s).toString("base64");
+    const dataURIPrefix = "data:application/octet-stream;base64,";
+    const url = dataURIPrefix + base64;
+    const resp = await fetch(url);
+    const buf = await resp.arrayBuffer();
+    const str = Buffer.from(buf).toString("ascii");
+    expect(str).toEqual(s);
+  });
 });


### PR DESCRIPTION
### Issue # (if available)

Closed #565

### Description of changes

Support for `data: urls`(https://fetch.spec.whatwg.org/#data-urls) has been added.

Sample 1:
```javascript
// data-url1.js
const s = "hello"
const base64 = Buffer.from(s).toString("base64");
const dataURIPrefix = "data:application/octet-stream;base64,";
const url = dataURIPrefix + base64;
const resp = await fetch(url);
const buf = await resp.arrayBuffer();
const str = Buffer.from(buf).toString("ascii");
console.log(str === s);
```
```shell
% llrt data-url1.js
true
```

Sample 2: The source of the base64 string is, https://www.rfc-editor.org/rfc/rfc2397
```javascript
// data-url2.js
import fs from 'fs';
const imgUrl = "data:image/gif;base64,R0lGODdhMAAwAPAAAAAAAP///ywAAAAAMAAwAAAC8IyPqcvt3wCcDkiLc7C0qwyGHhSWpjQu5yqmCYsapyuvUUlvONmOZtfzgFzByTB10QgxOR0TqBQejhRNzOfkVJ+5YiUqrXF5Y5lKh/DeuNcP5yLWGsEbtLiOSpa/TPg7JpJHxyendzWTBfX0cxOnKPjgBzi4diinWGdkF8kjdfnycQZXZeYGejmJlZeGl9i2icVqaNVailT6F5iJ90m6mvuTS4OK05M0vDk0Q4XUtwvKOzrcd3iq9uisF81M1OIcR7lEewwcLp7tuNNkM3uNna3F2JQFo97Vriy/Xl4/f1cf5VWzXyym7PHhhx4dbgYKAAA7";
const res = await fetch(imgUrl);
const imgData = await res.blob();
console.log(imgData);
fs.writeFileSync('Larry.gif', await imgData.arrayBuffer());
```
```shell
% llrt data-url2.js
Blob {
  size: 273,
  type: 'image/gif'
}
```

<img width="48" alt="image" src="https://github.com/user-attachments/assets/a1478bd5-f539-4268-b5f7-42d50747ad8f">

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
