### PR TITLE
fix: Correction of extensions when loading Node.js packages

### DIFF
--- a/llrt_core/src/custom_resolver.rs
+++ b/llrt_core/src/custom_resolver.rs
@@ -398,7 +398,9 @@ fn load_package_exports(ctx: &Ctx<'_>, x: &str, dir: &str, is_esm: bool) -> Resu
 
     let module_path = package_exports_resolve(&package_json, name, is_esm)?;
 
-    Ok(Box::from([dir, "/", scope, "/", module_path].concat()))
+    Ok(correct_extensions(
+        &[dir, "/", scope, "/", module_path].concat(),
+    ))
 }
 
 // LOAD_PACKAGE_SELF(X, DIR)
@@ -536,4 +538,17 @@ fn is_exports_field_exists<'a>(package_json: &'a BorrowedValue<'a>) -> bool {
         }
     }
     false
+}
+
+fn correct_extensions(x: &str) -> Box<str> {
+    if Path::new(x).is_file() {
+        return Box::from(x);
+    }
+    for extension in [".js", ".mjs", ".cjs"].iter() {
+        let file = [x, extension].concat();
+        if Path::new(&file).is_file() {
+            return Box::from(file);
+        }
+    }
+    Box::from(x)
 }


### PR DESCRIPTION
### Description of changes

- In some rare cases, the extension is not specified in the package.json definition of a Node.js package. When loading such packages, an error occurs that cannot be resolved at this time.
- The fix is to complete the “.js”, “.mjs”, and “.cjs” extensions in order if they do not exist at the end, and pass those that do to the loader so they can be loaded.

node_modules/form-data/package.json:
```json
{
  "main": "./lib/form_data",
}
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
