### PR TITLE
Add primordials for faster common object lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
 name = "llrt_exceptions"
 version = "0.3.0-beta"
 dependencies = [
+ "llrt_utils",
  "rquickjs",
 ]
 

--- a/libs/llrt_utils/Cargo.toml
+++ b/libs/llrt_utils/Cargo.toml
@@ -16,6 +16,7 @@ bytearray-buffer = ["tokio/sync"]
 [dependencies]
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.8.1", features = [
   "array-buffer",
+  "macro",
 ], default-features = false }
 tokio = { version = "1", optional = true }
 tracing = "0.1"

--- a/libs/llrt_utils/src/class.rs
+++ b/libs/llrt_utils/src/class.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 use rquickjs::{
     atom::PredefinedAtom, class::JsClass, object::Accessor, prelude::This, Array, Class, Ctx,
-    Function, Object, Result, Symbol, Value,
+    Function, Object, Result, Value,
 };
 
-use super::{
-    object::{CreateSymbol, ObjectExt},
-    result::OptionExt,
-};
+use crate::primordials::{BasePrimordials, Primordial};
+
+use super::{object::ObjectExt, result::OptionExt};
 
 pub static CUSTOM_INSPECT_SYMBOL_DESCRIPTION: &str = "llrt.inspect.custom";
 
