### PR TITLE
Submodule update=none

### DIFF
--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
+      - name: Checkout submodules
+        run: git submodule update --init --checkout
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          submodules: true
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "zstd"]
 	path = zstd
 	url = https://github.com/facebook/zstd.git
-	update = none
+	update = none # Workaround for https://github.com/rust-lang/cargo/issues/4247

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "zstd"]
 	path = zstd
 	url = https://github.com/facebook/zstd.git
+	update = none

--- a/README.md
+++ b/README.md
@@ -369,12 +369,12 @@ There are many cases where LLRT shows notable performance drawbacks compared wit
 
 Clone code and cd to directory
 
-    git clone git@github.com:awslabs/llrt.git --recursive
+    git clone git@github.com:awslabs/llrt.git
     cd llrt
 
-Install git submodules if you've not cloned the repository with `--recursive`
+Install git submodules
 
-    git submodule update --init
+    git submodule update --init --checkout
 
 Install rust
 


### PR DESCRIPTION
### Description of changes

- Submodules get pulled in automatically by cargo when using a git dependency, this is annoying since we don't need zstd most of the time. This adds update=none to it so it won't do that, but the downside is that we need to override it elsewhere.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
