### PR TITLE
modules: add tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,6 +2865,7 @@ dependencies = [
  "llrt_perf_hooks",
  "llrt_process",
  "llrt_timers",
+ "llrt_tty",
  "llrt_url",
  "llrt_utils",
  "llrt_zlib",
@@ -2989,6 +2990,17 @@ dependencies = [
  "llrt_test",
  "llrt_utils",
  "once_cell",
+ "rquickjs",
+ "tokio",
+]
+
+[[package]]
+name = "llrt_tty"
+version = "0.3.0-beta"
+dependencies = [
+ "libc",
+ "llrt_test",
+ "llrt_utils",
  "rquickjs",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "modules/llrt_timers",
   "modules/llrt_url",
   "modules/llrt_zlib",
+  "modules/llrt_tty",
   "libs/llrt_build",
   "libs/llrt_compression",
   "libs/llrt_context",

--- a/build.mjs
+++ b/build.mjs
@@ -74,6 +74,7 @@ const ES_BUILD_OPTIONS = {
     "llrt:uuid",
     "llrt:xml",
     "perf_hooks",
+    "tty",
   ],
 };
 

--- a/llrt_core/src/module_builder.rs
+++ b/llrt_core/src/module_builder.rs
@@ -15,6 +15,7 @@ use crate::modules::{
     path::PathModule,
     perf_hooks::PerfHooksModule,
     process::ProcessModule,
+    tty::TtyModule,
     url::UrlModule,
     util::UtilModule,
     zlib::ZlibModule,
@@ -101,6 +102,7 @@ impl Default for ModuleBuilder {
             .with_module(PerfHooksModule)
             .with_global(crate::modules::perf_hooks::init)
             .with_module(ZlibModule)
+            .with_module(TtyModule)
     }
 }
 

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pub use llrt_modules::{
     abort, assert, buffer, child_process, crypto, events, exceptions, fs, http, navigator, net, os,
-    path, perf_hooks, process, url, zlib,
+    path, perf_hooks, process, tty, url, zlib,
 };
 
 pub mod console;

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -28,6 +28,7 @@ all = [
   "timers",
   "url",
   "zlib",
+  "tty",
 ]
 
 # Modules
@@ -49,6 +50,7 @@ perf-hooks = ["llrt_perf_hooks"]
 timers = ["llrt_timers"]
 url = ["llrt_url"]
 zlib = ["llrt_zlib"]
+tty = ["llrt_tty"]
 
 [dependencies]
 llrt_abort = { version = "0.3.0-beta", path = "../modules/llrt_abort", optional = true }
@@ -70,3 +72,4 @@ llrt_timers = { version = "0.3.0-beta", path = "../modules/llrt_timers", optiona
 llrt_url = { version = "0.3.0-beta", path = "../modules/llrt_url", optional = true }
 llrt_utils = { version = "0.3.0-beta", path = "../libs/llrt_utils" }
 llrt_zlib = { version = "0.3.0-beta", path = "../modules/llrt_zlib", optional = true }
+llrt_tty = { version = "0.3.0-beta", path = "../modules/llrt_tty", optional = true }

--- a/llrt_modules/src/lib.rs
+++ b/llrt_modules/src/lib.rs
@@ -36,6 +36,8 @@ mod modules {
     pub use llrt_process as process;
     #[cfg(feature = "timers")]
     pub use llrt_timers as timers;
+    #[cfg(feature = "tty")]
+    pub use llrt_tty as tty;
     #[cfg(feature = "url")]
     pub use llrt_url as url;
     #[cfg(feature = "zlib")]

--- a/modules/llrt_tty/Cargo.toml
+++ b/modules/llrt_tty/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "llrt_tty"
+description = "LLRT Module tty"
+version = "0.3.0-beta"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/awslabs/llrt"
+readme = "README.md"
+
+[lib]
+name = "llrt_tty"
+path = "src/lib.rs"
+
+[dependencies]
+llrt_utils = { version = "0.3.0-beta", path = "../../libs/llrt_utils", default-features = false }
+rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.8.1", default-features = false }
+libc = "0.2"
+
+[dev-dependencies]
+llrt_test = { path = "../../libs/llrt_test" }
+tokio = { version = "1", features = ["full"] }

--- a/modules/llrt_tty/src/lib.rs
+++ b/modules/llrt_tty/src/lib.rs
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use llrt_utils::module::{export_default, ModuleInfo};
+use rquickjs::{
+    module::{Declarations, Exports, ModuleDef},
+    prelude::Func,
+    Ctx, Result,
+};
+
+fn isatty(fd: i32) -> bool {
+    unsafe { libc::isatty(fd) != 0 }
+}
+
+pub struct TtyModule;
+
+impl ModuleDef for TtyModule {
+    fn declare(declare: &Declarations<'_>) -> Result<()> {
+        declare.declare("isatty")?;
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        export_default(ctx, exports, |default| {
+            default.set("isatty", Func::from(isatty))?;
+            Ok(())
+        })
+    }
+}
+
+impl From<TtyModule> for ModuleInfo<TtyModule> {
+    fn from(val: TtyModule) -> Self {
+        ModuleInfo {
+            name: "tty",
+            module: val,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::TtyModule;
+    use llrt_test::{call_test, test_async_with, ModuleEvaluator};
+    use std::io::{stderr, stdin, stdout, IsTerminal};
+
+    #[tokio::test]
+    async fn test_isatty() {
+        test_async_with(|ctx| {
+            Box::pin(async move {
+                ModuleEvaluator::eval_rust::<TtyModule>(ctx.clone(), "tty")
+                    .await
+                    .unwrap();
+
+                let module = ModuleEvaluator::eval_js(
+                    ctx.clone(),
+                    "test",
+                    r#"
+                        import { isatty } from 'tty';
+
+                        export async function test() {
+                            return new Array(3).fill(0).map((_, i) => +isatty(i)).join('')
+                        }
+                    "#,
+                )
+                .await
+                .unwrap();
+                let expect = [
+                    stdin().is_terminal(),
+                    stdout().is_terminal(),
+                    stderr().is_terminal(),
+                ]
+                .map(|i| (i as u8).to_string())
+                .join("");
+                let result = call_test::<String, _>(&ctx, &module, ()).await;
+                assert_eq!(result, expect);
+            })
+        })
+        .await;
+    }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,3 +19,4 @@
 /// <reference types="./stream.d.ts" />
 /// <reference types="./url.d.ts" />
 /// <reference types="./zlib.d.ts" />
+/// <reference types="./tty.d.ts" />

--- a/types/tty.d.ts
+++ b/types/tty.d.ts
@@ -1,0 +1,11 @@
+
+declare module "tty" {
+  /**
+   * The `tty.isatty()` method returns `true` if the given `fd` is associated with
+   * a TTY and `false` if it is not, including whenever `fd` is not a non-negative
+   * integer.
+   * @since v0.5.8
+   * @param fd A numeric file descriptor
+   */
+  function isatty(fd: number): boolean;
+}


### PR DESCRIPTION
### Description of changes

Add tty module and use libc to implement tty.isatty function

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
