### PR TITLE
Fix fetch test socket error

### DIFF
--- a/llrt_core/src/modules/js/@llrt/test/worker.ts
+++ b/llrt_core/src/modules/js/@llrt/test/worker.ts
@@ -403,6 +403,7 @@ class TestAgent {
             ended: performance.now(),
           });
         } catch (e) {
+          console.error("Error sending error message:", e);
           process.exit(1);
         }
       }

--- a/tests/unit/fetch.test.ts
+++ b/tests/unit/fetch.test.ts
@@ -8,6 +8,7 @@ let url: string;
 
 beforeAll((done) => {
   server = net.createServer((socket) => {
+    socket.on("error", () => {}); //ignore errors as abort signals might cancel the socket
     socket.on("data", () => {
       socket.write(
         "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html></html>"


### PR DESCRIPTION
### Issue # (if available)

Fix an issue where fetch tests sometimes failed due to missing error handler.

### Description of changes

If the socket has no error handler and we try to write to a closed socket, the process should crash with an exception. This is by design. In the fetch test we trigger the abort controllers signal to cancel a fetch request which might close the socket before the server had time to write cashing a crash in the worker.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