@@ -64,8 +63,9 @@ where
 {
     fn define_with_custom_inspect(globals: &Object<'js>) -> Result<()> {
         Self::define(globals)?;
-        let custom_inspect_symbol =
-            Symbol::for_description(globals, CUSTOM_INSPECT_SYMBOL_DESCRIPTION)?;
+        let custom_inspect_symbol = BasePrimordials::get(globals.ctx())?
+            .symbol_custom_inspect
+            .clone();
         if let Some(proto) = Class::<C>::prototype(globals.ctx())? {
             proto.prop(
                 custom_inspect_symbol,

--- a/libs/llrt_utils/src/lib.rs
+++ b/libs/llrt_utils/src/lib.rs
@@ -12,6 +12,7 @@ pub mod macros;
 pub mod mc_oneshot;
 pub mod module;
 pub mod object;
+pub mod primordials;
 pub mod result;
 pub mod sysinfo;
 pub mod time;

--- a/libs/llrt_utils/src/object.rs
+++ b/libs/llrt_utils/src/object.rs
@@ -4,8 +4,10 @@ use rquickjs::{
     atom::PredefinedAtom,
     function::{Constructor, IntoJsFunc},
     prelude::Func,
-    Array, Ctx, FromJs, Function, IntoAtom, IntoJs, Object, Result, Symbol, Undefined, Value,
+    Array, Ctx, FromJs, IntoAtom, IntoJs, Object, Result, Symbol, Undefined, Value,
 };
+
+use crate::primordials::{BasePrimordials, Primordial};
 
 pub trait ObjectExt<'js> {
     fn get_optional<K: IntoAtom<'js> + Clone, V: FromJs<'js>>(&self, k: K) -> Result<Option<V>>;
@@ -30,14 +32,14 @@ impl<'js> ObjectExt<'js> for Value<'js> {
 }
 
 pub trait CreateSymbol<'js> {
-    fn for_description(globals: &Object<'js>, description: &'static str) -> Result<Symbol<'js>>;
+    fn for_description(ctx: &Ctx<'js>, description: &str) -> Result<Symbol<'js>>;
 }
 
 impl<'js> CreateSymbol<'js> for Symbol<'js> {
-    fn for_description(globals: &Object<'js>, description: &'static str) -> Result<Symbol<'js>> {
-        let symbol_function: Function = globals.get(PredefinedAtom::Symbol)?;
-        let for_function: Function = symbol_function.get(PredefinedAtom::For)?;
-        for_function.call((description,))
+    fn for_description(ctx: &Ctx<'js>, description: &str) -> Result<Symbol<'js>> {
+        BasePrimordials::get(ctx)?
+            .function_symbol_for
+            .call((description,))
     }
 }
 

--- a/libs/llrt_utils/src/primordials.rs
+++ b/libs/llrt_utils/src/primordials.rs
@@ -1,0 +1,121 @@
+use rquickjs::{
+    atom::PredefinedAtom, function::Constructor, runtime::UserDataGuard, Ctx, Function, JsLifetime,
+    Object, Result, Symbol,
+};
+
+use crate::class::CUSTOM_INSPECT_SYMBOL_DESCRIPTION;
+
+#[derive(JsLifetime)]
+pub struct BasePrimordials<'js> {
+    // Constructors
+    pub constructor_map: Constructor<'js>,
+    pub constructor_set: Constructor<'js>,
+    pub constructor_date: Constructor<'js>,
+    pub constructor_error: Constructor<'js>,
+    pub constructor_regexp: Constructor<'js>,
+
+    // Prototypes
+    pub prototype_object: Object<'js>,
+    pub prototype_date: Object<'js>,
+    pub prototype_regexp: Object<'js>,
+    pub prototype_set: Object<'js>,
+    pub prototype_map: Object<'js>,
+    pub prototype_error: Object<'js>,
+
+    // Functions
+    pub function_array_from: Function<'js>,
+    pub function_array_buffer_is_view: Function<'js>,
+    pub function_get_own_property_descriptor: Function<'js>,
+    pub function_number: Function<'js>,
+    pub function_parse_int: Function<'js>,
+    pub function_parse_float: Function<'js>,
+    pub function_symbol_for: Function<'js>,
+
+    // Symbols
+    pub symbol_custom_inspect: Symbol<'js>,
+}
+
+pub trait Primordial<'js> {
+    fn get<'a>(ctx: &'a Ctx<'js>) -> Result<UserDataGuard<'a, Self>>
+    where
+        Self: Sized + JsLifetime<'js>,
+    {
+        if let Some(primordials) = ctx.userdata::<Self>() {
+            return Ok(primordials);
+        }
+
+        let primoridals = Self::new(ctx)?;
+
+        _ = ctx.store_userdata(primoridals);
+        Ok(ctx.userdata::<Self>().unwrap())
+    }
+
+    fn new(ctx: &Ctx<'js>) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+impl<'js> Primordial<'js> for BasePrimordials<'js> {
+    fn new(ctx: &Ctx<'js>) -> Result<Self> {
+        let globals = ctx.globals();
+
+        let constructor_object: Object = globals.get(PredefinedAtom::Object)?;
+        let prototype_object: Object = constructor_object.get(PredefinedAtom::Prototype)?;
+
+        let function_get_own_property_descriptor: Function =
+            constructor_object.get(PredefinedAtom::GetOwnPropertyDescriptor)?;
+
+        let constructor_date: Constructor = globals.get(PredefinedAtom::Date)?;
+        let prototype_date: Object = constructor_date.get(PredefinedAtom::Prototype)?;
+
+        let constructor_map: Constructor = globals.get(PredefinedAtom::Map)?;
+        let prototype_map: Object = constructor_map.get(PredefinedAtom::Prototype)?;
+
+        let constructor_set: Constructor = globals.get(PredefinedAtom::Set)?;
+        let prototype_set: Object = constructor_set.get(PredefinedAtom::Prototype)?;
+
+        let constructor_regexp: Constructor = globals.get(PredefinedAtom::RegExp)?;
+        let prototype_regexp: Object = constructor_regexp.get(PredefinedAtom::Prototype)?;
+
+        let constructor_error: Constructor = globals.get(PredefinedAtom::Error)?;
+        let prototype_error: Object = constructor_error.get(PredefinedAtom::Prototype)?;
+
+        let constructor_array: Object = globals.get(PredefinedAtom::Array)?;
+        let function_array_from: Function = constructor_array.get(PredefinedAtom::From)?;
+
+        let constructor_array_buffer: Object = globals.get(PredefinedAtom::ArrayBuffer)?;
+        let function_array_buffer_is_view: Function = constructor_array_buffer.get("isView")?;
+
+        let function_number: Function = globals.get(PredefinedAtom::Number)?;
+        let function_parse_float: Function = function_number.get("parseFloat")?;
+        let function_parse_int: Function = function_number.get("parseInt")?;
+
+        let symbol_constructor: Function = globals.get(PredefinedAtom::Symbol)?;
+        let function_symbol_for: Function = symbol_constructor.get(PredefinedAtom::For)?;
+
+        let symbol_custom_inspect: Symbol<'js> =
+            function_symbol_for.call((CUSTOM_INSPECT_SYMBOL_DESCRIPTION,))?;
+
+        Ok(Self {
+            constructor_map,
+            constructor_set,
+            constructor_date,
+            constructor_error,
+            constructor_regexp,
+            prototype_object,
+            prototype_date,
+            prototype_regexp,
+            prototype_set,
+            prototype_map,
+            prototype_error,
+            function_array_from,
+            function_array_buffer_is_view,
+            function_get_own_property_descriptor,
+            function_parse_float,
+            function_parse_int,
+            function_symbol_for,
+            function_number,
+            symbol_custom_inspect,
+        })
+    }
+}

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -19,7 +19,12 @@ use llrt_modules::{
     timers::{self, poll_timers},
 };
 use llrt_numbers::number_to_string;
-use llrt_utils::{bytes::ObjectBytes, error::ErrorExtensions, object::ObjectExt};
+use llrt_utils::{
+    bytes::ObjectBytes,
+    error::ErrorExtensions,
+    object::ObjectExt,
+    primordials::{BasePrimordials, Primordial},
+};
 use ring::rand::SecureRandom;
 use rquickjs::{
     atom::PredefinedAtom,
@@ -486,6 +491,9 @@ fn init(ctx: &Ctx<'_>, module_names: HashSet<&'static str>) -> Result<()> {
             Ok(value)
         }),
     )?;
+
+    //init base primordials
+    let _ = BasePrimordials::get(ctx)?;
 
     Ok(())
 }

--- a/modules/llrt_exceptions/Cargo.toml
+++ b/modules/llrt_exceptions/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/lib.rs"
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.8.1", features = [
   "macro",
 ], default-features = false }
