### PR TITLE
Fix top level await for initial file

### DIFF
--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -167,8 +167,8 @@ impl CustomLoader {
         let mut bytes: &[u8] = &bytes;
 
         if name.ends_with(BYTECODE_FILE_EXT) {
-            trace!("Loading binary module: {}", name);
-            return Ok((Self::load_bytecode_module(ctx, bytes)?, Some(name.into())));
+            trace!("Loading binary module: {}", path);
+            return Ok((Self::load_bytecode_module(ctx, bytes)?, Some(path.into())));
         }
         if !from_cjs_import && bytes.starts_with(b"#!") {
             bytes = bytes.splitn(2, |&c| c == b'\n').nth(1).unwrap_or(bytes);

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -176,15 +176,14 @@ impl Vm {
 
     pub async fn run_file(&self, filename: impl AsRef<str>, strict: bool, global: bool) {
         let source = [
-            r#"try{require(""#,
+            r#"import(""#,
             filename.as_ref(),
-            r#"")}catch(e){console.error(e);process.exit(1)}"#,
+            r#"").catch((e) => {{console.error(e);process.exit(1)}})"#,
         ]
         .concat();
 
         self.run(source, strict, global).await;
     }
-
     pub async fn run<S: Into<Vec<u8>> + Send>(&self, source: S, strict: bool, global: bool) {
         self.run_with(|ctx| {
             let mut options = EvalOptions::default();


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/662

### Description of changes

First loaded file should be an import. Exports are still available through global scope but does nothing fir the root file.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
