### PR TITLE
fix(crypto): fix a usage error in RSA-OAEP

### DIFF
--- a/API.md
+++ b/API.md
@@ -62,7 +62,7 @@ Everything else inherited from [Uint8Array](https://developer.mozilla.org/en-US/
 
 [subtle.encrypt](https://nodejs.org/api/webcrypto.html#subtleencryptalgorithm-key-data)
 
-[subtle.exportKey](hthttps://nodejs.org/api/webcrypto.html#subtleexportkeyformat-key)
+[subtle.exportKey](https://nodejs.org/api/webcrypto.html#subtleexportkeyformat-key)
 
 [subtle.generateKey](https://nodejs.org/api/webcrypto.html#subtlegeneratekeyalgorithm-extractable-keyusages)
 
@@ -70,7 +70,7 @@ Everything else inherited from [Uint8Array](https://developer.mozilla.org/en-US/
 
 [subtle.sign](https://nodejs.org/api/webcrypto.html#subtlesignalgorithm-key-data)
 
-[subtle.verify](hthttps://nodejs.org/api/webcrypto.html#subtleverifyalgorithm-key-signature-datah)
+[subtle.verify](https://nodejs.org/api/webcrypto.html#subtleverifyalgorithm-key-signature-datah)
 
 ## events
 

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -237,7 +237,7 @@ impl KeyAlgorithm {
             },
             "RSA-OAEP" | "RSA-PSS" | "RSASSA-PKCS1-v1_5" => {
                 if !matches!(mode, KeyAlgorithmMode::Import) {
-                    if name == "RSA-PSS" {
+                    if name == "RSA-OAEP" {
                         Self::classify_and_check_usages(
                             ctx,
                             name_ref,

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -71,7 +71,6 @@ pub enum KeyAlgorithm {
     Ec {
         curve: EllipticCurve,
     },
-    X25519,
     Ed25519,
     Hmac {
         hash: ShaAlgorithm,
@@ -82,6 +81,7 @@ pub enum KeyAlgorithm {
         public_exponent: Rc<Box<[u8]>>,
         hash: ShaAlgorithm,
     },
+    X25519,
     Derive(KeyDerivation),
     HkdfImport,
     Pbkdf2Import,
@@ -114,32 +114,6 @@ impl KeyAlgorithm {
         let name_ref = name.as_str();
         let mut is_symmetric = false;
         let algorithm = match name_ref {
-            "Ed25519" => {
-                if !matches!(mode, KeyAlgorithmMode::Import) {
-                    Self::classify_and_check_signature_usages(
-                        ctx,
-                        name_ref,
-                        &usages,
-                        is_symmetric,
-                        &mut private_usages,
-                        &mut public_usages,
-                    )?;
-                }
-                KeyAlgorithm::Ed25519
-            },
-            "X25519" => {
-                if !matches!(mode, KeyAlgorithmMode::Import) {
-                    Self::classify_and_check_symmetric_usages(
-                        ctx,
-                        name_ref,
-                        &usages,
-                        is_symmetric,
-                        &mut private_usages,
-                        &mut public_usages,
-                    )?;
-                }
-                KeyAlgorithm::X25519
-            },
             "AES-CBC" | "AES-CTR" | "AES-GCM" | "AES-KW" => {
                 is_symmetric = true;
                 if name_ref == "AES-KW" {
@@ -215,7 +189,19 @@ impl KeyAlgorithm {
                 }
                 KeyAlgorithm::Ec { curve }
             },
-
+            "Ed25519" => {
+                if !matches!(mode, KeyAlgorithmMode::Import) {
+                    Self::classify_and_check_signature_usages(
+                        ctx,
+                        name_ref,
+                        &usages,
+                        is_symmetric,
+                        &mut private_usages,
+                        &mut public_usages,
+                    )?;
+                }
+                KeyAlgorithm::Ed25519
+            },
             "HMAC" => {
                 is_symmetric = true;
                 Self::classify_and_check_usages(
@@ -278,6 +264,19 @@ impl KeyAlgorithm {
                     hash,
                 }
             },
+            "X25519" => {
+                if !matches!(mode, KeyAlgorithmMode::Import) {
+                    Self::classify_and_check_symmetric_usages(
+                        ctx,
+                        name_ref,
+                        &usages,
+                        is_symmetric,
+                        &mut private_usages,
+                        &mut public_usages,
+                    )?;
+                }
+                KeyAlgorithm::X25519
+            },
             "HKDF" => match mode {
                 KeyAlgorithmMode::Import => KeyAlgorithm::HkdfImport,
                 KeyAlgorithmMode::Derive => {
@@ -297,7 +296,6 @@ impl KeyAlgorithm {
                     return algorithm_not_supported_error(ctx);
                 },
             },
-
             "PBKDF2" => match mode {
                 KeyAlgorithmMode::Import => KeyAlgorithm::Pbkdf2Import,
                 KeyAlgorithmMode::Derive => {


### PR DESCRIPTION
### Description of changes

- Fixed a bug in generateKey where the usage judgment for RSA-OAEP and RSA-PSS was reversed.
- In addition, the order of conditional judgments has been fine-tuned.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
