### PR TITLE
feat: allow `fetch` to be initialized with user-provided client

### DIFF
--- a/modules/llrt_http/src/lib.rs
+++ b/modules/llrt_http/src/lib.rs
@@ -1,15 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use std::convert::Infallible;
 use std::{io, sync::OnceLock, time::Duration};
 
 use bytes::Bytes;
-use http_body_util::Full;
+use http_body_util::combinators::BoxBody;
 use hyper_rustls::HttpsConnector;
 use hyper_util::{
     client::legacy::{connect::HttpConnector, Client},
     rt::{TokioExecutor, TokioTimer},
 };
 use llrt_utils::class::CustomInspectExtension;
+use llrt_utils::result::ResultExt;
 use once_cell::sync::Lazy;
 use rquickjs::{Class, Ctx, Result};
 use rustls::{
@@ -117,36 +119,37 @@ fn get_http_version() -> HttpVersion {
     })
 }
 
-pub static HTTP_CLIENT: Lazy<io::Result<Client<HttpsConnector<HttpConnector>, Full<Bytes>>>> =
-    Lazy::new(|| {
-        let pool_idle_timeout = get_pool_idle_timeout();
+type HttpsClient = Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, Infallible>>;
+pub static HTTP_CLIENT: Lazy<io::Result<HttpsClient>> = Lazy::new(|| {
+    let pool_idle_timeout = get_pool_idle_timeout();
 
-        let maybe_tls_config = match &*TLS_CONFIG {
-            Ok(tls_config) => io::Result::Ok(tls_config.clone()),
-            Err(e) => io::Result::Err(io::Error::new(e.kind(), e.to_string())),
-        };
+    let maybe_tls_config = match &*TLS_CONFIG {
+        Ok(tls_config) => io::Result::Ok(tls_config.clone()),
+        Err(e) => io::Result::Err(io::Error::new(e.kind(), e.to_string())),
+    };
 
-        let builder = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(maybe_tls_config?)
-            .https_or_http();
+    let builder = hyper_rustls::HttpsConnectorBuilder::new()
+        .with_tls_config(maybe_tls_config?)
+        .https_or_http();
 
-        let https = match get_http_version() {
-            #[cfg(feature = "http1")]
-            HttpVersion::Http1_1 => builder.enable_http1().build(),
-            #[cfg(feature = "http2")]
-            HttpVersion::Http2 => builder.enable_all_versions().build(),
-        };
+    let https = match get_http_version() {
+        #[cfg(feature = "http1")]
+        HttpVersion::Http1_1 => builder.enable_http1().build(),
+        #[cfg(feature = "http2")]
+        HttpVersion::Http2 => builder.enable_all_versions().build(),
+    };
 
-        Ok(Client::builder(TokioExecutor::new())
-            .pool_idle_timeout(pool_idle_timeout)
-            .pool_timer(TokioTimer::new())
-            .build(https))
-    });
+    Ok(Client::builder(TokioExecutor::new())
+        .pool_idle_timeout(pool_idle_timeout)
+        .pool_timer(TokioTimer::new())
+        .build(https))
+});
 
 pub fn init(ctx: &Ctx) -> Result<()> {
     let globals = ctx.globals();
 
-    fetch::init(ctx, &globals)?;
+    //init eagerly
+    fetch::init(HTTP_CLIENT.as_ref().or_throw(ctx)?.clone(), &globals)?;
 
     Class::<Request>::define(&globals)?;
     Class::<Response>::define(&globals)?;

--- a/modules/llrt_http/src/lib.rs
+++ b/modules/llrt_http/src/lib.rs
@@ -119,8 +119,8 @@ fn get_http_version() -> HttpVersion {
     })
 }
 
-type HttpsClient = Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, Infallible>>;
-pub static HTTP_CLIENT: Lazy<io::Result<HttpsClient>> = Lazy::new(|| {
+pub type HyperClient = Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, Infallible>>;
+pub static HTTP_CLIENT: Lazy<io::Result<HyperClient>> = Lazy::new(|| {
     let pool_idle_timeout = get_pool_idle_timeout();
 
     let maybe_tls_config = match &*TLS_CONFIG {


### PR DESCRIPTION
### Description of changes

Allow consumers to supply their own `hyper` client when intializing `fetch`.

Combined with https://github.com/awslabs/llrt/pull/655 this will allow people to add `fetch` with their own configured hyper clients. This is particularly important for FIPS compliance.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
