### PR TITLE
fix: Remove extra unwrap

### DIFF
--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -450,7 +450,7 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
 
     module.prop(
         "exports",
-        Accessor::from(move || require_exports2.lock().unwrap().as_ref().cloned().unwrap())
+        Accessor::from(move || require_exports2.lock().unwrap().as_ref().cloned())
             .set(move |exports| {
                 require_exports3.lock().unwrap().replace(exports);
             })
@@ -462,7 +462,7 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
 
     globals.prop(
         "exports",
-        Accessor::from(move || require_exports4.lock().unwrap().as_ref().cloned().unwrap())
+        Accessor::from(move || require_exports4.lock().unwrap().as_ref().cloned())
             .set(move |exports| {
                 require_exports5.lock().unwrap().replace(exports);
             })


### PR DESCRIPTION
### Description of changes

Removed an extra unwrap which causes a called unwrap on None error. Before:
```sh
 ./target/release/llrt -e "console.log(global)"
 ```
Fails with:
 ```
thread 'main' panicked at llrt_core/src/vm.rs:465:83:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
