### PR TITLE
fix: Prevent unnecessary merging of absolute paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ llrt-lambda-${1}${2}.zip: export SDK_BUNDLE_MODE = ${3}
 llrt-lambda-${1}${2}.zip: | clean-js js
 	cargo $$(BUILD_ARG) --target $$(TARGET_linux_$$(RELEASE_ARCH_NAME_${1})) --features lambda
 	./pack target/$$(TARGET_linux_$$(RELEASE_ARCH_NAME_${1}))/release/llrt target/$$(TARGET_linux_$$(RELEASE_ARCH_NAME_${1}))/release/bootstrap
-	@rm -rf $$@ 
+	@rm -rf $$@
 	zip -j $$@ target/$$(TARGET_linux_$$(RELEASE_ARCH_NAME_${1}))/release/bootstrap
 
 llrt-container-${1}${2}: export SDK_BUNDLE_MODE = ${3}
@@ -80,20 +80,20 @@ llrt-container-${1}${2}: | clean-js js
 llrt-linux-${1}${2}.zip: export SDK_BUNDLE_MODE = ${3}
 llrt-linux-${1}${2}.zip: | clean-js js
 	cargo $$(BUILD_ARG) --target $$(TARGET_linux_$$(RELEASE_ARCH_NAME_${1}))
-	@rm -rf $$@ 
+	@rm -rf $$@
 	zip -j $$@ target/$$(TARGET_linux_$$(RELEASE_ARCH_NAME_${1}))/release/llrt
 
 llrt-darwin-${1}${2}.zip: export SDK_BUNDLE_MODE = ${3}
 llrt-darwin-${1}${2}.zip: | clean-js js
 	cargo $$(BUILD_ARG) --target $$(TARGET_darwin_$$(RELEASE_ARCH_NAME_${1}))
-	@rm -rf $$@ 
+	@rm -rf $$@
 	zip -j $$@ target/$$(TARGET_darwin_$$(RELEASE_ARCH_NAME_${1}))/release/llrt
 
 # llrt-windows-arm64* is automatically generated, but not currently supported.
 llrt-windows-${1}${2}.zip: export SDK_BUNDLE_MODE = ${3}
 llrt-windows-${1}${2}.zip: | clean-js js
 	cargo $$(BUILD_ARG) --target $$(TARGET_windows_$$(RELEASE_ARCH_NAME_${1}))
-	zip -j $$@ target/$$(TARGET_windows_$$(RELEASE_ARCH_NAME_${1}))/release/llrt/release/llrt.exe
+	zip -j $$@ target/$$(TARGET_windows_$$(RELEASE_ARCH_NAME_${1}))/release/llrt.exe
 endef
 
 $(foreach target,$(RELEASE_TARGETS),$(eval $(call release_template,$(target),-full-sdk,FULL)))

--- a/llrt_core/src/custom_resolver.rs
+++ b/llrt_core/src/custom_resolver.rs
@@ -90,7 +90,7 @@ pub fn require_resolve(ctx: &Ctx<'_>, x: &str, y: &str, is_esm: bool) -> Result<
 
     // 3. If X begins with './' or '/' or '../'
     if x.starts_with("./") || path::is_absolute(x) || x.starts_with("../") {
-        let y_plus_x = if cfg!(windows) && path::is_absolute(x) {
+        let y_plus_x = if path::is_absolute(x) {
             x.to_string()
         } else {
             [&dirname_y, "/", x].concat()


### PR DESCRIPTION
### Description of changes

- Suppress unnecessary merging of absolute paths (works fine as is, but the path representation is weird when outputting stack traces).
- We also noticed regression in makefile, so we fixed it as well.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
