### PR TITLE
Allow any value for clearTimeout

### DIFF
--- a/tests/unit/timers.test.ts
+++ b/tests/unit/timers.test.ts
@@ -35,7 +35,7 @@ describe("timers", () => {
     const end = Date.now();
 
     expect(end - start >= 10).toBeTruthy();
-    expect(status).toEqual("cleared")
+    expect(status).toEqual("cleared");
   });
 
   it("should set interval", async () => {
@@ -52,7 +52,7 @@ describe("timers", () => {
     });
     const end = Date.now();
     expect(end - start >= 10).toBeTruthy();
-    expect(count).toEqual(5)
+    expect(count).toEqual(5);
   });
 
   it("should clear interval", async () => {
@@ -70,11 +70,20 @@ describe("timers", () => {
     });
     const end = Date.now();
     expect(end - start > 10).toBeTruthy();
-    expect(count).toEqual(2)
+    expect(count).toEqual(2);
+  });
+
+  it("should accept any parameter to clear timeout", () => {
+    expect(() => {
+      clearTimeout(null as any);
+      clearTimeout("" as any);
+      clearTimeout(true as any);
+      clearTimeout({});
+    }).not.toThrow();
   });
 
   it("should import timers", () => {
-    expect(timers.setTimeout).toEqual(setTimeout)
+    expect(timers.setTimeout).toEqual(setTimeout);
   });
 
   it("delay is optional", async () => {


### PR DESCRIPTION
### Description of changes

Accept any parameter for setTimeout. None numeric values will just be ignored.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
