### PR TITLE
feat: Implementation of buffer.constants

### DIFF
--- a/API.md
+++ b/API.md
@@ -11,6 +11,10 @@
 
 [concat](https://nodejs.org/api/buffer.html#static-method-bufferconcatlist-totallength)
 
+[constants.MAX_LENGTH](https://nodejs.org/api/buffer.html#bufferconstantsmax_length)
+
+[constants.MAX_STRING_LENGTH](https://nodejs.org/api/buffer.html#bufferconstantsmax_string_length)
+
 [from](https://nodejs.org/api/buffer.html#static-method-bufferfromarray)
 
 Everything else inherited from [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -334,10 +334,7 @@ impl ModuleDef for BufferModule {
         let buf: Constructor = globals.get(stringify!(Buffer))?;
 
         let constants = Object::new(ctx.clone())?;
-        #[cfg(target_pointer_width = "32")]
-        constants.set("MAX_LENGTH", (1u32 << 30) - 1);
-        #[cfg(target_pointer_width = "64")]
-        constants.set("MAX_LENGTH", (1u64 << 53) - 1)?;
+        constants.set("MAX_LENGTH", usize::MAX)?;
         constants.set("MAX_STRING_LENGTH", (1u32 << 28) - 16)?;
 
         export_default(ctx, exports, |default| {

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -334,8 +334,8 @@ impl ModuleDef for BufferModule {
         let buf: Constructor = globals.get(stringify!(Buffer))?;
 
         let constants = Object::new(ctx.clone())?;
-        constants.set("MAX_LENGTH", usize::MAX)?;
-        constants.set("MAX_STRING_LENGTH", (1u32 << 28) - 16)?;
+        constants.set("MAX_LENGTH", u32::MAX)?; // For QuickJS
+        constants.set("MAX_STRING_LENGTH", (1 << 30) - 1)?; // For QuickJS
 
         export_default(ctx, exports, |default| {
             default.set(stringify!(Buffer), buf)?;

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -323,6 +323,7 @@ impl ModuleDef for BufferModule {
         declare.declare(stringify!(Buffer))?;
         declare.declare("atob")?;
         declare.declare("btoa")?;
+        declare.declare("constants")?;
         declare.declare("default")?;
 
         Ok(())
@@ -332,10 +333,18 @@ impl ModuleDef for BufferModule {
         let globals = ctx.globals();
         let buf: Constructor = globals.get(stringify!(Buffer))?;
 
+        let constants = Object::new(ctx.clone())?;
+        #[cfg(target_pointer_width = "32")]
+        constants.set("MAX_LENGTH", (1u32 << 30) - 1);
+        #[cfg(target_pointer_width = "64")]
+        constants.set("MAX_LENGTH", (1u64 << 53) - 1)?;
+        constants.set("MAX_STRING_LENGTH", (1u32 << 28) - 16)?;
+
         export_default(ctx, exports, |default| {
             default.set(stringify!(Buffer), buf)?;
             default.set("atob", Func::from(atob))?;
             default.set("btoa", Func::from(btoa))?;
+            default.set("constants", constants)?;
             Ok(())
         })?;
 

--- a/types/buffer.d.ts
+++ b/types/buffer.d.ts
@@ -36,6 +36,10 @@
  * ```
  */
 declare module "buffer" {
+  export const constants: {
+    MAX_LENGTH: number;
+    MAX_STRING_LENGTH: number;
+  };
   export type BufferEncoding =
     | "hex"
     | "base64"


### PR DESCRIPTION
### Description of changes

This is an implementation of `buffer.constants` used by `@opensearch-project/opensearch` and others.

- `constants.MAX_LENGTH` :  Conforms to the Node.js specification.
https://nodejs.org/api/buffer.html#bufferconstantsmax_length
- `constants.MAX_STRING_LENGTH` :  Since we did not know what to define, we chose a minimum value for the major runtimes. If you have a more suitable value, I would appreciate your advice.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length#description


### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
