### PR TITLE
fix(core): fix incompatibilities caused by the latest cargo fix

### DIFF
--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -395,7 +395,7 @@ fn node_modules_paths(start: &str) -> Vec<Box<str>> {
 
     // Iterate through parent directories
     while let Some(dir) = current {
-        if dir.file_name().map_or(false, |name| name != "node_modules") {
+        if dir.file_name().is_some_and(|name| name != "node_modules") {
             let mut node_modules = dir.to_path_buf();
             node_modules.push("node_modules");
             dirs.push(Box::from(node_modules.to_string_lossy()));

--- a/modules/llrt_child_process/src/lib.rs
+++ b/modules/llrt_child_process/src/lib.rs
@@ -355,9 +355,9 @@ impl<'js> ChildProcess<'js> {
     }
 }
 
-async fn wait_for_process<'js>(
+async fn wait_for_process(
     mut child: Child,
-    ctx: &Ctx<'js>,
+    ctx: &Ctx<'_>,
     mut kill_signal_rx: Receiver<Option<i32>>,
     exit_code: &mut Option<i32>,
     exit_signal: &mut Option<i32>,

--- a/modules/llrt_net/src/lib.rs
+++ b/modules/llrt_net/src/lib.rs
@@ -86,7 +86,7 @@ enum Listener {
 }
 
 impl Listener {
-    async fn accept<'js>(&self, ctx: &Ctx<'js>) -> Result<NetStream> {
+    async fn accept(&self, ctx: &Ctx<'_>) -> Result<NetStream> {
         match self {
             Listener::Tcp(tcp) => tcp
                 .accept()
@@ -119,8 +119,8 @@ fn get_address_parts(
     ))
 }
 
-async fn rw_join<'js>(
-    ctx: &Ctx<'js>,
+async fn rw_join(
+    ctx: &Ctx<'_>,
     readable_done: Receiver<bool>,
     writable_done: Receiver<bool>,
 ) -> Result<bool> {


### PR DESCRIPTION
### Description of changes

After applying the latest rust toolchain, we found new incompatibilities and have fixed them.

```
% rustup update          
info: syncing channel updates for 'stable-aarch64-apple-darwin'
info: syncing channel updates for 'nightly-aarch64-apple-darwin'
info: checking for self-update

   stable-aarch64-apple-darwin unchanged - rustc 1.84.0 (9fc6b4312 2025-01-07)
  nightly-aarch64-apple-darwin unchanged - rustc 1.86.0-nightly (824759493 2025-01-09)
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
