### PR TITLE
console.log supports multi-byte characters

### DIFF
--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -583,7 +583,6 @@ fn format_values_internal<'js>(
                     continue;
                 }
                 let bytes = str.as_bytes();
-                bytes.iter().position(|p| *p == b'%');
                 let mut i = 0;
                 let len = bytes.len();
                 let mut next_byte;
@@ -624,7 +623,6 @@ fn format_values_internal<'js>(
                                     continue;
                                 },
                                 b'%' => {
-                                    result.push_byte(byte);
                                     result.push_byte(byte);
                                     continue;
                                 },

--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -572,12 +572,12 @@ fn format_values_internal<'js>(
                                         continue;
                                     },
                                     '%' => {
-                                        result.push(byte as char);
+                                        result.push(byte);
                                         continue;
                                     },
                                     _ => {
-                                        result.push(byte as char);
-                                        result.push(next_byte as char);
+                                        result.push(byte);
+                                        result.push(next_byte);
                                         continue;
                                     },
                                 };

--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -90,6 +90,16 @@ pub enum LogLevel {
     Fatal = 16,
 }
 
+trait PushByte {
+    fn push_byte(&mut self, byte: u8);
+}
+
+impl PushByte for String {
+    fn push_byte(&mut self, byte: u8) {
+        unsafe { self.as_mut_vec() }.push(byte);
+    }
+}
+
 impl LogLevel {
     fn to_string(&self) -> String {
         match self {
@@ -240,6 +250,11 @@ fn format_raw<'js>(
     Ok(())
 }
 
+fn format_raw_string<'js>(result: &mut String, value: String, options: &FormatOptions<'js>) {
+    let (color_enabled_mask, not_root_mask, not_root) = get_masks(options, 0);
+    format_raw_string_inner(result, value, not_root_mask, color_enabled_mask, not_root);
+}
+
 fn format_raw_inner<'js>(
     result: &mut String,
     value: Value<'js>,
@@ -249,9 +264,7 @@ fn format_raw_inner<'js>(
 ) -> Result<()> {
     let value_type = value.type_of();
 
-    let color_enabled_mask = bitmask(options.color);
-    let not_root_mask = bitmask(depth != 0);
-    let not_root = (depth != 0) as usize;
+    let (color_enabled_mask, not_root_mask, not_root) = get_masks(options, depth);
 
     match value_type {
         Type::Uninitialized | Type::Null => {
@@ -287,16 +300,19 @@ fn format_raw_inner<'js>(
             }));
         },
         Type::String => {
-            Color::GREEN.push(result, not_root_mask & color_enabled_mask);
-            result.push_str(SINGLE_QUOTE_LOOKUP[not_root]);
-            result.push_str(unsafe {
-                &value
-                    .as_string()
-                    .unwrap_unchecked()
-                    .to_string()
-                    .unwrap_unchecked()
-            });
-            result.push_str(SINGLE_QUOTE_LOOKUP[not_root]);
+            format_raw_string_inner(
+                result,
+                unsafe {
+                    value
+                        .as_string()
+                        .unwrap_unchecked()
+                        .to_string()
+                        .unwrap_unchecked()
+                },
+                not_root_mask,
+                color_enabled_mask,
+                not_root,
+            );
         },
         Type::Symbol => {
             Color::YELLOW.push(result, color_enabled_mask);
@@ -453,6 +469,27 @@ fn format_raw_inner<'js>(
     Ok(())
 }
 
+#[inline(always)]
+fn get_masks(options: &FormatOptions<'_>, depth: usize) -> (usize, usize, usize) {
+    let color_enabled_mask = bitmask(options.color);
+    let not_root_mask = bitmask(depth != 0);
+    let not_root = (depth != 0) as usize;
+    (color_enabled_mask, not_root_mask, not_root)
+}
+
+fn format_raw_string_inner(
+    result: &mut String,
+    value: String,
+    not_root_mask: usize,
+    color_enabled_mask: usize,
+    not_root: usize,
+) {
+    Color::GREEN.push(result, not_root_mask & color_enabled_mask);
+    result.push_str(SINGLE_QUOTE_LOOKUP[not_root]);
+    result.push_str(&value);
+    result.push_str(SINGLE_QUOTE_LOOKUP[not_root]);
+}
+
 fn write_object<'js>(
     result: &mut String,
     obj: &Object<'js>,
