### PR TITLE
Fix and simplify CJS imports/requires

### DIFF
--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -567,7 +567,7 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
         Func::from(move |ctx, specifier: String| -> Result<Value> {
             struct Args<'js>(Ctx<'js>);
             let Args(ctx) = Args(ctx);
-            let specifier = if let Some(striped_specifier) = &specifier.strip_prefix("node:") {
+            let specifier = if let Some(striped_specifier) = specifier.strip_prefix("node:") {
                 striped_specifier.to_string()
             } else {
                 specifier


### PR DESCRIPTION
### Description of changes

Nested require imports could result in corrupt exports as they shared `module.exports` object.

In this new implementation, each require saves the current `module.export` object in stack memory and create a new one added to global scope. After module is imported the current one is restored. This prevents CJS imports/requires from corrupting the same object and is a much simpler, cleaner and more stable implemenaation.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
