### PR TITLE
fix: Improved package.json resolution logic

### DIFF
--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -611,14 +611,22 @@ fn is_exports_field_exists<'a>(package_json: &'a BorrowedValue<'a>) -> bool {
 }
 
 fn correct_extensions<'a>(x: String) -> Cow<'a, str> {
-    if Path::new(&x).is_file() {
-        return x.into();
+    if let Ok(metadata) = fs::metadata(&x) {
+        if metadata.is_file() {
+            return x.into();
+        }
+        if metadata.is_dir() {
+            for extension in JS_EXTENSIONS.iter() {
+                let file = [x.as_str(), "/index", extension].concat();
+                if Path::new(&file).is_file() {
+                    return file.into();
+                }
+            }
+        }
     }
 
-    let index = if Path::new(&x).is_dir() { "/index" } else { "" };
-
     for extension in JS_EXTENSIONS.iter() {
-        let file = [x.as_str(), index, extension].concat();
+        let file = [x.as_str(), extension].concat();
         if Path::new(&file).is_file() {
             return file.into();
         }

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -614,8 +614,11 @@ fn correct_extensions<'a>(x: String) -> Cow<'a, str> {
     if Path::new(&x).is_file() {
         return x.into();
     }
+
+    let index = if Path::new(&x).is_dir() { "/index" } else { "" };
+
     for extension in JS_EXTENSIONS.iter() {
-        let file = [x.as_str(), extension].concat();
+        let file = [x.as_str(), index, extension].concat();
         if Path::new(&file).is_file() {
             return file.into();
         }

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -611,22 +611,20 @@ fn is_exports_field_exists<'a>(package_json: &'a BorrowedValue<'a>) -> bool {
 }
 
 fn correct_extensions<'a>(x: String) -> Cow<'a, str> {
-    if let Ok(metadata) = fs::metadata(&x) {
-        if metadata.is_file() {
-            return x.into();
-        }
-        if metadata.is_dir() {
-            for extension in JS_EXTENSIONS.iter() {
-                let file = [x.as_str(), "/index", extension].concat();
-                if Path::new(&file).is_file() {
-                    return file.into();
-                }
-            }
-        }
-    }
+    let (x_is_file, x_is_dir) = if let Ok(md) = fs::metadata(&x) {
+        (md.is_file(), md.is_dir())
+    } else {
+        (false, false)
+    };
+
+    if x_is_file {
+        return x.into();
+    };
+
+    let index = if x_is_dir { "/index" } else { "" };
 
     for extension in JS_EXTENSIONS.iter() {
-        let file = [x.as_str(), extension].concat();
+        let file = [x.as_str(), index, extension].concat();
         if Path::new(&file).is_file() {
             return file.into();
         }


### PR DESCRIPTION
### Issue # (if available)

Fixed #671

### Description of changes

- Fix package.json so that “index” is used as the name of the file directly under it when the resolved result is a directory.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
