### PR TITLE
fix: AWS SDK connection init

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -713,6 +713,11 @@ async function buildSdks() {
       if (serviceNames) {
         sdkContents += "\nif(__bootstrap.addAwsSdkInitTask){\n";
         for (const serviceName of serviceNames) {
+          if (!serviceName) {
+            throw new Error(
+              `Service name "${serviceName}" for ${pkg} is invalid`
+            );
+          }
           sdkContents += `__bootstrap.addAwsSdkInitTask("${serviceName}");\n`;
         }
         sdkContents += "}\n";

--- a/build.mjs
+++ b/build.mjs
@@ -702,14 +702,20 @@ async function buildSdks() {
       const sdk = SDKS_BY_SDK_PACKAGES[pkg];
       const sdkIndexFile = path.join(packagePath, "index.js");
       const value = SERVICE_ENDPOINTS_BY_PACKAGE[sdk];
-      const serviceNames = Array.isArray(value) ? value : [value];
+      const serviceNames = Array.isArray(value)
+        ? value
+        : value
+          ? [value]
+          : null;
       await fs.mkdir(packagePath, { recursive: true });
 
       let sdkContents = `export * from "${pkg}";`;
       if (serviceNames) {
+        sdkContents += "\nif(__bootstrap.addAwsSdkInitTask){\n";
         for (const serviceName of serviceNames) {
-          sdkContents += `\nif(__bootstrap.addAwsSdkInitTask){\n   __bootstrap.addAwsSdkInitTask("${serviceName}");\n}`;
+          sdkContents += `__bootstrap.addAwsSdkInitTask("${serviceName}");\n`;
         }
+        sdkContents += "}\n";
       }
       await fs.writeFile(sdkIndexFile, sdkContents);
 


### PR DESCRIPTION
### Description of changes

Fix regression introduced by https://github.com/awslabs/llrt/pull/547 as invalid services names where eagerly added to connection init 

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
