### PR TITLE
Store wakers in Vec instead of busy waiting

### DIFF
--- a/libs/llrt_utils/Cargo.toml
+++ b/libs/llrt_utils/Cargo.toml
@@ -18,7 +18,7 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.8.1"
   "array-buffer",
   "macro",
 ], default-features = false }
-tokio = { version = "1" }
+tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/libs/llrt_utils/Cargo.toml
+++ b/libs/llrt_utils/Cargo.toml
@@ -18,7 +18,7 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.8.1"
   "array-buffer",
   "macro",
 ], default-features = false }
-tokio = { version = "1", optional = true }
+tokio = { version = "1" }
 tracing = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
### Description of changes

Store waiters in Vec instead of busy waiting

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
