### PR TITLE
Use haswell target-cpu for x86_64-unknown-linux-musl

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@ linker = "./linker/cc-aarch64-linux-musl"
 ar = "./linker/ar"
 
 [target.x86_64-unknown-linux-musl]
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = ["-Ctarget-feature=+crt-static", "-Ctarget-cpu=haswell"]
 linker = "./linker/cc-x86_64-linux-musl"
 ar = "./linker/ar"
 


### PR DESCRIPTION
### Description of changes

Enable CPU target

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
