### PR TITLE
Add http module

### DIFF
--- a/modules/llrt_http/src/lib.rs
+++ b/modules/llrt_http/src/lib.rs
@@ -158,3 +158,36 @@ pub fn init(ctx: &Ctx) -> Result<()> {
 
     Ok(())
 }
+
+pub struct HttpModule;
+
+impl rquickjs::module::ModuleDef for HttpModule {
+    fn declare(declare: &rquickjs::module::Declarations) -> Result<()> {
+        declare.declare("fetch")?;
+        declare.declare(stringify!(Request))?;
+        declare.declare(stringify!(Request))?;
+        declare.declare(stringify!(Headers))?;
+        declare.declare("Blob")?;
+        declare.declare(stringify!(File))?;
+
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &rquickjs::module::Exports<'js>) -> Result<()> {
+        llrt_utils::module::export_default(ctx, exports, |default| {
+            fetch::init(ctx, default)?;
+
+            Class::<Request>::define(default)?;
+            Class::<Response>::define(default)?;
+            Class::<Headers>::define_with_custom_inspect(default)?;
+
+            blob::init(ctx, default)?;
+
+            Class::<File>::define(default)?;
+
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Description of changes

Unsure if we want that, but I needed it for my own thing because I had problems with existing classes clashing.
Unsure what `ModuleInfo` name we would give it, not `http` since that is taken in node for other stuff. Maybe `fetch`?

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
