### PR TITLE
Add pure rust compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +301,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -2545,7 +2581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2761,6 +2797,7 @@ dependencies = [
 name = "llrt_http"
 version = "0.3.0-beta"
 dependencies = [
+ "brotli",
  "brotlic",
  "bytes",
  "either",

--- a/modules/llrt_http/Cargo.toml
+++ b/modules/llrt_http/Cargo.toml
@@ -12,16 +12,23 @@ name = "llrt_http"
 path = "src/lib.rs"
 
 [features]
-default = ["http1", "http2"]
+default = ["http1", "http2", "brotli-c", "flate2-c"]
 
 http1 = ["hyper/http1", "hyper-rustls/http1"]
 http2 = ["hyper/http2", "hyper-rustls/http2"]
 
+brotli-c = ["brotlic"]
+brotli-rust = ["brotli"]
+
+flate2-c = ["flate2/zlib-ng"]
+flate2-rust = ["flate2/miniz_oxide"]
+
 [dependencies]
-brotlic = "0.8"
+brotlic = { version = "0.8", optional = true }
+brotli = { version = "7", optional = true }
 bytes = "1.6.1"
 either = "1"
-flate2 = { version = "1", features = ["zlib-ng"], default-features = false }
+flate2 = { version = "1", default-features = false }
 http-body-util = "0.1.2"
 hyper = { version = "1.4.1", features = ["client"] }
 hyper-rustls = { version = "0.27.2", default-features = false, features = [
@@ -53,6 +60,7 @@ webpki-roots = "0.26.3"
 zstd = { version = "0.13.2", default-features = false }
 
 [dev-dependencies]
+brotlic = "0.8"
 llrt_test = { path = "../../libs/llrt_test" }
 tokio = { version = "1", features = ["full"] }
 wiremock = "0.6.0"

--- a/modules/llrt_http/src/compression.rs
+++ b/modules/llrt_http/src/compression.rs
@@ -1,5 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+#[cfg(not(any(feature = "flate2-c", feature = "flate2-rust")))]
+compile_error!("Either the `flate2-c` or `flate2-rust` feature must be enabled");
+
+#[cfg(not(any(feature = "brotli-c", feature = "brotli-rust")))]
+compile_error!("Either the `brotli-c` or `brotli-rust` feature must be enabled");
+
 pub(crate) mod zstd {
     use std::io::{BufReader, Read};
 
@@ -11,61 +18,46 @@ pub(crate) mod zstd {
     }
 }
 
+#[cfg(any(feature = "flate2-c", feature = "flate2-rust"))]
 pub(crate) mod gz {
     use std::io::Read;
 
     use flate2::read::GzDecoder;
 
     pub fn decoder<R: Read>(r: R) -> GzDecoder<R> {
-        #[cfg(any(feature = "flate2-c", feature = "flate2-rust"))]
-        {
-            GzDecoder::new(r)
-        }
-        #[cfg(not(any(feature = "flate2-c", feature = "flate2-rust")))]
-        {
-            compile_error!("Either the `flate2-c` or `flate2-rust` feature must be enabled")
-        }
+        GzDecoder::new(r)
     }
 }
 
+#[cfg(any(feature = "flate2-c", feature = "flate2-rust"))]
 pub(crate) mod zlib {
     use std::io::Read;
 
     use flate2::read::ZlibDecoder;
 
     pub fn decoder<R: Read>(r: R) -> ZlibDecoder<R> {
-        #[cfg(any(feature = "flate2-c", feature = "flate2-rust"))]
-        {
-            ZlibDecoder::new(r)
-        }
-        #[cfg(not(any(feature = "flate2-c", feature = "flate2-rust")))]
-        {
-            compile_error!("Either the `flate2-c` or `flate2-rust` feature must be enabled")
-        }
+        ZlibDecoder::new(r)
     }
 }
 
+#[cfg(feature = "brotli-c")]
 pub(crate) mod brotli {
-    #[cfg(feature = "brotli-c")]
     use std::io::BufRead;
-    #[cfg(all(not(feature = "brotli-c"), feature = "brotli-rust"))]
-    use std::io::Read;
 
-    #[cfg(all(not(feature = "brotli-c"), feature = "brotli-rust"))]
-    use brotli::Decompressor as BrotliDecoder;
-    #[cfg(feature = "brotli-c")]
     use brotlic::DecompressorReader as BrotliDecoder;
 
-    #[cfg(feature = "brotli-c")]
     pub fn decoder<R: BufRead>(r: R) -> BrotliDecoder<R> {
         BrotliDecoder::new(r)
     }
+}
 
-    #[cfg(all(not(feature = "brotli-c"), feature = "brotli-rust"))]
+#[cfg(all(not(feature = "brotli-c"), feature = "brotli-rust"))]
+pub(crate) mod brotli {
+    use std::io::Read;
+
+    use brotli::Decompressor as BrotliDecoder;
+
     pub fn decoder<R: Read>(r: R) -> BrotliDecoder<R> {
         BrotliDecoder::new(r, 8_096)
     }
-
-    #[cfg(not(any(feature = "brotli-c", feature = "brotli-rust")))]
-    compile_error!("Either the `brotli-c` or `brotli-rust` feature must be enabled");
 }

--- a/modules/llrt_http/src/compression.rs
+++ b/modules/llrt_http/src/compression.rs
@@ -48,10 +48,10 @@ pub(crate) mod zlib {
 pub(crate) mod brotli {
     #[cfg(feature = "brotli-c")]
     use std::io::BufRead;
-    #[cfg(feature = "brotli-rust")]
+    #[cfg(all(not(feature = "brotli-c"), feature = "brotli-rust"))]
     use std::io::Read;
 
-    #[cfg(feature = "brotli-rust")]
+    #[cfg(all(not(feature = "brotli-c"), feature = "brotli-rust"))]
     use brotli::Decompressor as BrotliDecoder;
     #[cfg(feature = "brotli-c")]
     use brotlic::DecompressorReader as BrotliDecoder;
@@ -61,7 +61,7 @@ pub(crate) mod brotli {
         BrotliDecoder::new(r)
     }
 
-    #[cfg(feature = "brotli-rust")]
+    #[cfg(all(not(feature = "brotli-c"), feature = "brotli-rust"))]
     pub fn decoder<R: Read>(r: R) -> BrotliDecoder<R> {
         BrotliDecoder::new(r, 8_096)
     }

--- a/modules/llrt_http/src/compression.rs
+++ b/modules/llrt_http/src/compression.rs
@@ -1,0 +1,69 @@
+pub(crate) mod zstd {
+    use std::io::{BufReader, Read};
+
+    use rquickjs::Result;
+    use zstd::stream::read::Decoder as ZstdDecoder;
+
+    pub fn decoder<R: Read>(r: R) -> Result<ZstdDecoder<'static, BufReader<R>>> {
+        Ok(ZstdDecoder::new(r)?)
+    }
+}
+
+pub(crate) mod gz {
+    use std::io::Read;
+
+    use flate2::read::GzDecoder;
+
+    pub fn decoder<R: Read>(r: R) -> GzDecoder<R> {
+        #[cfg(any(feature = "flate2-c", feature = "flate2-rust"))]
+        {
+            GzDecoder::new(r)
+        }
+        #[cfg(not(any(feature = "flate2-c", feature = "flate2-rust")))]
+        {
+            compile_error!("Either the `flate2-c` or `flate2-rust` feature must be enabled")
+        }
+    }
+}
+
+pub(crate) mod zlib {
+    use std::io::Read;
+
+    use flate2::read::ZlibDecoder;
+
+    pub fn decoder<R: Read>(r: R) -> ZlibDecoder<R> {
+        #[cfg(any(feature = "flate2-c", feature = "flate2-rust"))]
+        {
+            ZlibDecoder::new(r)
+        }
+        #[cfg(not(any(feature = "flate2-c", feature = "flate2-rust")))]
+        {
+            compile_error!("Either the `flate2-c` or `flate2-rust` feature must be enabled")
+        }
+    }
+}
+
+pub(crate) mod brotli {
+    #[cfg(feature = "brotli-c")]
+    use std::io::BufRead;
+    #[cfg(feature = "brotli-rust")]
+    use std::io::Read;
+
+    #[cfg(feature = "brotli-rust")]
+    use brotli::Decompressor as BrotliDecoder;
+    #[cfg(feature = "brotli-c")]
+    use brotlic::DecompressorReader as BrotliDecoder;
+
+    #[cfg(feature = "brotli-c")]
+    pub fn decoder<R: BufRead>(r: R) -> BrotliDecoder<R> {
+        BrotliDecoder::new(r)
+    }
+
+    #[cfg(feature = "brotli-rust")]
+    pub fn decoder<R: Read>(r: R) -> BrotliDecoder<R> {
+        BrotliDecoder::new(r, 8_096)
+    }
+
+    #[cfg(not(any(feature = "brotli-c", feature = "brotli-rust")))]
+    compile_error!("Either the `brotli-c` or `brotli-rust` feature must be enabled");
+}

--- a/modules/llrt_http/src/compression.rs
+++ b/modules/llrt_http/src/compression.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 pub(crate) mod zstd {
     use std::io::{BufReader, Read};
 

--- a/modules/llrt_http/src/lib.rs
+++ b/modules/llrt_http/src/lib.rs
@@ -22,6 +22,7 @@ use self::{file::File, headers::Headers, request::Request, response::Response};
 
 mod blob;
 mod body;
+mod compression;
 mod fetch;
 mod file;
 mod headers;


### PR DESCRIPTION
### Description of changes

- Adding support for pure rust implementation of compression in http

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
