### PR TITLE
support stringify BigInt

### DIFF
--- a/llrt_core/src/json/stringify.rs
+++ b/llrt_core/src/json/stringify.rs
@@ -231,7 +231,7 @@ fn write_primitive(context: &mut StringifyContext, add_comma: bool) -> Result<Pr
 
     if matches!(type_of, Type::BigInt) {
         return Err(Exception::throw_type(
-            &context.ctx,
+            context.ctx,
             "Do not know how to serialize a BigInt",
         ));
     }

--- a/llrt_core/src/json/stringify.rs
+++ b/llrt_core/src/json/stringify.rs
@@ -229,6 +229,13 @@ fn write_primitive(context: &mut StringifyContext, add_comma: bool) -> Result<Pr
         return Ok(PrimitiveStatus::Ignored);
     }
 
+    if matches!(type_of, Type::BigInt) {
+        return Err(Exception::throw_type(
+            &context.ctx,
+            "Do not know how to serialize a BigInt",
+        ));
+    }
+
     if let Some(include_keys_replacer) = include_keys_replacer {
         let key = get_key_or_index(context.itoa_buffer, key, index);
         if !include_keys_replacer.contains(key) {

--- a/tests/unit/json.test.ts
+++ b/tests/unit/json.test.ts
@@ -320,4 +320,12 @@ describe("JSON Stringified", () => {
     const exception = new Error("error");
     expect(JSON.stringify(exception)).toEqual("{}");
   });
+
+  it("should throw an Error when stringify BigInt", () => {
+    expect(() =>
+      JSON.stringify({
+        v: 1n,
+      })
+    ).toThrow(/Do not know how to serialize a BigInt/);
+  });
 });


### PR DESCRIPTION
### Description of changes

support stringify BigInt

```
JSON.stringify({
  v: 1n,
})
// TypeError: Do not know how to serialize a BigInt
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

