### PR TITLE
Fix require builtin path and windows paths

### DIFF
--- a/llrt_core/benches/slash_replacement.rs
+++ b/llrt_core/benches/slash_replacement.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use llrt_modules::path::replace_backslash;
 use rand::seq::SliceRandom;
 use rand::Rng;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const MAX_DEPTH: usize = 10;
 const PATH_STYLE_PROB: f64 = 0.5;
@@ -151,6 +151,42 @@ fn benchmark(c: &mut Criterion) {
             replace_backslash(path);
         })
     });
+
+    c.bench_function("File slash replace", |b| {
+        b.iter(|| {
+            let path = generate_random_path();
+            replace_filename(path);
+        })
+    });
+
+    c.bench_function("File components replace", |b| {
+        b.iter(|| {
+            let path = generate_random_path();
+            replace_components(path);
+        })
+    });
+}
+
+fn replace_components(path: String) -> String {
+    let length = path.len();
+    let path = Path::new(&path);
+    let mut components = path.components();
+    let mut new_path = String::with_capacity(length);
+
+    for component in components {
+        new_path.push_str(&component.as_os_str().to_string_lossy());
+        new_path.push('/');
+    }
+    new_path.truncate(length);
+
+    new_path
+}
+
+fn replace_filename(path: String) -> String {
+    Path::new(&path)
+        .to_string_lossy()
+        .to_string()
+        .replace('\\', "/")
 }
 
 criterion_group!(benches, benchmark);

--- a/llrt_core/benches/slash_replacement.rs
+++ b/llrt_core/benches/slash_replacement.rs
@@ -170,7 +170,7 @@ fn benchmark(c: &mut Criterion) {
 fn replace_components(path: String) -> String {
     let length = path.len();
     let path = Path::new(&path);
-    let mut components = path.components();
+    let components = path.components();
     let mut new_path = String::with_capacity(length);
 
     for component in components {

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -177,7 +177,7 @@ impl Vm {
     pub async fn run_file(&self, filename: impl AsRef<str>, strict: bool, global: bool) {
         let source = [
             r#"import(""#,
-            filename.as_ref(),
+            &filename.as_ref().replace('\\', "/"),
             r#"").catch((e) => {{console.error(e);process.exit(1)}})"#,
         ]
         .concat();
@@ -465,7 +465,9 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
                 if let Some(default_object) = default_export.as_object() {
                     for prop in props {
                         let (key, value) = prop?;
-                        default_object.set(key, value)?;
+                        if !default_object.contains_key(&key)? {
+                            default_object.set(key, value)?;
+                        }
                     }
                     let default_object = default_object.clone().into_value();
                     require_cache.set(import_name.as_ref(), default_object.clone())?;

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -126,3 +126,7 @@ if (!IS_WIN) {
     });
   });
 }
+
+it("require builtin modules", () => {
+  _require("path");
+});


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/676 & https://github.com/awslabs/llrt/issues/679

### Description of changes

Require with default export should only add named exports if not already there.

Also fixes windows paths as cli args.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
