### PR TITLE
feat: Implementation of os.arch()

### DIFF
--- a/API.md
+++ b/API.md
@@ -129,6 +129,12 @@ Available globally
 
 ## os
 
+[arch](https://nodejs.org/api/os.html#osarch)
+
+[availableParallelism](https://nodejs.org/api/os.html#osavailableparallelism)
+
+[EOL](https://nodejs.org/api/os.html#oseol)
+
 [platform](https://nodejs.org/api/os.html#osplatform)
 
 [release](https://nodejs.org/api/os.html#osrelease)
@@ -136,6 +142,8 @@ Available globally
 [tmpdir](https://nodejs.org/api/os.html#osplatform)
 
 [type](https://nodejs.org/api/os.html#ostype)
+
+[version](https://nodejs.org/api/os.html#osversion)
 
 ## path
 

--- a/types/os.d.ts
+++ b/types/os.d.ts
@@ -42,4 +42,10 @@ declare module "os" {
    * * `\r\n` on Windows
    */
   const EOL: string;
+
+  /**
+   * Returns the operating system CPU architecture for which the LLRT binary was compiled.
+   * Possible values are 'arm64', 'x64'. The return value is equivalent to `process.arch`.
+   */
+  export function arch(): string;
 }


### PR DESCRIPTION
### Description of changes

- This is an implementation of `os.arch()` used by `@opensearch-project/opensearch` and others.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
