### PR TITLE
feat: adding support for Buffer.isBuffer and Buffer.isEncoding

### DIFF
--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -15,8 +15,8 @@ use rquickjs::{
     function::{Constructor, Opt},
     module::{Declarations, Exports, ModuleDef},
     prelude::{Func, This},
-    Array, ArrayBuffer, Coerced, Ctx, Exception, IntoJs, JsLifetime, Object, Result, TypedArray,
-    Value,
+    Array, ArrayBuffer, Coerced, Ctx, Exception, Function, IntoJs, JsLifetime, Object, Result,
+    TypedArray, Value,
 };
 
 #[derive(JsLifetime)]
@@ -118,6 +118,25 @@ fn byte_length<'js>(ctx: Ctx<'js>, value: Value<'js>, encoding: Opt<String>) -> 
         &ctx,
         "value must be typed DataView, Buffer, ArrayBuffer, Uint8Array or string",
     ))
+}
+
+fn is_buffer<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<bool> {
+    let class: Function = ctx.globals().get(stringify!(Buffer))?;
+    if let Some(object) = value.as_object() {
+        return Ok(object.is_instance_of(class));
+    }
+
+    Ok(false)
+}
+
+fn is_encoding(value: Value) -> Result<bool> {
+    if let Some(js_string) = value.as_string() {
+        if let Ok(std_string) = js_string.to_string() {
+            return Ok(Encoder::from_str(std_string.as_str()).is_ok());
+        }
+    }
+
+    Ok(false)
 }
 
 fn to_string(this: This<Object<'_>>, ctx: Ctx, encoding: Opt<String>) -> Result<String> {
@@ -295,6 +314,8 @@ fn set_prototype<'js>(ctx: &Ctx<'js>, constructor: Object<'js>) -> Result<()> {
     let _ = &constructor.set(stringify!(alloc), Func::from(alloc))?;
     let _ = &constructor.set(stringify!(concat), Func::from(concat))?;
     let _ = &constructor.set("byteLength", Func::from(byte_length))?;
+    let _ = &constructor.set("isBuffer", Func::from(is_buffer))?;
+    let _ = &constructor.set("isEncoding", Func::from(is_encoding))?;
 
     let prototype: &Object = &constructor.get(PredefinedAtom::Prototype)?;
     prototype.set(PredefinedAtom::ToString, Func::from(to_string))?;

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -15,8 +15,8 @@ use rquickjs::{
     function::{Constructor, Opt},
     module::{Declarations, Exports, ModuleDef},
     prelude::{Func, This},
-    Array, ArrayBuffer, Coerced, Ctx, Exception, Function, IntoJs, JsLifetime, Object, Result,
-    TypedArray, Value,
+    Array, ArrayBuffer, Coerced, Ctx, Exception, IntoJs, JsLifetime, Object, Result, TypedArray,
+    Value,
 };
 
 #[derive(JsLifetime)]
@@ -121,9 +121,9 @@ fn byte_length<'js>(ctx: Ctx<'js>, value: Value<'js>, encoding: Opt<String>) -> 
 }
 
 fn is_buffer<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<bool> {
-    let class: Function = ctx.globals().get(stringify!(Buffer))?;
     if let Some(object) = value.as_object() {
-        return Ok(object.is_instance_of(class));
+        let constructor = BufferPrimordials::get(&ctx)?;
+        return Ok(object.is_instance_of(&constructor.constructor));
     }
 
     Ok(false)
@@ -131,9 +131,8 @@ fn is_buffer<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<bool> {
 
 fn is_encoding(value: Value) -> Result<bool> {
     if let Some(js_string) = value.as_string() {
-        if let Ok(std_string) = js_string.to_string() {
-            return Ok(Encoder::from_str(std_string.as_str()).is_ok());
-        }
+        let std_string = js_string.to_string()?;
+        return Ok(Encoder::from_str(std_string.as_str()).is_ok());
     }
 
     Ok(false)

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -352,3 +352,34 @@ describe("Buffer.subarray", () => {
     expect(subBuffer.toString()).toEqual("");
   });
 });
+
+describe("Buffer.isBuffer", () => {
+  it("should return true when the object being tested is an instance of Buffer", () => {
+    const buffer = Buffer.from("Hello, world!");
+
+    expect(Buffer.isBuffer(buffer)).toEqual(true);
+  });
+
+  it("should return false when the object being tested is not an instance of Buffer", () => {
+    expect(Buffer.isBuffer(false)).toEqual(false);
+    expect(Buffer.isBuffer(undefined)).toEqual(false);
+    expect(Buffer.isBuffer(null)).toEqual(false);
+    expect(Buffer.isBuffer("Buffer")).toEqual(false);
+    expect(Buffer.isBuffer(Buffer)).toEqual(false);
+  });
+});
+
+describe("Buffer.isEncoding", () => {
+  it("should return true when input is a valid encoding name", () => {
+    expect(Buffer.isEncoding("utf8")).toEqual(true);
+    expect(Buffer.isEncoding("hex")).toEqual(true);
+    expect(Buffer.isEncoding("base64")).toEqual(true);
+  });
+
+  it("should return false when input is not a valid encoding name", () => {
+    expect(Buffer.isEncoding(false as unknown as string)).toEqual(false);
+    expect(Buffer.isEncoding(undefined as unknown as string)).toEqual(false);
+    expect(Buffer.isEncoding(null as unknown as string)).toEqual(false);
+    expect(Buffer.isEncoding("utf8/8")).toEqual(false);
+  });
+});


### PR DESCRIPTION
### Issue # (if available)

No issue associated with this change.

### Description of changes
This PR adds support for `Buffer.isBuffer` and `Buffer.isEncoding` (see https://nodejs.org/api/buffer.html).

### Checklist

- [Y] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [Y] Ran `make fix` to format JS and apply Clippy auto fixes
- [Y] Made sure my code didn't add any additional warnings: `make check`
- [NA] Added relevant type info in `types/` directory
- [NA] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
