### PR TITLE
fix: Improved behavior when loading CJS modules from import statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@ yarn-error.log
 llrt-container-*
 bootstrap
 
-/node_modules
-/example/functions/node_modules
-/example/infrastructure/node_modules
+node_modules
+!/fixtures/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,11 @@
 *.zip
 cdk.out
 flamegraph.svg
-node_modules
 out.stacks
 yarn-error.log
 llrt-container-*
 bootstrap
+
+/node_modules
+/example/functions/node_modules
+/example/infrastructure/node_modules

--- a/fixtures/node_modules/elem-debug/package.json
+++ b/fixtures/node_modules/elem-debug/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "elem-debug",
+    "main": "./src/index.js",
+    "browser": "./src/browser.js"
+}

--- a/fixtures/node_modules/elem-debug/src/browser.js
+++ b/fixtures/node_modules/elem-debug/src/browser.js
@@ -1,0 +1,11 @@
+exports = module.exports;
+
+exports.str = "cat";
+exports.cat = function cat() {
+    return exports.str;
+}
+
+exports.array = [];
+exports.length = function length() {
+    return exports.array.length;
+}

--- a/fixtures/node_modules/elem-lodash.merge/index.js
+++ b/fixtures/node_modules/elem-lodash.merge/index.js
@@ -1,0 +1,5 @@
+var merge = function test(value) {
+    return value;
+}
+
+module.exports = merge;

--- a/fixtures/node_modules/elem-lodash.merge/package.json
+++ b/fixtures/node_modules/elem-lodash.merge/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "elem-lodash.merge"
+}

--- a/fixtures/node_modules/elem-uuid/dist/commonjs-browser/index.js
+++ b/fixtures/node_modules/elem-uuid/dist/commonjs-browser/index.js
@@ -1,0 +1,12 @@
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+exports.default = require1;
+
+function require1(hello) {
+    function helloWorld(world) {
+        return hello + ", " + world;
+    }
+    return helloWorld;
+}

--- a/fixtures/node_modules/elem-uuid/package.json
+++ b/fixtures/node_modules/elem-uuid/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "elem-uuid",
+    "main": "./dist/index.js",
+    "exports": {
+        ".": {
+            "browser": {
+                "import": "./dist/esm-browser/index.js",
+                "require": "./dist/commonjs-browser/index.js"
+            },
+            "default": "./dist/esm-browser/index.js"
+        }
+    },
+    "module": "./dist/esm-node/index.js"
+}

--- a/fixtures/test_modules/test-debug.js
+++ b/fixtures/test_modules/test-debug.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+
+const debug = require("elem-debug");
+
+assert.ok(debug.cat() == "cat");
+assert.ok(debug.length() == 0);

--- a/fixtures/test_modules/test-lodash.merge.js
+++ b/fixtures/test_modules/test-lodash.merge.js
@@ -1,0 +1,7 @@
+const assert = require("assert");
+
+import merge1 from "elem-lodash.merge";
+assert.ok(typeof merge1 === "function");
+
+const merge2 = require("elem-lodash.merge");
+assert.ok(typeof merge2 === "function");

--- a/fixtures/test_modules/test-uuid.js
+++ b/fixtures/test_modules/test-uuid.js
@@ -1,0 +1,9 @@
+const assert = require("assert");
+
+var fn = _interopRequireDefault(require("elem-uuid"));
+function _interopRequireDefault(e) {
+  return e && e.__esModule ? e : { default: e };
+}
+var greeting = (0, fn.default)("hello");
+
+assert.ok(greeting("world") == "hello, world");

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -510,11 +510,16 @@ fn load_package_exports<'a>(
         return Ok(sub_module.into());
     }
 
-    let module_path = package_exports_resolve(&package_json, name, is_esm)?;
+    let (module_path, is_cjs) = package_exports_resolve(&package_json, name, is_esm)?;
 
-    Ok(correct_extensions(
-        [dir, "/", scope, "/", module_path].concat(),
-    ))
+    let module_path = correct_extensions([dir, "/", scope, "/", module_path].concat());
+    let prefix = if is_cjs && is_esm {
+        CJS_LOADER_PREFIX
+    } else {
+        ""
+    };
+
+    Ok([prefix, &module_path].concat().into())
 }
 
 // LOAD_PACKAGE_SELF(X, DIR)
