### PR TITLE
refactor(crypto): implement of AesCbc*Variant and AesCtrVariant

### DIFF
--- a/modules/llrt_crypto/src/subtle/decrypt.rs
+++ b/modules/llrt_crypto/src/subtle/decrypt.rs
@@ -1,24 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use aes::cipher::{block_padding::Pkcs7, typenum::U12, BlockDecryptMut, KeyIvInit};
+use aes::cipher::typenum::U12;
 use aes_gcm::Nonce;
-use ctr::cipher::StreamCipher;
 use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
 use rquickjs::{ArrayBuffer, Class, Ctx, Result};
 
-use crate::subtle::{
-    Aes128Ctr128, Aes128Ctr32, Aes128Ctr64, Aes192Ctr128, Aes192Ctr32, Aes192Ctr64, Aes256Ctr128,
-    Aes256Ctr32, Aes256Ctr64, CryptoKey,
-};
-
 use super::{
     algorithm_missmatch_error, encryption_algorithm::EncryptionAlgorithm,
-    key_algorithm::KeyAlgorithm, rsa_private_key, AesGcmVariant,
+    key_algorithm::KeyAlgorithm, rsa_private_key, AesCbcDecVariant, AesCtrVariant, AesGcmVariant,
+    CryptoKey,
 };
-
-type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
-type Aes192CbcDec = cbc::Decryptor<aes::Aes192>;
-type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
 
 pub async fn subtle_decrypt<'js>(
     ctx: Ctx<'js>,
