### PR TITLE
feat: Resolver control by environment variable "LLRT_PLATFORM"

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,10 @@ Space-delimited list of hosts or socket paths which should be denied for network
 
 Set a timeout in seconds for idle sockets being kept-alive. Default timeout is 15 seconds
 
+### `LLRT_PLATFORM=value`
+
+Used to explicitly specify a preferred platform for the Node.js package resolver. The default is `browser`. If `node` is specified, "node" takes precedence in the search path. If a value other than `browser` or `node` is specified, it will behave as if "browser" was specified.
+
 ### `LLRT_TLS_VERSION=value`
 
 Set the TLS version to be used for network connections. By default only TLS 1.2 is enabled. TLS 1.3 can also be enabled by setting this variable to `1.3`

--- a/llrt_core/src/environment.rs
+++ b/llrt_core/src/environment.rs
@@ -12,5 +12,8 @@ pub const ENV_LLRT_EXTRA_CA_CERTS: &str = "LLRT_EXTRA_CA_CERTS";
 //log
 pub const ENV_LLRT_LOG: &str = "LLRT_LOG";
 
+//module
+pub const ENV_LLRT_PLATFORM: &str = "LLRT_PLATFORM";
+
 //vm
 pub const ENV_LLRT_GC_THRESHOLD_MB: &str = "LLRT_GC_THRESHOLD_MB";

--- a/llrt_core/src/module_loader/loader.rs
+++ b/llrt_core/src/module_loader/loader.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 use once_cell::sync::Lazy;
 use rquickjs::{loader::Loader, Ctx, Function, Module, Object, Result, Value};
 use std::{

--- a/llrt_core/src/module_loader/mod.rs
+++ b/llrt_core/src/module_loader/mod.rs
@@ -1,3 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::env;
+
+use once_cell::sync::Lazy;
+
+use crate::environment;
+
 pub mod loader;
 pub mod resolver;
 
@@ -5,3 +13,13 @@ pub mod resolver;
 pub const CJS_IMPORT_PREFIX: &str = "__cjs:";
 // added to force CJS imports in loader
 pub const CJS_LOADER_PREFIX: &str = "__cjsm:";
+
+pub static LLRT_PLATFORM: Lazy<String> = Lazy::new(|| {
+    let platform =
+        env::var(environment::ENV_LLRT_PLATFORM).unwrap_or_else(|_| "browser".to_string());
+    if platform == "node" {
+        "node".to_string()
+    } else {
+        "browser".to_string()
+    }
+});

--- a/llrt_core/src/module_loader/mod.rs
+++ b/llrt_core/src/module_loader/mod.rs
@@ -15,11 +15,8 @@ pub const CJS_IMPORT_PREFIX: &str = "__cjs:";
 pub const CJS_LOADER_PREFIX: &str = "__cjsm:";
 
 pub static LLRT_PLATFORM: Lazy<String> = Lazy::new(|| {
-    let platform =
-        env::var(environment::ENV_LLRT_PLATFORM).unwrap_or_else(|_| "browser".to_string());
-    if platform == "node" {
-        "node".to_string()
-    } else {
-        "browser".to_string()
-    }
+    env::var(environment::ENV_LLRT_PLATFORM)
+        .ok()
+        .filter(|platform| platform == "node")
+        .unwrap_or_else(|| "browser".to_string())
 });

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -375,12 +375,12 @@ fn load_node_modules<'a>(
         // b. LOAD_AS_FILE(DIR/X)
         if let Ok(Some(path)) = load_as_file(ctx, dir_slash_x.clone()) {
             trace!("|  load_node_modules(2.b): {}", path);
-            return Some(to_abs_path(path).unwrap());
+            return Some(path);
         }
         // c. LOAD_AS_DIRECTORY(DIR/X)
         if let Ok(Some(path)) = load_as_directory(ctx, dir_slash_x.clone()) {
             trace!("|  load_node_modules(2.c): {}", path);
-            return Some(to_abs_path(path).unwrap());
+            return Some(path);
         }
     }
 
@@ -515,8 +515,7 @@ fn load_package_exports<'a>(
 
     let module_path = to_abs_path(correct_extensions(
         [dir, "/", scope, "/", module_path].concat(),
-    ))
-    .unwrap();
+    ))?;
 
     let prefix = if is_cjs && is_esm {
         CJS_LOADER_PREFIX


### PR DESCRIPTION
### Issue # (if available)

https://github.com/awslabs/llrt/pull/680#issuecomment-2482365305

### Description of changes

This PR adds the ability to toggle platform preferences in the Node.js package resolver.

```javascript
// index19.js
import chalk from 'chalk';
console.log(chalk.blue('Hello world!'));
```

Use "browser":
```
% export LLRT_PLATFORM=browser
% llrt index19.js
Hello world!
```

Use "node":
```
% export LLRT_PLATFORM=node
% llrt index19.js
ReferenceError: Error resolving module 'node:tty' from '/Users/shinya/Workspaces/llrt-test/node_modules/chalk/./source/vendor/supports-color/index.js'
```
NOTE: This behavior is currently as expected, as the tty module has not yet been merged into mainline.

Non use:
```
% unset LLRT_PLATFORM
% llrt index19.js
Hello world!
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
