### PR TITLE
fix: CJS export default

### DIFF
--- a/llrt/src/main.rs
+++ b/llrt/src/main.rs
@@ -123,7 +123,7 @@ async fn start_cli(vm: &Vm) {
                     },
                     "-e" | "--eval" => {
                         if let Some(source) = args.get(i + 1) {
-                            vm.run(source.as_bytes(), false, true).await;
+                            vm.run(source.as_bytes(), false, false).await;
                         }
                         return;
                     },

--- a/llrt/src/main.rs
+++ b/llrt/src/main.rs
@@ -192,7 +192,12 @@ async fn start_cli(vm: &Vm) {
             }
         }
     } else {
-        vm.run_file("index", true, false).await;
+        let index = if let Ok(dir) = std::env::current_dir() {
+            [dir.to_string_lossy().as_ref(), "/index"].concat()
+        } else {
+            "index".into()
+        };
+        vm.run_file(index, true, false).await;
     }
 }
 

--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use rquickjs::{loader::Loader, Ctx, Function, Module, Object, Result, Value};
+use rquickjs::{loader::Loader, Ctx, Module, Object, Result};
 use std::{
     fs::File,
     io::{self, Read},

--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -15,6 +15,7 @@ use crate::{
         BYTECODE_COMPRESSED, BYTECODE_FILE_EXT, BYTECODE_UNCOMPRESSED, BYTECODE_VERSION,
         SIGNATURE_LENGTH,
     },
+    module_loader::CJS_LOADER_PREFIX,
     vm::COMPRESSION_DICT,
 };
 
