### PR TITLE
fix: update React DOM to use edge

### DIFF
--- a/example/functions/src/ssr.ts
+++ b/example/functions/src/ssr.ts
@@ -1,6 +1,6 @@
 import fs from "fs/promises";
 import App from "./react/App";
-import ReactDOMServer from "react-dom/server";
+import ReactDOMServer from "react-dom/server.edge";
 
 import React from "react";
 import API from "./api";


### PR DESCRIPTION

### Issue # (if available)

Closes #769

### Description of changes

async hooks won't be supported and are discouraged, the edge version of React DOM doesn't use async hooks.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
