### PR TITLE
Add init to url

### DIFF
--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -86,6 +86,7 @@ impl Default for ModuleBuilder {
             .with_module(ProcessModule)
             .with_global(crate::modules::process::init)
             .with_global(crate::modules::navigator::init)
+            .with_global(crate::modules::url::init)
             .with_module(UrlModule)
             .with_global(crate::modules::http::init)
             .with_global(crate::modules::exceptions::init)

--- a/llrt_core/src/modules/http/mod.rs
+++ b/llrt_core/src/modules/http/mod.rs
@@ -17,7 +17,6 @@ use hyper_util::{
     client::legacy::{connect::HttpConnector, Client},
     rt::{TokioExecutor, TokioTimer},
 };
-use llrt_modules::url::{url_class::URL, url_search_params::URLSearchParams};
 use llrt_utils::class::CustomInspectExtension;
 use once_cell::sync::Lazy;
 use rquickjs::{Class, Ctx, Result};
@@ -111,8 +110,6 @@ pub fn init(ctx: &Ctx) -> Result<()> {
     Class::<Request>::define(&globals)?;
     Class::<Response>::define(&globals)?;
     Class::<Headers>::define_with_custom_inspect(&globals)?;
-    Class::<URLSearchParams>::define(&globals)?;
-    Class::<URL>::define(&globals)?;
 
     blob::init(ctx, &globals)?;
 

--- a/llrt_modules/src/modules/url/mod.rs
+++ b/llrt_modules/src/modules/url/mod.rs
@@ -14,7 +14,8 @@ use rquickjs::{
 };
 use url_crate::{quirks, Url};
 
-use crate::url::url_class::{url_to_http_options, URL};
+use self::url_class::{url_to_http_options, URL};
+use self::url_search_params::URLSearchParams;
 use crate::ModuleInfo;
 
 pub fn domain_to_unicode(domain: &str) -> String {
@@ -111,6 +112,15 @@ pub fn url_format<'js>(url: Class<'js, URL<'js>>, options: Opt<Value<'js>>) -> R
     }
 
     Ok(string)
+}
+
+pub fn init(ctx: &Ctx<'_>) -> Result<()> {
+    let globals = ctx.globals();
+
+    Class::<URLSearchParams>::define(&globals)?;
+    Class::<URL>::define(&globals)?;
+
+    Ok(())
 }
 
 pub struct UrlModule;


### PR DESCRIPTION
### Description of changes

- Moved the init from http to url to keep things contain (also the module didn't work otherwise because it needs the global to be set)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
