### PR TITLE
add snmalloc feature and msvc support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@ linker = "./linker/cc-aarch64-linux-musl"
 ar = "./linker/ar"
 
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
+rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-Ctarget-feature=+crt-static", "-Ctarget-cpu=haswell"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,9 @@ rustflags = ["-Ctarget-feature=+lse,+crt-static", "-Ctarget-cpu=neoverse-n1"]
 linker = "./linker/cc-aarch64-linux-musl"
 ar = "./linker/ar"
 
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-Ctarget-feature=+crt-static", "-Ctarget-cpu=haswell"]
 linker = "./linker/cc-x86_64-linux-musl"

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -11,8 +11,7 @@ jobs:
             platform: windows
             arch: x86_64
             release: x64
-            toolchain: nightly-x86_64-pc-windows-gnu
-            RUSTFLAGS: -C target-feature=+crt-static
+            toolchain: nightly-x86_64-pc-windows-msvc
           - os: ubuntu-latest
             platform: linux
             arch: x86_64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,11 @@ on:
       toolchain:
         required: false
         type: string
-        default: "nightly"
+        default: nightly
 
 jobs:
   build:
+    name: build-${{ inputs.platform }}-${{ inputs.arch }}
     runs-on: ${{ inputs.os }}
     steps:
       - name: Checkout
@@ -69,6 +70,9 @@ jobs:
             zstd
             patch
             unzip
+          shell: pwsh
+          run: |
+            echo "RUSTFLAGS='-C target-feature=+crt-static'" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install JavaScript dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,8 +118,6 @@ jobs:
       - name: Build Windows binaries
         if: inputs.release && inputs.platform == 'windows'
         shell: msys2 {0}
-        env:
-          RUSTFLAGS: "-C target-feature=+crt-static"
         run: |
           # HACK: Add scoop/shims to PATH
           export PATH="$PATH:/c/Users/$USER/scoop/shims"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,6 @@ jobs:
             zstd
             patch
             unzip
-          shell: pwsh
-          run: |
-            echo "RUSTFLAGS='-C target-feature=+crt-static'" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install JavaScript dependencies
         run: |
@@ -121,6 +118,8 @@ jobs:
       - name: Build Windows binaries
         if: inputs.release && inputs.platform == 'windows'
         shell: msys2 {0}
+        env:
+          RUSTFLAGS: "-C target-feature=+crt-static"
         run: |
           # HACK: Add scoop/shims to PATH
           export PATH="$PATH:/c/Users/$USER/scoop/shims"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,8 @@ jobs:
       - name: Build Windows binaries
         if: inputs.release && inputs.platform == 'windows'
         shell: msys2 {0}
+        env:
+          RUSTFLAGS: "-C target-feature=+crt-static"
         run: |
           # HACK: Add scoop/shims to PATH
           export PATH="$PATH:/c/Users/$USER/scoop/shims"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           - os: windows-latest
             platform: windows
             arch: x86_64
-            toolchain: stable-x86_64-pc-windows-gnu
+            toolchain: stable-x86_64-pc-windows-msvc
     uses: ./.github/workflows/build-modules.yml
     with:
       os: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TARGET_linux_x86_64 = x86_64-unknown-linux-musl
 TARGET_linux_arm64 = aarch64-unknown-linux-musl
 TARGET_darwin_x86_64 = x86_64-apple-darwin
 TARGET_darwin_arm64 = aarch64-apple-darwin
-TARGET_windows_x86_64 = x86_64-pc-windows-gnu
+TARGET_windows_x86_64 = x86_64-pc-windows-msvc
 TARGET_windows_arm64 = aarch64-is-not-yet-supported
 RUST_VERSION = nightly
 TOOLCHAIN = +$(RUST_VERSION)
@@ -35,7 +35,7 @@ endif
 ZSTD_LIB_CC_ARGS = -s -O3 -flto
 ZSTD_LIB_ARGS = -j lib-nomt UNAME=Linux ZSTD_LIB_COMPRESSION=0 ZSTD_LIB_DICTBUILDER=0 AR="zig ar"
 ifeq ($(DETECTED_OS),windows)
-ZSTD_LIB_CC_x64 = CC="zig cc -target x86_64-windows-gnu $(ZSTD_LIB_CC_ARGS)"
+ZSTD_LIB_CC_x64 = CC="zig cc -target x86_64-windows-msvc $(ZSTD_LIB_CC_ARGS)"
 else
 ZSTD_LIB_CC_arm64 = CC="zig cc -target aarch64-linux-musl $(ZSTD_LIB_CC_ARGS)"
 ZSTD_LIB_CC_x64 = CC="zig cc -target x86_64-linux-musl $(ZSTD_LIB_CC_ARGS)"

--- a/llrt/Cargo.toml
+++ b/llrt/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2021"
 license-file = "LICENSE"
 
 [features]
-default = ["macro"]
+default = ["macro", "snmalloc"]
 macro = ["llrt_core/macro"]
 lambda = ["llrt_core/lambda"]
 no-sdk = ["llrt_core/no-sdk"]
 uncompressed = ["llrt_core/uncompressed"]
 bindgen = ["llrt_core/bindgen"]
+snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 llrt_core = { path = "../llrt_core" }
@@ -18,9 +19,7 @@ tracing = { version = "0.1.40", features = ["log"] }
 chrono = { version = "0.4.38", default-features = false, features = ["std"] }
 tracing-core = "0.1.32"
 tokio = { version = "1", features = ["full"] }
-
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-snmalloc-rs = { version = "0.3.6", features = ["lto"] }
+snmalloc-rs = { version = "0.3.6", features = ["lto"], optional = true }
 
 [[bin]]
 name = "llrt"

--- a/llrt/src/main.rs
+++ b/llrt/src/main.rs
@@ -29,7 +29,7 @@ use tracing::trace;
 #[cfg(not(feature = "lambda"))]
 use llrt_core::compiler::compile_file;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "snmalloc")]
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -884,8 +884,10 @@ describe("File class", () => {
     expect(file.type).toBe("text/plain");
   });
 
-  it("has last modified date", () => {
+  it("has last modified date", async () => {
     const file = new File(["file content"], "example.txt");
+    // FIXME: msvc has no equivalent implementation of gettimeofday
+    await new Promise(r => setTimeout(r, 1000))
     const now = new Date();
     expect(file.lastModified).toBeLessThanOrEqual(now.getTime());
   });

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -886,8 +886,10 @@ describe("File class", () => {
 
   it("has last modified date", async () => {
     const file = new File(["file content"], "example.txt");
-    // FIXME: msvc has no equivalent implementation of gettimeofday
-    await new Promise(r => setTimeout(r, 1000))
+    if (IS_WIN) {
+      // FIXME: msvc has no equivalent implementation of gettimeofday
+      await new Promise(r => setTimeout(r, 1000))
+    }
     const now = new Date();
     expect(file.lastModified).toBeLessThanOrEqual(now.getTime());
   });


### PR DESCRIPTION
### Description of changes

msvc + snmalloc has a slight performance advantage over gnu, but since msvc has no equivalent implementation of gettimeofday, the lastModified attribute of the file may be slightly different from Date.now

The increase in size is due to the use of ```RUSTFLAGS: -C target-feature=+crt-static```, which reduces dll dependencies and can run on old Windows devices

| Engine | llrt-msvc | llrt-gnu |
| --- | --- | --- |
| Executable size | 12M | 10M |
| Richards | 985 | 961 |
| DeltaBlue | 1076 | 870 |
| Crypto | 604 | 1156 |
| RayTrace | 1745 | 1382 |
| EarleyBoyer | 2731 | 2145 |
| RegExp | 407 | 382 |
| Splay | 2912 | 2102 |
| NavierStokes | 1617 | 2311 |
| Score | 1247 | 1232 |


```
 ldd ./llrt-msvc.exe
        ntdll.dll => /c/WINDOWS/SYSTEM32/ntdll.dll (0x7ff9a1900000)
        KERNEL32.DLL => /c/WINDOWS/System32/KERNEL32.DLL (0x7ff99f810000)
        KERNELBASE.dll => /c/WINDOWS/System32/KERNELBASE.dll (0x7ff99ed10000)
        bcryptprimitives.dll => /c/WINDOWS/System32/bcryptprimitives.dll (0x7ff99f4c0000)
        WS2_32.dll => /c/WINDOWS/System32/WS2_32.dll (0x7ff9a05c0000)
        RPCRT4.dll => /c/WINDOWS/System32/RPCRT4.dll (0x7ff99fe60000)
        bcrypt.dll => /c/WINDOWS/SYSTEM32/bcrypt.dll (0x7ff99e590000)
        CRYPTBASE.dll => /c/WINDOWS/SYSTEM32/CRYPTBASE.dll (0x7ff99dd00000)

```

```
 ldd ./llrt-gnu.exe
        ntdll.dll => /c/WINDOWS/SYSTEM32/ntdll.dll (0x7ff9a1900000)
        KERNEL32.DLL => /c/WINDOWS/System32/KERNEL32.DLL (0x7ff99f810000)
        KERNELBASE.dll => /c/WINDOWS/System32/KERNELBASE.dll (0x7ff99ed10000)
        advapi32.dll => /c/WINDOWS/System32/advapi32.dll (0x7ff99ff80000)
        msvcrt.dll => /c/WINDOWS/System32/msvcrt.dll (0x7ff9a0050000)
        sechost.dll => /c/WINDOWS/System32/sechost.dll (0x7ff9a0480000)
        RPCRT4.dll => /c/WINDOWS/System32/RPCRT4.dll (0x7ff99fe60000)
        ws2_32.dll => /c/WINDOWS/System32/ws2_32.dll (0x7ff9a05c0000)
        bcryptprimitives.dll => /c/WINDOWS/System32/bcryptprimitives.dll (0x7ff99f4c0000)
        bcrypt.dll => /c/WINDOWS/SYSTEM32/bcrypt.dll (0x7ff99e590000)
        CRYPTBASE.DLL => /c/WINDOWS/SYSTEM32/CRYPTBASE.DLL (0x7ff99dd00000)
```
