### PR TITLE
Make modules public in http

### DIFF
--- a/modules/llrt_http/src/blob.rs
+++ b/modules/llrt_http/src/blob.rs
@@ -211,7 +211,7 @@ fn bytes_from_parts<'js>(
     Ok(data)
 }
 
-pub(crate) fn init<'js>(ctx: &Ctx<'js>, globals: &Object<'js>) -> Result<()> {
+pub fn init<'js>(ctx: &Ctx<'js>, globals: &Object<'js>) -> Result<()> {
     if let Some(constructor) = Class::<Blob>::create_constructor(ctx)? {
         constructor.prop(
             PredefinedAtom::SymbolHasInstance,

--- a/modules/llrt_http/src/fetch.rs
+++ b/modules/llrt_http/src/fetch.rs
@@ -24,7 +24,7 @@ use super::{blob::Blob, headers::Headers, response::Response, security::ensure_u
 
 const MAX_REDIRECT_COUNT: u32 = 20;
 
-pub(crate) fn init<C>(client: Client<C, BoxBody<Bytes, Infallible>>, globals: &Object) -> Result<()>
+pub fn init<C>(client: Client<C, BoxBody<Bytes, Infallible>>, globals: &Object) -> Result<()>
 where
     C: Clone + Send + Sync + Connect + 'static,
 {

--- a/modules/llrt_http/src/lib.rs
+++ b/modules/llrt_http/src/lib.rs
@@ -22,14 +22,14 @@ use webpki_roots::TLS_SERVER_ROOTS;
 pub use self::security::{get_allow_list, get_deny_list, set_allow_list, set_deny_list};
 use self::{file::File, headers::Headers, request::Request, response::Response};
 
-mod blob;
+pub mod blob;
 mod body;
-mod fetch;
-mod file;
-mod headers;
+pub mod fetch;
+pub mod file;
+pub mod headers;
 mod incoming;
-mod request;
-mod response;
+pub mod request;
+pub mod response;
 mod security;
 
 const DEFAULT_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);


### PR DESCRIPTION
### Description of changes

Make relevant modules public on llrt_http so people can craft their own module

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
