### PR TITLE
chore(deps): bump sysinfo from 0.32.1 to 0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+checksum = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/modules/llrt_os/Cargo.toml
+++ b/modules/llrt_os/Cargo.toml
@@ -19,7 +19,7 @@ llrt_utils = { version = "0.3.0-beta", path = "../../libs/llrt_utils", default-f
 num_cpus = "1"
 once_cell = "1"
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.8.1", default-features = false }
-sysinfo = { version = "0.32", features = ["system"], default-features = false }
+sysinfo = { version = "0.33", features = ["system"], default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/modules/llrt_os/src/lib.rs
+++ b/modules/llrt_os/src/lib.rs
@@ -68,8 +68,8 @@ fn get_load_avg() -> Vec<f64> {
     vec![load_avg.one, load_avg.five, load_avg.fifteen]
 }
 
-fn get_machine(ctx: Ctx<'_>) -> Result<String> {
-    System::cpu_arch().ok_or_else(|| Exception::throw_reference(&ctx, "System::cpu_arch"))
+fn get_machine() -> String {
+    System::cpu_arch()
 }
 
 fn get_tmp_dir() -> String {

--- a/modules/llrt_os/src/statistics.rs
+++ b/modules/llrt_os/src/statistics.rs
@@ -8,9 +8,9 @@ use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
 static SYSTEM: Lazy<Arc<Mutex<System>>> = Lazy::new(|| {
     Arc::new(Mutex::new(System::new_with_specifics(
-        RefreshKind::new()
-            .with_cpu(CpuRefreshKind::new().with_cpu_usage().with_frequency())
-            .with_memory(MemoryRefreshKind::new().with_ram()),
+        RefreshKind::nothing()
+            .with_cpu(CpuRefreshKind::nothing().with_cpu_usage().with_frequency())
+            .with_memory(MemoryRefreshKind::nothing().with_ram()),
     )))
 });
 
@@ -40,13 +40,13 @@ pub fn get_cpus(ctx: Ctx<'_>) -> Result<Vec<Object>> {
 pub fn get_free_mem() -> u64 {
     let mut system = SYSTEM.lock().unwrap();
 
-    system.refresh_memory_specifics(MemoryRefreshKind::new().with_ram());
+    system.refresh_memory_specifics(MemoryRefreshKind::nothing().with_ram());
     system.free_memory()
 }
 
 pub fn get_total_mem() -> u64 {
     let mut system = SYSTEM.lock().unwrap();
 
-    system.refresh_memory_specifics(MemoryRefreshKind::new().with_ram());
+    system.refresh_memory_specifics(MemoryRefreshKind::nothing().with_ram());
     system.total_memory()
 }


### PR DESCRIPTION
### Description of changes

The sysinfo crate has been updated. This has resulted in some incompatible changes being addressed.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
