### PR TITLE
Fix a bug where request options set as undefined or null result in a quickjs cast error

### DIFF
--- a/modules/llrt_http/src/request.rs
+++ b/modules/llrt_http/src/request.rs
@@ -51,7 +51,7 @@ impl<'js> Trace<'js> for Request<'js> {
 #[rquickjs::methods(rename_all = "camelCase")]
 impl<'js> Request<'js> {
     #[qjs(constructor)]
-    pub fn new(ctx: Ctx<'js>, input: Value<'js>, options: Opt<Object<'js>>) -> Result<Self> {
+    pub fn new(ctx: Ctx<'js>, input: Value<'js>, options: Opt<Value<'js>>) -> Result<Self> {
         let mut request = Self {
             url: String::from(""),
             method: "GET".to_string(),
@@ -70,7 +70,9 @@ impl<'js> Request<'js> {
             })?;
         }
         if let Some(options) = options.0 {
-            assign_request(&mut request, ctx.clone(), &options)?;
+            if let Some(obj) = options.as_object() {
+                assign_request(&mut request, ctx.clone(), obj)?;
+            }
         }
         if request.headers.is_none() {
             let headers = Class::instance(ctx, Headers::default())?;

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -318,6 +318,11 @@ describe("Request class", () => {
     expect((await request.blob()).size).toEqual(blob.size);
     expect((await request.blob()).type).toEqual("text/plain");
   });
+
+  it("should ignore request options which are not an object", async () => {
+    const request = new Request("http://localhost", undefined);
+    expect(request instanceof Request).toBeTruthy();
+  });
 });
 
 describe("Response class", () => {


### PR DESCRIPTION
### Issue # (if available)

https://github.com/awslabs/llrt/issues/744

### Description of changes

Passing null or undefined into the http Request constructor results in a TypeError. This is a change in behaviour versus nodejs where null or undefined request options are ignored. This PR addresses the problem by first checking the request options argument is an object before setting it on the class.

### Checklist

- [Y] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [Y] Ran `make fix` to format JS and apply Clippy auto fixes
- [Y] Made sure my code didn't add any additional warnings: `make check`
- [NA] Added relevant type info in `types/` directory
- [NA] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
