### PR TITLE
feat: Browser priority for loading Node.js packages

### DIFF
--- a/llrt_core/src/custom_resolver.rs
+++ b/llrt_core/src/custom_resolver.rs
@@ -459,6 +459,12 @@ fn package_exports_resolve<'a>(
     if let BorrowedValue::Object(map) = package_json {
         if let Some(BorrowedValue::Object(exports)) = map.get("exports") {
             if let Some(BorrowedValue::Object(name)) = exports.get(modules_name) {
+                // Check for exports -> name -> browser -> [import | require]
+                if let Some(BorrowedValue::Object(browser)) = name.get("browser") {
+                    if let Some(BorrowedValue::String(ident)) = browser.get(ident) {
+                        return Ok(ident.as_ref());
+                    }
+                }
                 // Check for exports -> name -> [import | require] -> default
                 if let Some(BorrowedValue::Object(ident)) = name.get(ident) {
                     if let Some(BorrowedValue::String(default)) = ident.get("default") {


### PR DESCRIPTION
### Description of changes

- Node.js packages usually use the Node.js API, but some have a module for the Browser.
- In the case of LLRT, as can be seen from the fact that the bundle target of `@aws-sdk` is Browser, if there is a module for Browser, it is more likely to work if you give priority to that one. At least modules like `axios` will now work.
- There may be other ways to specify a different Browser, but there doesn't seem to be a clear rule, so we will address them as soon as we find them.

node_modules/axios/package.json:
```json
  "exports": {
    ".": {
      "browser": {
        "require": "./dist/browser/axios.cjs",
        "default": "./index.js"
      },
      "default": {
        "require": "./dist/node/axios.cjs",
        "default": "./index.js"
      }
    },
  },
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
