### PR TITLE
feat: Implementation of process.versions.node

### DIFF
--- a/modules/llrt_process/src/lib.rs
+++ b/modules/llrt_process/src/lib.rs
@@ -67,10 +67,8 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     let process = Object::new(ctx.clone())?;
     let process_versions = Object::new(ctx.clone())?;
     process_versions.set("llrt", VERSION)?;
-    // Node.js version - We need to set up a version that meets all the conditions listed below.
-    // [Node.js package] required version : reason
-    // [cls-hooked] >= 8.0.0 : To direct to async_hooks (API currently supported in Node.js)
-    process_versions.set("node", "22.11.0")?;
+    // Node.js version - Set for compatibility with some Node.js packages (e.g. cls-hooked).
+    process_versions.set("node", "0.0.0")?;
 
     let hr_time = Function::new(ctx.clone(), hr_time)?;
     hr_time.set("bigint", Func::from(hr_time_big_int))?;

--- a/modules/llrt_process/src/lib.rs
+++ b/modules/llrt_process/src/lib.rs
@@ -67,6 +67,10 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     let process = Object::new(ctx.clone())?;
     let process_versions = Object::new(ctx.clone())?;
     process_versions.set("llrt", VERSION)?;
+    // Node.js version - We need to set up a version that meets all the conditions listed below.
+    // [Node.js package] required version : reason
+    // [cls-hooked] >= 8.0.0 : To direct to async_hooks (API currently supported in Node.js)
+    process_versions.set("node", "22.11.0")?;
 
     let hr_time = Function::new(ctx.clone(), hr_time)?;
     hr_time.set("bigint", Func::from(hr_time_big_int))?;


### PR DESCRIPTION
### Description of changes

- Some Node.js packages use `process.versions.node` as a decision condition.
For example : https://www.npmjs.com/package/cls-hooked?activeTab=readme
- Having a provisional version in `process.versions.node` takes compatibility a little further.
- `22.11.0` is the latest LTS version of Node.js at the time of implementation. If there are no inconveniences, there is no need to change it in the future.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