@@ -539,61 +576,77 @@ fn format_values_internal<'js>(
         if index == 0 && size > 1 {
             if let Some(str) = arg.as_string() {
                 let str = str.to_string()?;
-                let mut char_iter = str.chars();
-                while let Some(byte) = char_iter.next() {
-                    if byte == '%' {
-                        if let Some(next_byte) = char_iter.next() {
-                            if iter.peek().is_some() {
-                                let mut next_value = || unsafe { iter.next().unwrap_unchecked() }.1;
 
-                                let value = match next_byte {
-                                    's' => {
-                                        let str = next_value().get::<Coerced<String>>()?;
-                                        result.push_str(str.as_str());
-                                        continue;
-                                    },
-                                    'd' => options.number_function.call((next_value(),))?,
-                                    'i' => options.parse_int.call((next_value(),))?,
-                                    'f' => options.parse_float.call((next_value(),))?,
-                                    'j' => {
-                                        result.push_str(
-                                            &json_stringify(ctx, next_value())?
-                                                .unwrap_or("undefined".into()),
-                                        );
-                                        continue;
-                                    },
-                                    'O' => {
-                                        options.object_filter = default_filter;
-                                        next_value()
-                                    },
-                                    'o' => next_value(),
-                                    'c' => {
-                                        // CSS is ignored
-                                        continue;
-                                    },
-                                    '%' => {
-                                        result.push(byte);
-                                        continue;
-                                    },
-                                    _ => {
-                                        result.push(byte);
-                                        result.push(next_byte);
-                                        continue;
-                                    },
-                                };
-                                options.color = false;
-                                format_raw(result, value, options)?;
-                                options.object_filter = current_filter;
-                                continue;
-                            } else {
-                                result.push(byte);
-                                result.push(next_byte);
-                                continue;
-                            }
+                //fast check for format any strings
+                if str.find('%').is_none() {
+                    format_raw_string(result, str, options);
+                    continue;
+                }
+                let bytes = str.as_bytes();
+                bytes.iter().position(|p| *p == b'%');
+                let mut i = 0;
+                let len = bytes.len();
+                let mut next_byte;
+                let mut byte;
+                while i < len {
+                    byte = bytes[i];
+                    if byte == b'%' && i + 1 < len {
+                        next_byte = bytes[i + 1];
+                        i += 1;
+                        if iter.peek().is_some() {
+                            i += 1;
+
+                            let mut next_value = || unsafe { iter.next().unwrap_unchecked() }.1;
+
+                            let value = match next_byte {
+                                b's' => {
+                                    let str = next_value().get::<Coerced<String>>()?;
+                                    result.push_str(str.as_str());
+                                    continue;
+                                },
+                                b'd' => options.number_function.call((next_value(),))?,
+                                b'i' => options.parse_int.call((next_value(),))?,
+                                b'f' => options.parse_float.call((next_value(),))?,
+                                b'j' => {
+                                    result.push_str(
+                                        &json_stringify(ctx, next_value())?
+                                            .unwrap_or("undefined".into()),
+                                    );
+                                    continue;
+                                },
+                                b'O' => {
+                                    options.object_filter = default_filter;
+                                    next_value()
+                                },
+                                b'o' => next_value(),
+                                b'c' => {
+                                    // CSS is ignored
+                                    continue;
+                                },
+                                b'%' => {
+                                    result.push_byte(byte);
+                                    result.push_byte(byte);
+                                    continue;
+                                },
+                                _ => {
+                                    result.push_byte(byte);
+                                    result.push_byte(next_byte);
+                                    continue;
+                                },
+                            };
+                            options.color = false;
+
+                            format_raw(result, value, options)?;
+                            options.object_filter = current_filter;
+                            continue;
                         }
+                        result.push_byte(byte);
+                        result.push_byte(next_byte);
                     } else {
-                        result.push(byte);
+                        result.push_byte(byte);
                     }
+
+                    i += 1;
                 }
                 continue;
             }

--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -250,7 +250,7 @@ fn format_raw<'js>(
     Ok(())
 }
 
-fn format_raw_string<'js>(result: &mut String, value: String, options: &FormatOptions<'js>) {
+fn format_raw_string(result: &mut String, value: String, options: &FormatOptions<'_>) {
     let (color_enabled_mask, not_root_mask, not_root) = get_masks(options, 0);
     format_raw_string_inner(result, value, not_root_mask, color_enabled_mask, not_root);
 }

--- a/tests/unit/console.test.ts
+++ b/tests/unit/console.test.ts
@@ -5,6 +5,7 @@ import util from "util";
 
 it("should format strings correctly", () => {
   expect(util.format("%s:%s", "foo", "bar")).toEqual("foo:bar");
+  expect(util.format("█", "foo")).toEqual("█ foo");
   expect(util.format(1, 2, 3)).toEqual("1 2 3");
   expect(util.format("%% %s")).toEqual("%% %s");
   expect(util.format("%s:%s", "foo")).toEqual("foo:%s");


### PR DESCRIPTION
### Issue # (if available)

close: https://github.com/awslabs/llrt/issues/605

### Description of changes

console.log supports multi-byte characters

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

