### PR TITLE
Fix JSON.stringify of objects with function values and fix incorrect toJSON indentaion

### DIFF
--- a/llrt_core/src/json/stringify.rs
+++ b/llrt_core/src/json/stringify.rs
@@ -128,14 +128,20 @@ fn run_to_json<'js>(
     js_object: &Object<'js>,
 ) -> Result<()> {
     let to_json = js_object.get::<_, Function>(PredefinedAtom::ToJSON)?;
-    let val = to_json.call((This(js_object.clone()),))?;
+    let val: Value = to_json.call((This(js_object.clone()),))?;
+
+    //only preserve indentation if we're returning nested data
+    let indentation = context.indentation.and_then(|indentation| {
+        matches!(val.type_of(), Type::Object | Type::Array).then_some(indentation)
+    });
+
     append_value(
         &mut StringifyContext {
             ctx: context.ctx,
             result: context.result,
             value: &val,
             depth: context.depth,
-            indentation: context.indentation,
+            indentation,
             key: None,
             index: None,
             parent: Some(js_object),
@@ -215,7 +221,11 @@ fn write_primitive(context: &mut StringifyContext, add_comma: bool) -> Result<Pr
 
     let type_of = value.type_of();
 
-    if matches!(type_of, Type::Symbol | Type::Undefined) && context.index.is_none() {
+    if matches!(
+        type_of,
+        Type::Symbol | Type::Undefined | Type::Function | Type::Constructor
+    ) && context.index.is_none()
+    {
         return Ok(PrimitiveStatus::Ignored);
     }
 

--- a/llrt_core/src/json/stringify.rs
+++ b/llrt_core/src/json/stringify.rs
@@ -132,7 +132,7 @@ fn run_to_json<'js>(
 
     //only preserve indentation if we're returning nested data
     let indentation = context.indentation.and_then(|indentation| {
-        matches!(val.type_of(), Type::Object | Type::Array).then_some(indentation)
+        matches!(val.type_of(), Type::Object | Type::Array | Type::Exception).then_some(indentation)
     });
 
     append_value(

--- a/llrt_core/src/json/stringify.rs
+++ b/llrt_core/src/json/stringify.rs
@@ -420,7 +420,7 @@ fn iterate(context: &mut StringifyContext<'_, '_>) -> Result<()> {
     let ctx = context.ctx;
     let indentation = context.indentation;
     match elem.type_of() {
-        Type::Object => {
+        Type::Object | Type::Exception => {
             let js_object = unsafe { elem.as_object().unwrap_unchecked() };
             if js_object.contains_key(PredefinedAtom::ToJSON)? {
                 return run_to_json(context, js_object);

--- a/tests/unit/json.test.ts
+++ b/tests/unit/json.test.ts
@@ -185,11 +185,20 @@ describe("JSON Stringified", () => {
 
   // Test more complex JSON structure
   it("Should stringify a complex object with custom spacing and replacer", () => {
+    const date = new Date();
+    class Foo {
+      prop = 1;
+    }
     const complexData = {
       key: "value",
+      date,
       nested: {
         array: [1, 2, 3],
         obj: { a: "apple", b: "banana" },
+        foo: new Foo(),
+        arrowFn: () => {},
+        fn: function () {},
+        namedFn: function namedFn() {},
       },
     };
 
@@ -198,8 +207,11 @@ describe("JSON Stringified", () => {
 
     const jsonString = JSON.stringify(complexData, replacerFunction, 4);
 
+    console.log(jsonString);
+
     const expectedJsonString = `{
     "key": "VALUE",
+    "date": "${date.toJSON()}",
     "nested": {
         "array": [
             1,
@@ -209,6 +221,9 @@ describe("JSON Stringified", () => {
         "obj": {
             "a": "APPLE",
             "b": "BANANA"
+        },
+        "foo": {
+            "prop": 1
         }
     }
 }`;
@@ -283,5 +298,21 @@ describe("JSON Stringified", () => {
 
     const valueEnd = ["123", "123", undefined];
     expect(JSON.stringify(valueEnd)).toEqual(`["123","123",null]`);
+  });
+
+  it("should stringify and remove objects that are not valid json", () => {
+    const dateString = new Date().toJSON();
+    const data = {
+      a: "123",
+      b: undefined,
+      c: () => {
+        return "123";
+      },
+      d: RegExp("apa"),
+      e: new Date(),
+    };
+    expect(JSON.stringify(data)).toEqual(
+      `{"a":"123","d":{},"e":"${dateString}"}`
+    );
   });
 });

--- a/tests/unit/json.test.ts
+++ b/tests/unit/json.test.ts
@@ -315,4 +315,9 @@ describe("JSON Stringified", () => {
       `{"a":"123","d":{},"e":"${dateString}"}`
     );
   });
+
+  it("should stringify an exception", () => {
+    const exception = new Error("error");
+    expect(JSON.stringify(exception)).toEqual("{}");
+  });
 });


### PR DESCRIPTION
### Description of changes

keys containing functions or constructors where not ignored. Also indentation was incorrectly rendered when toJSON returned a primitive instead of an object. This PR fixes that.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