+llrt_utils = { version = "0.3.0-beta", path = "../../libs/llrt_utils", default-features = false }

--- a/modules/llrt_exceptions/src/lib.rs
+++ b/modules/llrt_exceptions/src/lib.rs
@@ -1,3 +1,4 @@
+use llrt_utils::primordials::{BasePrimordials, Primordial};
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use rquickjs::{
@@ -62,9 +63,8 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     Class::<DOMException>::define(&globals)?;
 
     let dom_ex_proto = Class::<DOMException>::prototype(ctx)?.unwrap();
-    let error_ctor: Object = globals.get(PredefinedAtom::Error)?;
-    let error_proto = error_ctor.get_prototype();
-    dom_ex_proto.set_prototype(error_proto.as_ref())?;
+    let error_prototype = &BasePrimordials::get(ctx)?.prototype_error;
+    dom_ex_proto.set_prototype(Some(error_prototype))?;
 
     Ok(())
 }

--- a/modules/llrt_url/src/url_search_params.rs
+++ b/modules/llrt_url/src/url_search_params.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{cell::RefCell, collections::HashSet, rc::Rc};
 
-use llrt_utils::class::IteratorDef;
+use llrt_utils::{
+    class::IteratorDef,
+    primordials::{BasePrimordials, Primordial},
+};
 use rquickjs::{
     atom::PredefinedAtom, class::Trace, function::Opt, Array, Class, Coerced, Ctx, Exception,
     FromJs, Function, IntoJs, Null, Object, Result, Symbol, Value,
@@ -317,9 +320,9 @@ impl<'js> URLSearchParams {
     pub fn from_object(ctx: &Ctx<'js>, object: Object<'js>) -> Result<Self> {
         let iterator = Symbol::iterator(ctx.clone());
         if object.contains_key(iterator)? {
-            let array_object: Object = ctx.globals().get(PredefinedAtom::Array)?;
-            let array_from: Function = array_object.get(PredefinedAtom::From)?;
-            let query_pairs: Array = array_from.call((object,))?;
+            let query_pairs: Array = BasePrimordials::get(ctx)?
+                .function_array_from
+                .call((object,))?;
             return Self::from_array(ctx, query_pairs);
         }
 


### PR DESCRIPTION
### Description of changes

BasePrimordials & BufferPrimordials provide cached fields for common objects for faster lookup

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
