### PR TITLE
Move cargo-patch to workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ inherits = "release"
 strip = false
 debug = true
 
+[workspace.metadata.patch.rquickjs-core]
+version = "*"
+patches = ["llrt_core/patches/promise-poll.patch"]
+
+[patch.crates-io]
+rquickjs-core = { path = "target/patch/rquickjs-core-0.6.2" }
+
 [profile.release]
 strip = true
 lto = true

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -11,13 +11,6 @@ no-sdk = []
 uncompressed = []
 macro = ["rquickjs/macro"]
 
-[package.metadata.patch.rquickjs-core]
-version = "*"
-patches = ["patches/promise-poll.patch"]
-
-[patch.crates-io]
-rquickjs-core = { path = "target/patch/rquickjs-core-0.6.2" }
-
 [dependencies]
 llrt_modules = { path = "../llrt_modules", features = ["all"] }
 llrt_utils = { path = "../llrt_utils", features = ["all"] }
@@ -88,7 +81,6 @@ tokio = { version = "1", features = ["full"] }
 phf_codegen = "0.11.2"
 jwalk = "0.8.1"
 nanoid = "0.4.0"
-cargo-patch = "0.3.2"
 
 [dev-dependencies]
 wiremock = "0.6.0"

--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -40,9 +40,6 @@ async fn main() -> StdResult<(), Box<dyn Error>> {
 
     rerun_if_changed!(BUNDLE_JS_DIR);
     rerun_if_changed!("Cargo.toml");
-    rerun_if_changed!("patches");
-
-    cargo_patch::patch()?;
 
     let resolver = (DummyResolver,);
     let loader = (DummyLoader,);


### PR DESCRIPTION
### Issue # (if available)

Cargo patch only works in root workspace. This is shown as warning during all builds of llrt_core.

### Description of changes

Moved cargo-patch patching from `build.rs` in `llrt_core` to patching via `cargo patch` command in Makefile in workspace root. This seems to be the only way for automated cargo-patch in this workspace.

In Makefile, I added `patch` after every `js` was called and `cargo install cargo-patch` after every cargo toolchain install.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
