### PR TITLE
Improved logging of promises

### DIFF
--- a/tests/unit/console.test.ts
+++ b/tests/unit/console.test.ts
@@ -126,6 +126,8 @@ it("should log complex object", () => {
     3: {},
     [3.14]: 1,
     4: [1, 2, 3],
+    5: Promise.reject(1),
+    6: Promise.resolve(1),
     abc: 123,
   };
 
@@ -138,9 +140,15 @@ it("should log complex object", () => {
     `
 {
   '1': Symbol(foo),
-  '2': Promise {},
+  '2': Promise { <pending> },
   '3': {},
   '4': [ 1, 2, 3 ],
+  '5': Promise {
+    <rejected> 1
+  },
+  '6': Promise {
+    1
+  },
   a: 1,
   b: \'foo\',
   c: {


### PR DESCRIPTION
### Description of changes

Add better console logging for Promises.

Console now logs the state of the promise.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
