### PR TITLE
fix: CJS module import via ESM import

### DIFF
--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -148,7 +148,7 @@ impl CustomLoader {
 
                 return Ok((Module::declare(ctx, path, json)?, None));
             }
-            if name.ends_with(".cjs") {
+            if name.ends_with(".js") || name.ends_with(".mjs") || name.ends_with(".cjs") {
                 let url = ["file://", path].concat();
                 return Ok((Self::load_cjs_module(name, ctx)?, Some(url)));
             }


### PR DESCRIPTION
### Issue # (if available)

#641

### Description of changes

- Allow import as a CJS module even if the extension is `js` or `mjs`.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