@@ -42,12 +33,8 @@ fn decrypt(
     match algorithm {
         EncryptionAlgorithm::AesCbc { iv } => {
             if let KeyAlgorithm::Aes { length } = key.algorithm {
-                match length {
-                    128 => decrypt_aes_cbc_gen::<Aes128CbcDec>(ctx, handle, iv, data),
-                    192 => decrypt_aes_cbc_gen::<Aes192CbcDec>(ctx, handle, iv, data),
-                    256 => decrypt_aes_cbc_gen::<Aes256CbcDec>(ctx, handle, iv, data),
-                    _ => unreachable!(), // 'length' has already been sanitized.
-                }
+                let variant = AesCbcDecVariant::new(length, handle, iv).or_throw(ctx)?;
+                variant.decrypt(data).or_throw(ctx)
             } else {
                 algorithm_missmatch_error(ctx)
             }
@@ -55,18 +42,9 @@ fn decrypt(
         EncryptionAlgorithm::AesCtr { counter, length } => {
             let encryption_length = length;
             if let KeyAlgorithm::Aes { length } = key.algorithm {
-                match (length, encryption_length) {
-                    (128, 32) => decrypt_aes_ctr_gen::<Aes128Ctr32>(ctx, handle, counter, data),
-                    (128, 64) => decrypt_aes_ctr_gen::<Aes128Ctr64>(ctx, handle, counter, data),
-                    (128, 128) => decrypt_aes_ctr_gen::<Aes128Ctr128>(ctx, handle, counter, data),
-                    (192, 32) => decrypt_aes_ctr_gen::<Aes192Ctr32>(ctx, handle, counter, data),
-                    (192, 64) => decrypt_aes_ctr_gen::<Aes192Ctr64>(ctx, handle, counter, data),
-                    (192, 128) => decrypt_aes_ctr_gen::<Aes192Ctr128>(ctx, handle, counter, data),
-                    (256, 32) => decrypt_aes_ctr_gen::<Aes256Ctr32>(ctx, handle, counter, data),
-                    (256, 64) => decrypt_aes_ctr_gen::<Aes256Ctr64>(ctx, handle, counter, data),
-                    (256, 128) => decrypt_aes_ctr_gen::<Aes256Ctr128>(ctx, handle, counter, data),
-                    _ => unreachable!(), // 'length' has already been sanitized.
-                }
+                let mut variant = AesCtrVariant::new(length, *encryption_length, handle, counter)
+                    .or_throw(ctx)?;
+                variant.decrypt(data).or_throw(ctx)
             } else {
                 algorithm_missmatch_error(ctx)
             }
@@ -97,25 +75,4 @@ fn decrypt(
             }
         },
     }
-}
-
-fn decrypt_aes_cbc_gen<T>(ctx: &Ctx<'_>, key: &[u8], iv: &[u8], data: &[u8]) -> Result<Vec<u8>>
-where
-    T: KeyIvInit + BlockDecryptMut,
-{
-    T::new(key.into(), iv.into())
-        .decrypt_padded_vec_mut::<Pkcs7>(data)
-        .or_throw(ctx)
-}
-
-fn decrypt_aes_ctr_gen<T>(ctx: &Ctx<'_>, key: &[u8], counter: &[u8], data: &[u8]) -> Result<Vec<u8>>
-where
-    T: KeyIvInit + StreamCipher,
-{
-    let mut cipher = T::new(key.into(), counter.into());
-
-    let mut plaintext = data.to_vec();
-    cipher.try_apply_keystream(&mut plaintext).or_throw(ctx)?;
-
-    Ok(plaintext)
 }

--- a/modules/llrt_crypto/src/subtle/encrypt.rs
+++ b/modules/llrt_crypto/src/subtle/encrypt.rs
@@ -1,25 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use aes::cipher::{block_padding::Pkcs7, typenum::U12, KeyIvInit};
+use aes::cipher::typenum::U12;
 use aes_gcm::Nonce;
-use ctr::cipher::{BlockEncryptMut, StreamCipher};
 use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
 use rquickjs::{ArrayBuffer, Class, Ctx, Result};
 use rsa::rand_core::OsRng;
 
-use crate::subtle::{
-    Aes128Ctr128, Aes128Ctr32, Aes128Ctr64, Aes192Ctr128, Aes192Ctr32, Aes192Ctr64, Aes256Ctr128,
-    Aes256Ctr32, Aes256Ctr64, CryptoKey,
-};
-
 use super::{
     algorithm_missmatch_error, encryption_algorithm::EncryptionAlgorithm,
-    key_algorithm::KeyAlgorithm, rsa_private_key, AesGcmVariant,
+    key_algorithm::KeyAlgorithm, rsa_private_key, AesCbcEncVariant, AesCtrVariant, AesGcmVariant,
+    CryptoKey,
 };
-
-type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
-type Aes192CbcEnc = cbc::Encryptor<aes::Aes192>;
-type Aes256CbcEnc = cbc::Encryptor<aes::Aes256>;
 
 pub async fn subtle_encrypt<'js>(
     ctx: Ctx<'js>,
@@ -44,12 +35,8 @@ fn encrypt(
     match algorithm {
         EncryptionAlgorithm::AesCbc { iv } => {
             if let KeyAlgorithm::Aes { length } = key.algorithm {
-                match length {
-                    128 => encrypt_aes_cbc_gen::<Aes128CbcEnc>(ctx, handle, iv, data),
-                    192 => encrypt_aes_cbc_gen::<Aes192CbcEnc>(ctx, handle, iv, data),
-                    256 => encrypt_aes_cbc_gen::<Aes256CbcEnc>(ctx, handle, iv, data),
-                    _ => unreachable!(), // 'length' has already been sanitized.
-                }
+                let variant = AesCbcEncVariant::new(length, handle, iv).or_throw(ctx)?;
+                Ok(variant.encrypt(data))
             } else {
                 algorithm_missmatch_error(ctx)
             }
@@ -57,18 +44,9 @@ fn encrypt(
         EncryptionAlgorithm::AesCtr { counter, length } => {
             let encryption_length = length;
             if let KeyAlgorithm::Aes { length } = key.algorithm {
-                match (length, encryption_length) {
-                    (128, 32) => encrypt_aes_ctr_gen::<Aes128Ctr32>(ctx, handle, counter, data),
-                    (128, 64) => encrypt_aes_ctr_gen::<Aes128Ctr64>(ctx, handle, counter, data),
-                    (128, 128) => encrypt_aes_ctr_gen::<Aes128Ctr128>(ctx, handle, counter, data),
-                    (192, 32) => encrypt_aes_ctr_gen::<Aes192Ctr32>(ctx, handle, counter, data),
-                    (192, 64) => encrypt_aes_ctr_gen::<Aes192Ctr64>(ctx, handle, counter, data),
-                    (192, 128) => encrypt_aes_ctr_gen::<Aes192Ctr128>(ctx, handle, counter, data),
-                    (256, 32) => encrypt_aes_ctr_gen::<Aes256Ctr32>(ctx, handle, counter, data),
-                    (256, 64) => encrypt_aes_ctr_gen::<Aes256Ctr64>(ctx, handle, counter, data),
-                    (256, 128) => encrypt_aes_ctr_gen::<Aes256Ctr128>(ctx, handle, counter, data),
-                    _ => unreachable!(), // 'length' has already been sanitized.
-                }
+                let mut variant = AesCtrVariant::new(length, *encryption_length, handle, counter)
+                    .or_throw(ctx)?;
+                variant.encrypt(data).or_throw(ctx)
             } else {
                 algorithm_missmatch_error(ctx)
             }
@@ -101,23 +79,4 @@ fn encrypt(
             }
         },
     }
-}
-
-fn encrypt_aes_cbc_gen<T>(_ctx: &Ctx<'_>, key: &[u8], iv: &[u8], data: &[u8]) -> Result<Vec<u8>>
-where
-    T: KeyIvInit + BlockEncryptMut,
-{
-    Ok(T::new(key.into(), iv.into()).encrypt_padded_vec_mut::<Pkcs7>(data))
-}
-
-fn encrypt_aes_ctr_gen<T>(ctx: &Ctx<'_>, key: &[u8], counter: &[u8], data: &[u8]) -> Result<Vec<u8>>
-where
-    T: KeyIvInit + StreamCipher,
-{
-    let mut cipher = T::new(key.into(), counter.into());
-
-    let mut ciphertext = data.to_vec();
-    cipher.try_apply_keystream(&mut ciphertext).or_throw(ctx)?;
-
-    Ok(ciphertext)
 }


### PR DESCRIPTION
### Description of changes

We created the following enum types and moved more of the implementation into them:
- AesCbcEncVariant
- AesCbcDecVariant
- AesCtrVariant

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
