### PR TITLE
feat: More browser priority support when loading Node.js packages

### DIFF
--- a/llrt_core/src/custom_resolver.rs
+++ b/llrt_core/src/custom_resolver.rs
@@ -499,6 +499,10 @@ fn package_exports_resolve<'a>(
                 }
             }
         }
+        // Check for browser field
+        if let Some(BorrowedValue::String(browser)) = map.get("browser") {
+            return Ok(browser.as_ref());
+        }
         // [ESM only] Check for module field
         if is_esm {
             if let Some(BorrowedValue::String(module)) = map.get("module") {
@@ -506,7 +510,6 @@ fn package_exports_resolve<'a>(
             }
         }
         // Check for main field
-        // Workaround for modules that have only “main” defined and whose entrypoint is not “index.js”
         if let Some(BorrowedValue::String(main)) = map.get("main") {
             return Ok(main.as_ref());
         }


### PR DESCRIPTION
### Description of changes

- This PR is further browser-preferred support for Node.js package loading.
- This support allows packages such as `debug` to be loaded with Browser priority.

node_modules/debug/package.json:

```json
{
  "browser": "./src/browser.js",
}
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
