### PR TITLE
Fix CJS name normalize regression

### DIFF
--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -174,7 +174,7 @@ impl CustomLoader {
             }
             if is_cjs || normalized_name.ends_with(".cjs") {
                 let url = ["file://", path].concat();
-                return Ok((Self::load_cjs_module(normalized_name, ctx)?, Some(url)));
+                return Ok((Self::load_cjs_module(path, ctx)?, Some(url)));
             }
         }
 

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -475,7 +475,10 @@ fn load_package_exports<'a>(
 
     if let Some(sub_module) = sub_module {
         if package_json.get_str("type") != Some("module") {
-            return Ok([CJS_LOADER_PREFIX, &sub_module].concat().into());
+            if is_esm {
+                return Ok([CJS_LOADER_PREFIX, &sub_module].concat().into());
+            }
+            return Ok(sub_module.into());
         }
         return Ok(sub_module.into());
     }

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -382,6 +382,8 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
                 specifier.into()
             };
 
+            trace!("After specifier: {}", import_specifier);
+
             let globals = ctx.globals();
             let require_cache: Object = globals.get(REQUIRE_CACHE_NAME)?;
 


### PR DESCRIPTION
### Issue # (if available)

Fix regession of CJS imports from node_modules where we auto detected CJS module

### Description of changes

Don't add CJS import prefix if importing from require when looking up node modules.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
