### PR TITLE
fix: Removed invalid endpoints for `@aws-sdk/client-sfn`

### DIFF
--- a/sdk.cfg
+++ b/sdk.cfg
@@ -52,7 +52,7 @@ client-opensearchserverless,OpenSearchServerless,aoss,1
 # ApplicationIntegration
 client-eventbridge,EventBridge,events,0
 client-scheduler,Scheduler,scheduler,1
-client-sfn,SFN,states,sync-states,0
+client-sfn,SFN,states,0
 client-sns,SNS,sns,0
 client-sqs,SQS,sqs,0
 


### PR DESCRIPTION
### Issue # (if available)

Fixed #694

### Description of changes

This PR fixes the issue by removing endpoint `sync-states` from the definition file that are defined in the `@aws-sdk/client-sfn` document but not implemented in the actual source, preventing timeouts during pre-connection at LLRT startup.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
