### PR TITLE
feat: multi-flavor support for local machine binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,14 +103,15 @@ jobs:
         if: inputs.release && inputs.platform == 'linux'
         run: |
           make libs-${{ inputs.release }}
-          make llrt-linux-${{ inputs.release }}.zip
-          make release-${{ inputs.release }}
-          make release-${{ inputs.release }}-no-sdk
-          make release-${{ inputs.release }}-full-sdk
+          make release-for-aws-${{ inputs.release }}
+          make release-for-aws-${{ inputs.release }}-no-sdk
+          make release-for-aws-${{ inputs.release }}-full-sdk
       - name: Build Darwin binaries
         if: inputs.release && inputs.platform == 'darwin'
         run: |
           make llrt-darwin-${{ inputs.release }}.zip
+          make llrt-darwin-${{ inputs.release }}-no-sdk.zip
+          make llrt-darwin-${{ inputs.release }}-full-sdk.zip
       - name: Build Windows binaries
         if: inputs.release && inputs.platform == 'windows'
         shell: msys2 {0}
@@ -120,6 +121,8 @@ jobs:
           make stdlib
           make libs-${{ inputs.release }}
           make llrt-windows-${{ inputs.release }}.zip
+          make llrt-windows-${{ inputs.release }}-no-sdk.zip
+          make llrt-windows-${{ inputs.release }}-full-sdk.zip
       - name: Upload artifacts
         if: inputs.release
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,22 +66,32 @@ jobs:
           prerelease: contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc')
           files: |
             ./llrt-lambda-x64.zip
-            ./llrt-lambda-arm64.zip
-            ./llrt-container-x64
-            ./llrt-container-arm64
-            ./llrt-lambda-x64-full-sdk.zip
-            ./llrt-lambda-arm64-full-sdk.zip
-            ./llrt-container-x64-full-sdk
-            ./llrt-container-arm64-full-sdk
             ./llrt-lambda-x64-no-sdk.zip
+            ./llrt-lambda-x64-full-sdk.zip
+            ./llrt-lambda-arm64.zip
             ./llrt-lambda-arm64-no-sdk.zip
+            ./llrt-lambda-arm64-full-sdk.zip
+            ./llrt-container-x64
             ./llrt-container-x64-no-sdk
+            ./llrt-container-x64-full-sdk
+            ./llrt-container-arm64
             ./llrt-container-arm64-no-sdk
+            ./llrt-container-arm64-full-sdk
             ./llrt-linux-x64.zip
-            ./llrt-windows-x64.zip
+            ./llrt-linux-x64-no-sdk.zip
+            ./llrt-linux-x64-full-sdk.zip
             ./llrt-linux-arm64.zip
+            ./llrt-linux-arm64-no-sdk.zip
+            ./llrt-linux-arm64-full-sdk.zip
             ./llrt-darwin-x64.zip
+            ./llrt-darwin-x64-no-sdk.zip
+            ./llrt-darwin-x64-full-sdk.zip
             ./llrt-darwin-arm64.zip
+            ./llrt-darwin-arm64-no-sdk.zip
+            ./llrt-darwin-arm64-full-sdk.zip
+            ./llrt-windows-x64.zip
+            ./llrt-windows-x64-no-sdk.zip
+            ./llrt-windows-x64-full-sdk.zip
   publish:
     needs:
       - build

--- a/README.md
+++ b/README.md
@@ -414,13 +414,13 @@ Install generate libs and setup rust targets & toolchains
 Build binaries for Lambda (Per bundle type and architecture desired)
 
     # for arm64, use
-    make llrt-lambda-arm64
-    make llrt-lambda-arm64-no-sdk
-    make llrt-lambda-arm64-full-sdk
+    make llrt-lambda-arm64.zip
+    make llrt-lambda-arm64-no-sdk.zip
+    make llrt-lambda-arm64-full-sdk.zip
     # or for x86-64, use
-    make llrt-lambda-x64
-    make llrt-lambda-x64-no-sdk
-    make llrt-lambda-x64-full-sdk
+    make llrt-lambda-x64.zip
+    make llrt-lambda-x64-no-sdk.zip
+    make llrt-lambda-x64-full-sdk.zip
 
 Build binaries for Container (Per bundle type and architecture desired)
 
@@ -436,6 +436,8 @@ Build binaries for Container (Per bundle type and architecture desired)
 Optionally build for your local machine (Mac or Linux)
 
     make release
+    make release-no-sdk
+    make release-full-sdk
 
 You should now have a `llrt-lambda-arm64*.zip` or `llrt-lambda-x64*.zip`. You can manually upload this as a Lambda layer or use it via your Infrastructure-as-code pipeline
 


### PR DESCRIPTION
### Issue # (if available)

Closed #590

### Description of changes

- Multi-flavor support for local machine binaries (linux/macos/windows).
- In the makefile, the method of specifying ARCH for Windows was different from other operating systems, so this has been corrected. However, we have not been able to confirm the execution result after the modification on the local machine. Therefore, there might be an error in the build/release process of Github Actions.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
