### PR TITLE
Add support for decoding URL safe base64 encoded strings

### DIFF
--- a/libs/llrt_encoding/src/lib.rs
+++ b/libs/llrt_encoding/src/lib.rs
@@ -138,7 +138,16 @@ pub fn bytes_to_b64_string(bytes: &[u8]) -> String {
 }
 
 pub fn bytes_from_b64(bytes: &[u8]) -> Result<Vec<u8>, String> {
-    base64_simd::forgiving_decode_to_vec(bytes).map_err(|e| e.to_string())
+    let standard_b64_bytes: Vec<u8> = bytes
+        .iter()
+        .map(|b| match b {
+            b'-' => b'+',
+            b'_' => b'/',
+            _ => *b,
+        })
+        .collect();
+
+    base64_simd::forgiving_decode_to_vec(&standard_b64_bytes).map_err(|e| e.to_string())
 }
 
 pub fn bytes_to_b64(bytes: &[u8]) -> Vec<u8> {

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -81,12 +81,32 @@ describe("Buffer.from", () => {
   it("should create a buffer from a string with base64 encoding", () => {
     const input = "SGVsbG8sIHdvcmxkIQ==";
     const buffer = Buffer.from(input, "base64");
-
     expect(buffer.toString()).toEqual("Hello, world!");
 
     const input2 = "SGVsbG8sIHdvcmxkIQ";
     const buffer2 = Buffer.from(input2, "base64");
     expect(buffer2.toString()).toEqual("Hello, world!");
+  });
+
+  it("should create a buffer from a string with base64 encoding that contains / or +", () => {
+    const input = "PD8+MTIz";
+    const buffer = Buffer.from(input, "base64");
+    expect(buffer.toString()).toEqual("<?>123");
+
+    const input3 = "PD8/PjEyMw==";
+    const buffer3 = Buffer.from(input3, "base64");
+    expect(buffer3.toString()).toEqual("<??>123");
+  });
+
+  // https://en.wikipedia.org/wiki/Base64#URL_applications
+  it("should create a buffer from a string with URL safe base64 encoding that contains _ or -", () => {
+    const input = "PD8-MTIz";
+    const buffer = Buffer.from(input, "base64");
+    expect(buffer.toString()).toEqual("<?>123");
+
+    const input3 = "PD8_PjEyMw";
+    const buffer3 = Buffer.from(input3, "base64");
+    expect(buffer3.toString()).toEqual("<??>123");
   });
 
   it("should create a buffer from a string with hex encoding", () => {


### PR DESCRIPTION
### Issue # (if available)

https://github.com/awslabs/llrt/issues/773

### Description of changes

This PR updates `Buffer.from(str, "base64")` to also support decoding [URL safe base64](https://en.wikipedia.org/wiki/Base64#URL_applications) encoded strings to make the implementation more consistent with Node's.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