@@ -101,48 +102,66 @@ impl CustomLoader {
         module.push_str(name);
         module.push_str("\");export default value.default||value;");
         if let Some(obj) = export_object.as_object() {
-            module.push_str("const{");
             let keys: Result<Vec<String>> = obj.keys().collect();
             let keys = keys?;
-            for p in keys.iter() {
-                if p == "default" {
-                    continue;
+
+            if !keys.is_empty() {
+                module.push_str("const{");
+
+                for p in keys.iter() {
+                    if p == "default" {
+                        continue;
+                    }
+                    module.push_str(p);
+                    module.push(',');
                 }
-                module.push_str(p);
-                module.push(',');
-            }
-            module.truncate(module.len() - 1);
-            module.push_str("}=value;");
-            module.push_str("export{");
-            for p in keys.iter() {
-                if p == "default" {
-                    continue;
+                module.truncate(module.len() - 1);
+                module.push_str("}=value;");
+                module.push_str("export{");
+                for p in keys.iter() {
+                    if p == "default" {
+                        continue;
+                    }
+                    module.push_str(p);
+                    module.push(',');
                 }
-                module.push_str(p);
-                module.push(',');
+                module.truncate(module.len() - 1);
+                module.push_str("};");
             }
-            module.truncate(module.len() - 1);
-            module.push_str("};");
         }
         Module::declare(ctx, name, module)
     }
 
-    fn load_module<'js>(name: &str, ctx: &Ctx<'js>) -> Result<(Module<'js>, Option<String>)> {
-        let mut from_cjs_import = false;
-        let path = if let Some(cjs_path) = name.strip_prefix(CJS_IMPORT_PREFIX) {
-            from_cjs_import = true;
-            cjs_path
-        } else {
-            name
-        };
+    fn normalize_name(name: &str) -> (bool, bool, &str, &str) {
+        if !name.starts_with("__") {
+            // If name doesn’t start with "__", return defaults
+            return (false, false, name, name);
+        }
 
+        if let Some(cjs_path) = name.strip_prefix(CJS_IMPORT_PREFIX) {
+            // If it starts with CJS_IMPORT_PREFIX, mark as from_cjs_import
+            return (true, false, name, cjs_path);
+        }
+
+        if let Some(cjs_path) = name.strip_prefix(CJS_LOADER_PREFIX) {
+            // If it starts with CJS_LOADER_PREFIX, mark as is_cjs
+            return (false, true, cjs_path, cjs_path);
+        }
+
+        // Default return if no prefixes match
+        (false, false, name, name)
+    }
+
+    fn load_module<'js>(name: &str, ctx: &Ctx<'js>) -> Result<(Module<'js>, Option<String>)> {
         let ctx = ctx.clone();
 
-        trace!("Loading module: {}", name);
+        let (from_cjs_import, is_cjs, normalized_name, path) = Self::normalize_name(name);
+
+        trace!("Loading module: {}", normalized_name);
 
         //json files can never be from CJS imports as they are handled by require
         if !from_cjs_import {
-            if name.ends_with(".json") {
+            if normalized_name.ends_with(".json") {
                 let mut file = File::open(path)?;
                 let prefix = "export default JSON.parse(`";
                 let suffix = "`);";
@@ -153,9 +172,9 @@ impl CustomLoader {
 
                 return Ok((Module::declare(ctx, path, json)?, None));
             }
-            if name.ends_with(".cjs") {
+            if is_cjs || normalized_name.ends_with(".cjs") {
                 let url = ["file://", path].concat();
-                return Ok((Self::load_cjs_module(name, ctx)?, Some(url)));
+                return Ok((Self::load_cjs_module(normalized_name, ctx)?, Some(url)));
             }
         }
 
@@ -171,7 +190,7 @@ impl CustomLoader {
         let bytes = std::fs::read(path)?;
         let mut bytes: &[u8] = &bytes;
 
-        if name.ends_with(BYTECODE_FILE_EXT) {
+        if normalized_name.ends_with(BYTECODE_FILE_EXT) {
             trace!("Loading binary module: {}", path);
             return Ok((Self::load_bytecode_module(ctx, bytes)?, Some(path.into())));
         }
@@ -180,7 +199,7 @@ impl CustomLoader {
         }
 
         let url = ["file://", path].concat();
-        Ok((Module::declare(ctx, name, bytes)?, Some(url)))
+        Ok((Module::declare(ctx, normalized_name, bytes)?, Some(url)))
     }
 }
 

--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -93,32 +93,9 @@ impl CustomLoader {
 
     fn load_cjs_module<'js>(name: &str, ctx: Ctx<'js>) -> Result<Module<'js>> {
         let cjs_specifier = [CJS_IMPORT_PREFIX, name].concat();
-        let require: Function = ctx.globals().get("require")?;
-        let export_object: Value = require.call((&cjs_specifier,))?;
         let mut module = String::from("const value = require(\"");
-
-        module.push_str(name);
-        module.push_str("\");export default value;");
-        if let Some(obj) = export_object.as_object() {
-            module.push_str("const{");
-            let keys: Result<Vec<String>> = obj.keys().collect();
-            let keys = keys?;
-            for (i, p) in keys.iter().enumerate() {
-                if i > 0 {
-                    module.push(',');
-                }
-                module.push_str(p);
-            }
-            module.push_str("}=value;");
-            module.push_str("export{");
-            for (i, p) in keys.iter().enumerate() {
-                if i > 0 {
-                    module.push(',');
-                }
-                module.push_str(p);
-            }
-            module.push_str("};");
-        }
+        module.push_str(&cjs_specifier);
+        module.push_str("\");export default value.default||value");
         Module::declare(ctx, name, module)
     }
 

--- a/llrt_core/src/module_loader/mod.rs
+++ b/llrt_core/src/module_loader/mod.rs
@@ -1,4 +1,7 @@
 pub mod loader;
 pub mod resolver;
 
+// added when .cjs files are imported
 pub const CJS_IMPORT_PREFIX: &str = "__cjs:";
+// added to force CJS imports in loader
+pub const CJS_LOADER_PREFIX: &str = "__cjsm:";

--- a/llrt_core/src/modules/js/@llrt/test/SocketClient.ts
+++ b/llrt_core/src/modules/js/@llrt/test/SocketClient.ts
@@ -33,8 +33,6 @@ class SocketClient extends EventEmitter {
       const errorListener = (err: Error) => reject(err);
       this.socket.on("error", errorListener);
       this.socket.connect(this.port, this.host, () => {
-        console.log(`Connected to ${this.host}:${this.port}`);
-
         this.socket.off("error", errorListener);
         this.socket.on("error", (err) => this.emit("error", err));
         resolve();

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -366,7 +366,7 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
                 } else {
                     let module_name = get_script_or_module_name(&ctx);
                     let module_name = module_name.trim_start_matches(CJS_IMPORT_PREFIX);
-                    let abs_path = resolve_path([module_name].iter());
+                    let abs_path = resolve_path([module_name].iter())?;
 
                     let resolved_path =
                         require_resolve(&ctx, &specifier, &abs_path, false)?.into_owned();

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -2,6 +2,9 @@ globalThis._require = require; //used to preserve require during bundling/minifi
 const CWD = process.cwd();
 import { spawn } from "child_process";
 
+import { platform } from "os";
+const IS_WIN = platform() === "win32";
+
 it("should require a file (absolute path)", () => {
   const { hello } = _require(`${CWD}/fixtures/hello.js`);
 
@@ -112,12 +115,14 @@ it("should handle inner referenced exports", () => {
   expect(a.length()).toBe(1);
 });
 
-it("should handle named exports from CJS imports", (cb) => {
-  spawn(process.argv0, [
-    "-e",
-    `import {cat} from "${CWD}/fixtures/referenced-exports.cjs"`,
-  ]).on("close", (code) => {
-    expect(code).toBe(0);
-    cb();
+if (!IS_WIN) {
+  it("should handle named exports from CJS imports", (cb) => {
+    spawn(process.argv0, [
+      "-e",
+      `import {cat} from "${CWD}/fixtures/referenced-exports.cjs"`,
+    ]).on("close", (code) => {
+      expect(code).toBe(0);
+      cb();
+    });
   });
-});
+}

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -1,6 +1,6 @@
 globalThis._require = require; //used to preserve require during bundling/minification
-
 const CWD = process.cwd();
+import { spawn } from "child_process";
 
 it("should require a file (absolute path)", () => {
   const { hello } = _require(`${CWD}/fixtures/hello.js`);
@@ -110,4 +110,14 @@ it("should handle inner referenced exports", () => {
   const a = _require(`${CWD}/fixtures/referenced-exports.cjs`);
   expect(a.cat()).toBe("str");
   expect(a.length()).toBe(1);
+});
+
+it("should handle named exports from CJS imports", (cb) => {
+  spawn(process.argv0, [
+    "-e",
+    `import {cat} from "${CWD}/fixtures/referenced-exports.cjs"`,
+  ]).on("close", (code) => {
+    expect(code).toBe(0);
+    cb();
+  });
 });


### PR DESCRIPTION
### Description of changes

CJS imports via ESM now returns the default export if present. This should help with https://github.com/awslabs/llrt/pull/668 and maintain better consistency with Node.
@nabetti1720 even tho all testes are passing, can you verify this doesn't change expected CJS import behavior from ESM?

### Checklist
- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
