### PR TITLE
Fix `toString()` of 0 for all radix values

### DIFF
--- a/libs/llrt_numbers/src/lib.rs
+++ b/libs/llrt_numbers/src/lib.rs
@@ -76,6 +76,11 @@ pub fn i64_to_base_n(number: i64, radix: u8) -> String {
 
 #[inline(always)]
 fn internal_i64_to_base_n(buf: &mut [u8], number: i64, radix: u8) -> usize {
+    if number == 0 {
+        buf[BUF_SIZE - 1] = DIGITS[0];
+        return BUF_SIZE - 1;
+    }
+
     let mut n = number;
     let mut index = BUF_SIZE;
 
@@ -295,6 +300,9 @@ mod test {
         }
 
         // Test i64_to_base_n
+        let base_36 = i64_to_base_n(0, 36);
+        assert_eq!("0", base_36);
+
         let base_36 = i64_to_base_n(123456789, 36);
         assert_eq!("21i3v9", base_36);
 


### PR DESCRIPTION
### Issue # (if available)

https://github.com/awslabs/llrt/issues/712

### Description of changes

In Node, `(0).toString(16)` returns `"0"`, whereas in LLRT it returns `""`. This PR updates the `internal_i64_to_base_n` function so that the LLRT implementation is consistent with the Node.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
