### PR TITLE
Add global parameter to execute old js code

### DIFF
--- a/llrt/src/main.rs
+++ b/llrt/src/main.rs
@@ -172,7 +172,12 @@ async fn start_cli(vm: &Vm) {
 
                 match ext {
                     ".cjs" => {
-                        return vm.run_cjs_file(filename, false, true).await;
+                        if file_exists {
+                            return vm.run_cjs_file(filename, false, true).await;
+                        } else {
+                            eprintln!("No such file: {}", arg);
+                            exit(1);
+                        }
                     },
                     ".js" | ".mjd" => {
                         if file_exists {

--- a/llrt/src/main.rs
+++ b/llrt/src/main.rs
@@ -179,7 +179,7 @@ async fn start_cli(vm: &Vm) {
                             exit(1);
                         }
                     },
-                    ".js" | ".mjd" => {
+                    ".js" | ".mjs" => {
                         if file_exists {
                             return vm.run_esm_file(filename, true, false).await;
                         } else {

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -429,8 +429,12 @@ impl Vm {
         .await;
     }
     pub async fn run_cjs_file(&self, filename: &Path, strict: bool, global: bool) {
-        let source = std::fs::read(filename)
-            .expect(&["No such file: ", &filename.to_string_lossy()].concat());
+        let source = std::fs::read(filename).unwrap_or_else(|_| {
+            panic!(
+                "{}",
+                ["No such file: ", &filename.to_string_lossy()].concat()
+            )
+        });
         self.run(source, strict, global).await;
     }
 

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -429,7 +429,8 @@ impl Vm {
         .await;
     }
     pub async fn run_cjs_file(&self, filename: &Path, strict: bool, global: bool) {
-        let source = std::fs::read(filename).unwrap();
+        let source = std::fs::read(filename)
+            .expect(&["No such file: ", &filename.to_string_lossy()].concat());
         self.run(source, strict, global).await;
     }
 

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -415,7 +415,7 @@ impl Vm {
             .await;
     }
 
-    pub async fn run_file(&self, filename: &Path) {
+    pub async fn run_esm_file(&self, filename: &Path, strict: bool, global: bool) {
         self.run(
             [
                 r#"import(""#,
@@ -423,17 +423,22 @@ impl Vm {
                 r#"").catch((e) => {{console.error(e);process.exit(1)}})"#,
             ]
             .concat(),
-            false,
+            strict,
+            global,
         )
         .await;
     }
+    pub async fn run_cjs_file(&self, filename: &Path, strict: bool, global: bool) {
+        let source = std::fs::read(filename).unwrap();
+        self.run(source, strict, global).await;
+    }
 
-    pub async fn run<S: Into<Vec<u8>> + Send>(&self, source: S, strict: bool) {
+    pub async fn run<S: Into<Vec<u8>> + Send>(&self, source: S, strict: bool, global: bool) {
         self.run_with(|ctx| {
             let mut options = EvalOptions::default();
             options.strict = strict;
             options.promise = true;
-            options.global = false;
+            options.global = global;
             let _ = ctx.eval_with_options::<Value, _>(source, options)?;
             Ok::<_, Error>(())
         })


### PR DESCRIPTION
### Description of changes

Add global parameter to execute old js code

```js
a=1
console.log(a)
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)


