### PR TITLE
feat: Initial implementation of assert module

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,6 +3,10 @@
 > [!NOTE]
 > The long term goal for LLRT is to become [Winter CG compliant](https://github.com/wintercg/admin/blob/main/proposals.md). Not every API from Node.js will be supported.
 
+## assert
+
+[ok](https://nodejs.org/api/assert.html#assertokvalue-message)
+
 ## buffer
 
 [alloc](https://nodejs.org/api/buffer.html#static-method-bufferallocsize-fill-encoding)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "llrt_assert"
+version = "0.3.0-beta"
+dependencies = [
+ "llrt_test",
+ "llrt_utils",
+ "rquickjs",
+ "tokio",
+]
+
+[[package]]
 name = "llrt_buffer"
 version = "0.3.0-beta"
 dependencies = [
@@ -2810,6 +2820,7 @@ name = "llrt_modules"
 version = "0.3.0-beta"
 dependencies = [
  "llrt_abort",
+ "llrt_assert",
  "llrt_buffer",
  "llrt_child_process",
  "llrt_crypto",

--- a/README.md
+++ b/README.md
@@ -98,31 +98,38 @@ The test runner also has support for filters. Using filters is as simple as addi
 > [!NOTE]
 > LLRT only support a fraction of the Node.js APIs. It is **NOT** a drop in replacement for Node.js, nor will it ever be. Below is a high level overview of partially supported APIs and modules. For more details consult the [API](API.md) documentation
 
-|               | Node.js | LLRT ⚠️ |
+| Modules       | Node.js | LLRT ⚠️ |
 | ------------- | ------- | ------- |
+| assert        | ✔︎     | ✔︎️    |
 | buffer        | ✔︎     | ✔︎️    |
-| streams       | ✔︎     | ✔︎\*   |
 | child_process | ✔︎     | ✔︎⏱   |
-| net:sockets   | ✔︎     | ✔︎⏱   |
-| net:server    | ✔︎     | ✔︎     |
-| tls           | ✔︎     | ✘⏱     |
-| fetch         | ✔︎     | ✔︎     |
-| http          | ✔︎     | ✘⏱\*\* |
-| https         | ✔︎     | ✘⏱\*\* |
+| console       | ✔︎     | ✔︎     |
+| crypto        | ✔︎     | ✔︎     |
+| events        | ✔︎     | ✔︎     |
 | fs/promises   | ✔︎     | ✔︎     |
 | fs            | ✔︎     | ✘⏱     |
+| http          | ✔︎     | ✘⏱\*\* |
+| https         | ✔︎     | ✘⏱\*\* |
+| net:sockets   | ✔︎     | ✔︎⏱   |
+| net:server    | ✔︎     | ✔︎     |
+| os            | ✔︎     | ✔︎     |
 | path          | ✔︎     | ✔︎     |
-| timers        | ✔︎     | ✔︎     |
-| crypto        | ✔︎     | ✔︎     |
+| perf_hooks    | ✔︎     | ✔︎     |
 | process       | ✔︎     | ✔︎     |
-| encoding      | ✔︎     | ✔︎     |
-| console       | ✔︎     | ✔︎     |
-| events        | ✔︎     | ✔︎     |
+| streams       | ✔︎     | ✔︎\*   |
+| timers        | ✔︎     | ✔︎     |
+| url           | ✔︎     | ✔︎     |
+| tls           | ✔︎     | ✘⏱     |
 | zlib          | ✔︎     | ✔︎     |
-| ESM           | ✔︎     | ✔︎     |
-| CJS           | ✔︎     | ✔︎     |
-| async/await   | ✔︎     | ✔︎     |
 | Other modules | ✔︎     | ✘       |
+
+| Features    | Node.js | LLRT ⚠️ |
+| ----------- | ------- | ------- |
+| async/await | ✔︎     | ✔︎     |
+| encoding    | ✔︎     | ✔︎     |
+| fetch       | ✔︎     | ✔︎     |
+| ESM         | ✔︎     | ✔︎     |
+| CJS         | ✔︎     | ✔︎     |
 
 _⚠️ = partially supported in LLRT_<br />
 _⏱ = planned partial support_<br />

--- a/build.mjs
+++ b/build.mjs
@@ -53,6 +53,7 @@ const ES_BUILD_OPTIONS = {
   platform: "browser",
   format: "esm",
   external: [
+    "assert",
     "console",
     "node:console",
     "crypto",

--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use crate::modules::{
+    assert::AssertModule,
     buffer::BufferModule,
     child_process::ChildProcessModule,
     console::ConsoleModule,
@@ -67,6 +68,7 @@ pub struct ModuleBuilder {
 impl Default for ModuleBuilder {
     fn default() -> Self {
         Self::new()
+            .with_module(AssertModule)
             .with_module(CryptoModule)
             .with_global(crate::modules::crypto::init)
             .with_global(crate::modules::util::init)

--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -138,13 +138,19 @@ impl CustomLoader {
             return (false, false, name, name);
         }
 
+        // If it starts with CJS_IMPORT_PREFIX, mark as from_cjs_import
         if let Some(cjs_path) = name.strip_prefix(CJS_IMPORT_PREFIX) {
-            // If it starts with CJS_IMPORT_PREFIX, mark as from_cjs_import
+            if let Some(cjs_path) = cjs_path.strip_prefix(CJS_LOADER_PREFIX) {
+                return (true, false, cjs_path, cjs_path);
+            }
             return (true, false, name, cjs_path);
         }
 
+        // If it starts with CJS_LOADER_PREFIX, mark as is_cjs
         if let Some(cjs_path) = name.strip_prefix(CJS_LOADER_PREFIX) {
-            // If it starts with CJS_LOADER_PREFIX, mark as is_cjs
+            if let Some(cjs_path) = cjs_path.strip_prefix(CJS_IMPORT_PREFIX) {
+                return (false, true, cjs_path, cjs_path);
+            }
             return (false, true, cjs_path, cjs_path);
         }
 

--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -138,19 +138,13 @@ impl CustomLoader {
             return (false, false, name, name);
         }
 
-        // If it starts with CJS_IMPORT_PREFIX, mark as from_cjs_import
         if let Some(cjs_path) = name.strip_prefix(CJS_IMPORT_PREFIX) {
-            if let Some(cjs_path) = cjs_path.strip_prefix(CJS_LOADER_PREFIX) {
-                return (true, false, cjs_path, cjs_path);
-            }
+            // If it starts with CJS_IMPORT_PREFIX, mark as from_cjs_import
             return (true, false, name, cjs_path);
         }
 
-        // If it starts with CJS_LOADER_PREFIX, mark as is_cjs
         if let Some(cjs_path) = name.strip_prefix(CJS_LOADER_PREFIX) {
-            if let Some(cjs_path) = cjs_path.strip_prefix(CJS_IMPORT_PREFIX) {
-                return (false, true, cjs_path, cjs_path);
-            }
+            // If it starts with CJS_LOADER_PREFIX, mark as is_cjs
             return (false, true, cjs_path, cjs_path);
         }
 

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 pub use llrt_modules::{
-    abort, buffer, child_process, crypto, events, exceptions, fs, http, navigator, net, os, path,
-    perf_hooks, process, url, zlib,
+    abort, assert, buffer, child_process, crypto, events, exceptions, fs, http, navigator, net, os,
+    path, perf_hooks, process, url, zlib,
 };
 
 pub mod console;

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 default = ["all"]
 all = [
   "abort",
+  "assert",
   "buffer",
   "child-process",
   "crypto",
@@ -31,6 +32,7 @@ all = [
 
 # Modules
 abort = ["llrt_abort"]
+assert = ["llrt_assert"]
 buffer = ["llrt_buffer"]
 child-process = ["llrt_child_process"]
 crypto = ["llrt_crypto"]
@@ -50,6 +52,7 @@ zlib = ["llrt_zlib"]
 
 [dependencies]
 llrt_abort = { version = "0.3.0-beta", path = "../modules/llrt_abort", optional = true }
+llrt_assert = { version = "0.3.0-beta", path = "../modules/llrt_assert", optional = true }
 llrt_buffer = { version = "0.3.0-beta", path = "../modules/llrt_buffer", optional = true }
 llrt_child_process = { version = "0.3.0-beta", path = "../modules/llrt_child_process", optional = true }
 llrt_crypto = { version = "0.3.0-beta", path = "../modules/llrt_crypto", optional = true }

--- a/llrt_modules/README.md
+++ b/llrt_modules/README.md
@@ -56,6 +56,7 @@ async fn main() -> anyhow::Result<()> {
 |               | Node.js | LLRT Modules | Feature         | Crate                |
 | ------------- | ------- | ------------ | --------------- | -------------------- |
 | abort         | ✔︎     | ✔︎️         | `abort`         | `llrt_abort`         |
+| assert        | ✔︎     | ⚠️           | `assert`        | `llrt_assert`        |
 | buffer        | ✔︎     | ✔︎️         | `buffer`        | `llrt_buffer`        |
 | child process | ✔︎     | ⚠️           | `child-process` | `llrt_child_process` |
 | crypto        | ✔︎     | ⚠️           | `crypto`        | `llrt_cryto`         |

--- a/llrt_modules/src/lib.rs
+++ b/llrt_modules/src/lib.rs
@@ -6,6 +6,8 @@ pub use self::modules::*;
 mod modules {
     #[cfg(feature = "abort")]
     pub use llrt_abort as abort;
+    #[cfg(feature = "assert")]
+    pub use llrt_assert as assert;
     #[cfg(feature = "buffer")]
     pub use llrt_buffer as buffer;
     #[cfg(feature = "child-process")]

--- a/modules/llrt_assert/Cargo.toml
+++ b/modules/llrt_assert/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "llrt_assert"
+description = "LLRT Module assert"
+version = "0.3.0-beta"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/awslabs/llrt"
+
+[lib]
+name = "llrt_assert"
+path = "src/lib.rs"
+
+[dependencies]
+llrt_utils = { version = "0.3.0-beta", path = "../../libs/llrt_utils", default-features = false }
+rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", rev = "3af3f46b13eb89a2694e5e4e2e73924a20fa9dd1", default-features = false }
+
+[dev-dependencies]
+llrt_test = { path = "../../libs/llrt_test" }
+tokio = { version = "1", features = ["full"] }

--- a/modules/llrt_assert/src/lib.rs
+++ b/modules/llrt_assert/src/lib.rs
@@ -31,13 +31,14 @@ fn assert(ctx: Ctx, value: Value, message: Opt<Value>) -> Result<()> {
     }
 
     if let Some(obj) = message.0 {
-        if let Some(msg) = obj.as_string() {
-            let msg = msg.to_string().unwrap();
-            return Err(Exception::throw_message(&ctx, &msg));
-        }
-        if let Some(err) = obj.as_exception() {
-            return Err(err.clone().throw());
-        }
+        match obj.type_of() {
+            Type::String => {
+                let msg = obj.as_string().unwrap().to_string().unwrap();
+                return Err(Exception::throw_message(&ctx, &msg));
+            },
+            Type::Exception => return Err(obj.as_exception().cloned().unwrap().throw()),
+            _ => {},
+        };
     }
 
     Err(Exception::throw_message(

--- a/modules/llrt_assert/src/lib.rs
+++ b/modules/llrt_assert/src/lib.rs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use llrt_utils::module::{export_default, ModuleInfo};
+use rquickjs::{
+    module::{Declarations, Exports, ModuleDef},
+    prelude::{Func, Opt},
+    Ctx, Exception, Result, Value,
+};
+
+fn ok(ctx: Ctx, value: Value, message: Opt<Value>) -> Result<()> {
+    if value.as_bool().unwrap_or(false) {
+        return Ok(());
+    }
+    if value.as_number().unwrap_or(0.0) != 0.0 {
+        return Ok(());
+    }
+    if value.is_string() && !value.as_string().unwrap().to_string().unwrap().is_empty() {
+        return Ok(());
+    }
+    if value.is_array() || value.is_object() {
+        return Ok(());
+    }
+
+    if let Some(obj) = message.0 {
+        if let Some(msg) = obj.as_string() {
+            let msg = msg.to_string().unwrap();
+            return Err(Exception::throw_message(&ctx, &msg));
+        }
+        if let Some(err) = obj.as_exception() {
+            return Err(err.clone().throw());
+        }
+    }
+
+    Err(Exception::throw_message(
+        &ctx,
+        "The expression was evaluated to a falsy value",
+    ))
+}
+
+pub struct AssertModule;
+
+impl ModuleDef for AssertModule {
+    fn declare(declare: &Declarations) -> Result<()> {
+        declare.declare("ok")?;
+
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        export_default(ctx, exports, |default| {
+            default.set("ok", Func::from(ok))?;
+
+            Ok(())
+        })
+    }
+}
+
+impl From<AssertModule> for ModuleInfo<AssertModule> {
+    fn from(val: AssertModule) -> Self {
+        ModuleInfo {
+            name: "assert",
+            module: val,
+        }
+    }
+}

--- a/modules/llrt_assert/src/lib.rs
+++ b/modules/llrt_assert/src/lib.rs
@@ -58,7 +58,7 @@ impl ModuleDef for AssertModule {
     }
 
     fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
-        let ok_function = Function::new(ctx.clone(), ok)?;
+        let ok_function = Function::new(ctx.clone(), ok)?.with_name("ok")?;
         ok_function.set("ok", ok_function.clone())?;
 
         exports.export("ok", ok_function.clone())?;

--- a/modules/llrt_assert/src/lib.rs
+++ b/modules/llrt_assert/src/lib.rs
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use llrt_utils::module::{export_default, ModuleInfo};
+use llrt_utils::module::ModuleInfo;
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
-    prelude::{Func, Opt},
-    Ctx, Exception, Result, Type, Value,
+    prelude::Opt,
+    Ctx, Exception, Function, Result, Type, Value,
 };
 
-fn assert(ctx: Ctx, value: Value, message: Opt<Value>) -> Result<()> {
+fn ok(ctx: Ctx, value: Value, message: Opt<Value>) -> Result<()> {
     match value.type_of() {
         Type::Bool => {
             if value.as_bool().unwrap() {
@@ -58,11 +58,12 @@ impl ModuleDef for AssertModule {
     }
 
     fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
-        export_default(ctx, exports, |default| {
-            default.set("ok", Func::from(assert))?;
+        let ok_function = Function::new(ctx.clone(), ok)?;
+        ok_function.set("ok", ok_function.clone())?;
 
-            Ok(())
-        })
+        exports.export("ok", ok_function.clone())?;
+        exports.export("default", ok_function)?;
+        Ok(())
     }
 }
 

--- a/modules/llrt_assert/src/lib.rs
+++ b/modules/llrt_assert/src/lib.rs
@@ -24,7 +24,13 @@ fn ok(ctx: Ctx, value: Value, message: Opt<Value>) -> Result<()> {
                 return Ok(());
             }
         },
-        Type::Array | Type::Object => {
+        Type::Array
+        | Type::BigInt
+        | Type::Constructor
+        | Type::Exception
+        | Type::Function
+        | Type::Symbol
+        | Type::Object => {
             return Ok(());
         },
         _ => {},
@@ -43,7 +49,7 @@ fn ok(ctx: Ctx, value: Value, message: Opt<Value>) -> Result<()> {
 
     Err(Exception::throw_message(
         &ctx,
-        "The expression was evaluated to a falsy value",
+        "AssertionError: The expression was evaluated to a falsy value",
     ))
 }
 

--- a/tests/unit/assert.test.ts
+++ b/tests/unit/assert.test.ts
@@ -1,0 +1,63 @@
+import * as assert from "assert";
+
+describe("assert.ok", () => {
+  it("Should be returned 'undefined' (So it's not an error)", () => {
+    expect(assert.ok(true)).toBeUndefined();
+    expect(assert.ok(1)).toBeUndefined();
+    expect(assert.ok("non-empty string")).toBeUndefined();
+    expect(assert.ok([])).toBeUndefined();
+    expect(assert.ok({})).toBeUndefined();
+  });
+
+  it("Should be returned exception", () => {
+    const errMsg = "The expression was evaluated to a falsy value";
+    try {
+      assert.ok(false);
+    } catch (err) {
+      expect(err.message).toEqual(errMsg);
+    }
+    try {
+      assert.ok(0);
+    } catch (err) {
+      expect(err.message).toEqual(errMsg);
+    }
+    try {
+      assert.ok("");
+    } catch (err) {
+      expect(err.message).toEqual(errMsg);
+    }
+    try {
+      assert.ok(null);
+    } catch (err) {
+      expect(err.message).toEqual(errMsg);
+    }
+  });
+
+  it("should be returned as original error message", () => {
+    try {
+      assert.ok(false, "Value must be true");
+    } catch (err) {
+      expect(err.message).toEqual("Value must be true");
+    }
+  });
+
+  it("should be returned as original error", () => {
+    try {
+      assert.ok(false, Error("This is error"));
+    } catch (err) {
+      expect(err.message).toEqual("This is error");
+    }
+  });
+
+  it("Should be handled correctly even within functions", () => {
+    function checkValue(value) {
+      assert.ok(value, "Value should be truthy");
+    }
+    expect(checkValue(true)).toBeUndefined();
+    try {
+      checkValue(false);
+    } catch (err) {
+      expect(err.message).toEqual("Value should be truthy");
+    }
+  });
+});

--- a/tests/unit/assert.test.ts
+++ b/tests/unit/assert.test.ts
@@ -2,15 +2,22 @@ import assert from "assert";
 
 describe("assert.ok", () => {
   it("Should be returned 'undefined' (So it's not an error)", () => {
-    expect(assert.ok(true)).toBeUndefined();
-    expect(assert.ok(1)).toBeUndefined();
-    expect(assert.ok("non-empty string")).toBeUndefined();
-    expect(assert.ok([])).toBeUndefined();
-    expect(assert.ok({})).toBeUndefined();
+    expect(assert.ok(true)).toBeUndefined(); //bool
+    expect(assert.ok(1)).toBeUndefined(); // numeric
+    expect(assert.ok("non-empty string")).toBeUndefined(); // string
+    expect(assert.ok([])).toBeUndefined(); // array
+    expect(assert.ok({})).toBeUndefined(); // object
+    expect(assert.ok(() => {})).toBeUndefined(); // function
+    expect(assert.ok(123n)).toBeUndefined(); // bigint
+    expect(assert.ok(Symbol())).toBeUndefined(); // symbol
+    expect(assert.ok(new Error())).toBeUndefined(); // error
+    class AssertTestClass {}
+    expect(assert.ok(AssertTestClass)).toBeUndefined(); // constructor
   });
 
   it("Should be returned exception", () => {
-    const errMsg = "The expression was evaluated to a falsy value";
+    const errMsg =
+      "AssertionError: The expression was evaluated to a falsy value";
     try {
       assert.ok(false);
     } catch (err) {

--- a/tests/unit/assert.test.ts
+++ b/tests/unit/assert.test.ts
@@ -1,4 +1,4 @@
-import * as assert from "assert";
+import assert from "assert";
 
 describe("assert.ok", () => {
   it("Should be returned 'undefined' (So it's not an error)", () => {
@@ -59,5 +59,15 @@ describe("assert.ok", () => {
     } catch (err) {
       expect(err.message).toEqual("Value should be truthy");
     }
+  });
+});
+
+describe("assert", () => {
+  it("Should be returned 'undefined' (So it's not an error)", () => {
+    expect(assert(true)).toBeUndefined();
+    expect(assert(1)).toBeUndefined();
+    expect(assert("non-empty string")).toBeUndefined();
+    expect(assert([])).toBeUndefined();
+    expect(assert({})).toBeUndefined();
   });
 });

--- a/tests/unit/assert.test.ts
+++ b/tests/unit/assert.test.ts
@@ -18,54 +18,29 @@ describe("assert.ok", () => {
   it("Should be returned exception", () => {
     const errMsg =
       "AssertionError: The expression was evaluated to a falsy value";
-    try {
-      assert.ok(false);
-    } catch (err) {
-      expect(err.message).toEqual(errMsg);
-    }
-    try {
-      assert.ok(0);
-    } catch (err) {
-      expect(err.message).toEqual(errMsg);
-    }
-    try {
-      assert.ok("");
-    } catch (err) {
-      expect(err.message).toEqual(errMsg);
-    }
-    try {
-      assert.ok(null);
-    } catch (err) {
-      expect(err.message).toEqual(errMsg);
-    }
+    expect(() => assert.ok(false)).toThrow(errMsg);
+    expect(() => assert.ok(0)).toThrow(errMsg);
+    expect(() => assert.ok("")).toThrow(errMsg);
+    expect(() => assert.ok(null)).toThrow(errMsg);
   });
 
   it("should be returned as original error message", () => {
-    try {
-      assert.ok(false, "Value must be true");
-    } catch (err) {
-      expect(err.message).toEqual("Value must be true");
-    }
+    const errMsg = "Error: Value must be true";
+    expect(() => assert.ok(false, errMsg)).toThrow(errMsg);
   });
 
   it("should be returned as original error", () => {
-    try {
-      assert.ok(false, Error("This is error"));
-    } catch (err) {
-      expect(err.message).toEqual("This is error");
-    }
+    const errMsg = "Error: This is error";
+    expect(() => assert.ok(false, Error(errMsg))).toThrow(errMsg);
   });
 
   it("Should be handled correctly even within functions", () => {
+    const errMsg = "Error: Value should be truthy";
     function checkValue(value) {
-      assert.ok(value, "Value should be truthy");
+      assert.ok(value, errMsg);
     }
     expect(checkValue(true)).toBeUndefined();
-    try {
-      checkValue(false);
-    } catch (err) {
-      expect(err.message).toEqual("Value should be truthy");
-    }
+    expect(() => checkValue(false)).toThrow(errMsg);
   });
 });
 

--- a/types/assert.d.ts
+++ b/types/assert.d.ts
@@ -3,6 +3,11 @@
  */
 declare module "assert" {
   /**
+   * An alias of {@link ok}.
+   * @param value The input that is checked for being truthy.
+   */
+  function assert(value: unknown, message?: string | Error): asserts value;
+  /**
    * Tests if `value` is truthy.
    *
    * If `value` is not truthy, an `AssertionError` is thrown with a `message` property set equal to the value of the `message` parameter. If the `message` parameter is `undefined`, a default

--- a/types/assert.d.ts
+++ b/types/assert.d.ts
@@ -1,0 +1,34 @@
+/**
+ * The `assert` module provides a set of assertion functions for verifying invariants.
+ */
+declare module "assert" {
+  /**
+   * Tests if `value` is truthy.
+   *
+   * If `value` is not truthy, an `AssertionError` is thrown with a `message` property set equal to the value of the `message` parameter. If the `message` parameter is `undefined`, a default
+   * error message is assigned. If the `message` parameter is an instance of an `Error` then it will be thrown instead of the `AssertionError`.
+   * If no arguments are passed in at all `message` will be set to the string:`` 'No value argument passed to `assert.ok()`' ``.
+   *
+   * ```js
+   * import * as assert from 'assert';
+   *
+   * assert.ok(true);
+   * // OK
+   * assert.ok(1);
+   * // OK
+   *
+   * assert.ok();
+   * // TypeError: Error calling function with 0 argument(s) while 1 where expected
+   *
+   * assert.ok(false, 'it\'s false');
+   * // AssertionError: it's false
+   *
+   * assert.ok(false);
+   * // AssertionError: The expression was evaluated to a falsy value
+   *
+   * assert.ok(0);
+   * // AssertionError: The expression was evaluated to a falsy value
+   * ```
+   */
+  function ok(value: unknown, message?: string | Error): asserts value;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="./abort.d.ts" />
+/// <reference types="./assert.d.ts" />
 /// <reference types="./buffer.d.ts" />
 /// <reference types="./child_process.d.ts" />
 /// <reference types="./crypto.d.ts" />


### PR DESCRIPTION
### Issue # (if available)

#628

### Description of changes

The following Node.js APIs, which are also used in the libraries on which `aws-xray-sdk-core` depends, have been implemented. Note that we do not intend to support all APIs from the beginning.

- assert.ok()

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
