### PR TITLE
Fix & simplify CJS support

### DIFF
--- a/fixtures/e.cjs
+++ b/fixtures/e.cjs
@@ -1,0 +1,1 @@
+module.exports.prop = "a";

--- a/llrt/src/main.rs
+++ b/llrt/src/main.rs
@@ -170,18 +170,12 @@ async fn start_cli(vm: &Vm) {
                 let filename = Path::new(arg);
                 let file_exists = filename.exists();
 
+                let global = ext == ".cjs";
+
                 match ext {
-                    ".cjs" => {
+                    ".cjs" | ".js" | ".mjs" => {
                         if file_exists {
-                            return vm.run_cjs_file(filename, false, true).await;
-                        } else {
-                            eprintln!("No such file: {}", arg);
-                            exit(1);
-                        }
-                    },
-                    ".js" | ".mjs" => {
-                        if file_exists {
-                            return vm.run_esm_file(filename, true, false).await;
+                            return vm.run_file(filename, true, global).await;
                         } else {
                             eprintln!("No such file: {}", arg);
                             exit(1);
@@ -189,7 +183,7 @@ async fn start_cli(vm: &Vm) {
                     },
                     _ => {
                         if file_exists {
-                            return vm.run_esm_file(filename, true, false).await;
+                            return vm.run_file(filename, true, false).await;
                         }
                         eprintln!("Unknown command: {}", arg);
                         usage();
@@ -199,7 +193,7 @@ async fn start_cli(vm: &Vm) {
             }
         }
     } else if let Some(filename) = get_js_path("index") {
-        vm.run_esm_file(&filename, true, false).await;
+        vm.run_file(&filename, true, false).await;
     }
 }
 

--- a/llrt_core/src/modules/js/@llrt/std.ts
+++ b/llrt_core/src/modules/js/@llrt/std.ts
@@ -2,23 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 import "./init";
 
-Object.defineProperty(globalThis, "module", {
-  value: new Proxy(
-    {},
-    {
-      set: __bootstrap.moduleExport,
-    }
-  ),
-  configurable: false,
-});
-Object.defineProperty(globalThis, "exports", {
-  value: new Proxy(
-    {},
-    {
-      set: __bootstrap.exports,
-    }
-  ),
-  configurable: false,
-});
-
 Object.freeze(__bootstrap);

--- a/llrt_utils/src/object.rs
+++ b/llrt_utils/src/object.rs
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use rquickjs::{atom::PredefinedAtom, FromJs, Function, IntoAtom, Object, Result, Symbol, Value};
+use rquickjs::{
+    atom::PredefinedAtom,
+    function::{Constructor, IntoJsFunc},
+    prelude::Func,
+    Ctx, FromJs, Function, IntoAtom, IntoJs, Object, Result, Symbol, Undefined, Value,
+};
 
 pub trait ObjectExt<'js> {
     fn get_optional<K: IntoAtom<'js> + Clone, V: FromJs<'js>>(&self, k: K) -> Result<Option<V>>;
@@ -33,5 +38,49 @@ impl<'js> CreateSymbol<'js> for Symbol<'js> {
         let symbol_function: Function = globals.get(PredefinedAtom::Symbol)?;
         let for_function: Function = symbol_function.get(PredefinedAtom::For)?;
         for_function.call((description,))
+    }
+}
+
+pub struct Proxy<'js> {
+    target: Value<'js>,
+    options: Object<'js>,
+}
+
+impl<'js> IntoJs<'js> for Proxy<'js> {
+    fn into_js(self, ctx: &Ctx<'js>) -> Result<Value<'js>> {
+        let proxy_ctor = ctx.globals().get::<_, Constructor>(PredefinedAtom::Proxy)?;
+
+        proxy_ctor.construct::<_, Value>((self.target, self.options))
+    }
+}
+
+impl<'js> Proxy<'js> {
+    pub fn new(ctx: Ctx<'js>) -> Result<Self> {
+        let options = Object::new(ctx.clone())?;
+        Ok(Self {
+            target: Undefined.into_value(ctx),
+            options,
+        })
+    }
+
+    pub fn with_target(ctx: Ctx<'js>, target: Value<'js>) -> Result<Self> {
+        let options = Object::new(ctx)?;
+        Ok(Self { target, options })
+    }
+
+    pub fn setter<T, P>(&self, setter: Func<T, P>) -> Result<()>
+    where
+        T: IntoJsFunc<'js, P> + 'js,
+    {
+        self.options.set(PredefinedAtom::Setter, setter)?;
+        Ok(())
+    }
+
+    pub fn getter<T, P>(&self, getter: Func<T, P>) -> Result<()>
+    where
+        T: IntoJsFunc<'js, P> + 'js,
+    {
+        self.options.set(PredefinedAtom::Getter, getter)?;
+        Ok(())
     }
 }

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -30,6 +30,12 @@ it("should handle cjs requires", () => {
   expect(a.c).toEqual("c");
 });
 
+it("should handle cjs requires", () => {
+  const a = _require(`${CWD}/fixtures/e.cjs`);
+
+  expect(a.prop).toEqual("a");
+});
+
 it("should be able to use node module with prefix `node:` with require", () => {
   let { Console } = require("node:console");
   const consoleObj = new Console({


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/607

### Description of changes

Move some JS code to Rust and enable support for setting properties on the export object directly. Also files passed as arguments to CLI works as both CJS and MJS

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