@@ -549,9 +554,14 @@ fn load_package_self(ctx: &Ctx<'_>, x: &str, dir: &str, is_esm: bool) -> Result<
     //    "." + X.slice("name".length), `package.json` "exports", ["node", "require"])
     //    <a href="esm.md#resolver-algorithm-specification">defined in the ESM resolver</a>.
     // 6. RESOLVE_ESM_MATCH(MATCH)
-    if let Ok(path) = package_exports_resolve(&package_json, &name, is_esm) {
+    if let Ok((path, is_cjs)) = package_exports_resolve(&package_json, &name, is_esm) {
+        let prefix = if is_cjs && is_esm {
+            CJS_LOADER_PREFIX
+        } else {
+            ""
+        };
         trace!("|  load_package_self(2.c): {}", path);
-        return Ok(Some(path.into()));
+        return Ok(Some([prefix, path].concat()));
     }
 
     Ok(None)
@@ -570,68 +580,71 @@ fn package_exports_resolve<'a>(
     package_json: &'a BorrowedValue<'a>,
     modules_name: &str,
     is_esm: bool,
-) -> Result<&'a str> {
+) -> Result<(&'a str, bool)> {
     let ident = if is_esm { "import" } else { "require" };
 
     if let BorrowedValue::Object(map) = package_json {
+        let is_cjs =
+            !matches!(map.get("type"), Some(BorrowedValue::String(ref _type)) if _type == "module");
+
         if let Some(BorrowedValue::Object(exports)) = map.get("exports") {
             if let Some(BorrowedValue::Object(name)) = exports.get(modules_name) {
                 // Check for exports -> name -> browser -> [import | require]
                 if let Some(BorrowedValue::Object(browser)) = name.get("browser") {
                     if let Some(BorrowedValue::String(ident)) = browser.get(ident) {
-                        return Ok(ident.as_ref());
+                        return Ok((ident.as_ref(), is_cjs));
                     }
                 }
                 // Check for exports -> name -> [import | require] -> default
                 if let Some(BorrowedValue::Object(ident)) = name.get(ident) {
                     if let Some(BorrowedValue::String(default)) = ident.get("default") {
-                        return Ok(default.as_ref());
+                        return Ok((default.as_ref(), is_cjs));
                     }
                 }
                 // Check for exports -> name -> [import | require]
                 if let Some(BorrowedValue::String(ident)) = name.get(ident) {
-                    return Ok(ident.as_ref());
+                    return Ok((ident.as_ref(), is_cjs));
                 }
                 // [CJS only] Check for exports -> name -> default
                 if !is_esm {
                     if let Some(BorrowedValue::String(default)) = name.get("default") {
-                        return Ok(default.as_ref());
+                        return Ok((default.as_ref(), is_cjs));
                     }
                 }
             }
             // Check for exports -> [import | require] -> default
             if let Some(BorrowedValue::Object(ident)) = exports.get(ident) {
                 if let Some(BorrowedValue::String(default)) = ident.get("default") {
-                    return Ok(default.as_ref());
+                    return Ok((default.as_ref(), is_cjs));
                 }
             }
             // Check for exports -> [import | require]
             if let Some(BorrowedValue::String(ident)) = exports.get(ident) {
-                return Ok(ident.as_ref());
+                return Ok((ident.as_ref(), is_cjs));
             }
             // [CJS only] Check for exports -> default
             if !is_esm {
                 if let Some(BorrowedValue::String(default)) = exports.get("default") {
-                    return Ok(default.as_ref());
+                    return Ok((default.as_ref(), is_cjs));
                 }
             }
         }
         // Check for browser field
         if let Some(BorrowedValue::String(browser)) = map.get("browser") {
-            return Ok(browser.as_ref());
+            return Ok((browser.as_ref(), is_cjs));
         }
         // [ESM only] Check for module field
         if is_esm {
             if let Some(BorrowedValue::String(module)) = map.get("module") {
-                return Ok(module.as_ref());
+                return Ok((module.as_ref(), is_cjs));
             }
         }
         // Check for main field
         if let Some(BorrowedValue::String(main)) = map.get("main") {
-            return Ok(main.as_ref());
+            return Ok((main.as_ref(), is_cjs));
         }
     }
-    Ok("./index.js")
+    Ok(("./index.js", true))
 }
 
 // Implementation equivalent to PACKAGE_IMPORTS_RESOLVE including RESOLVE_ESM_MATCH

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -554,14 +554,9 @@ fn load_package_self(ctx: &Ctx<'_>, x: &str, dir: &str, is_esm: bool) -> Result<
     //    "." + X.slice("name".length), `package.json` "exports", ["node", "require"])
     //    <a href="esm.md#resolver-algorithm-specification">defined in the ESM resolver</a>.
     // 6. RESOLVE_ESM_MATCH(MATCH)
-    if let Ok((path, is_cjs)) = package_exports_resolve(&package_json, &name, is_esm) {
-        let prefix = if is_cjs && is_esm {
-            CJS_LOADER_PREFIX
-        } else {
-            ""
-        };
+    if let Ok((path, _)) = package_exports_resolve(&package_json, &name, is_esm) {
         trace!("|  load_package_self(2.c): {}", path);
-        return Ok(Some([prefix, path].concat()));
+        return Ok(Some(path.into()));
     }
 
     Ok(None)

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -130,3 +130,15 @@ if (!IS_WIN) {
 it("require builtin modules", () => {
   _require("path");
 });
+
+it("require `debug` module element", () => {
+  _require(`${CWD}/fixtures/test_modules/test-debug.js`);
+});
+
+it("require `lodash.merge` module element", () => {
+  _require(`${CWD}/fixtures/test_modules/test-lodash.merge.js`);
+});
+
+it("require `uuid` module element", () => {
+  _require(`${CWD}/fixtures/test_modules/test-uuid.js`);
+});


### PR DESCRIPTION
### Issue # (if available)

Fixed #667
Related #641 

### Description of changes

Fixed an issue where the error `SyntaxError: Could not find export 'default' from '...'` occurred when loading a CJS module from an import statement.

- When resolving a Node.js Package, we now also determine whether the package is CJS.
- After that, if we determine that it is a CJS module called by import statement, we now use prefix `__cjsm:` to achieve this behavior.

The following use case, which was an issue in #641, will now work:

```javascript
// powertoolsLogger.js
import { Logger } from '@aws-lambda-powertools/logger'
const logger = new Logger()
logger.info('Hello world')
```

```
% llrt powertoolsLogger.js 
{"level":"INFO","message":"Hello world","sampling_rate":0,"service":"service_undefined","timestamp":"2024-11-17T01:52:13.459Z"}
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
