### PR TITLE
fix(core): fix a bug where a package's code could not load its own package

### DIFF
--- a/fixtures/node_modules/elem-react-dom/cjs/react-dom-server.edge.development.js
+++ b/fixtures/node_modules/elem-react-dom/cjs/react-dom-server.edge.development.js
@@ -1,0 +1,6 @@
+"use strict";
+
+(function () {
+    var ReactDOM = require("elem-react-dom");
+    exports.name = "react-dom/server.edge";
+})();

--- a/fixtures/node_modules/elem-react-dom/cjs/react-dom.development.js
+++ b/fixtures/node_modules/elem-react-dom/cjs/react-dom.development.js
@@ -1,0 +1,5 @@
+"use strict";
+
+(function () {
+    exports.name = "react-dom";
+})();

--- a/fixtures/node_modules/elem-react-dom/index.js
+++ b/fixtures/node_modules/elem-react-dom/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./cjs/react-dom.development.js');

--- a/fixtures/node_modules/elem-react-dom/package.json
+++ b/fixtures/node_modules/elem-react-dom/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "elem-react-dom",
+    "main": "index.js",
+    "exports": {
+        ".": {
+            "default": "./index.js"
+        },
+        "./server.edge": {
+            "default": "./server.edge.js"
+        }
+    }
+}

--- a/fixtures/node_modules/elem-react-dom/server.edge.js
+++ b/fixtures/node_modules/elem-react-dom/server.edge.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./cjs/react-dom-server.edge.development.js');

--- a/fixtures/test_modules/test-react-dom.js
+++ b/fixtures/test_modules/test-react-dom.js
@@ -1,0 +1,7 @@
+const assert = require("assert");
+
+import * as dom1 from "elem-react-dom/server.edge";
+assert.ok(dom1.name == "react-dom/server.edge");
+
+const dom2 = require("elem-react-dom/server.edge");
+assert.ok(dom2.name == "react-dom/server.edge");

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -168,7 +168,7 @@ pub fn require_resolve<'a>(
     // 5. LOAD_PACKAGE_SELF(X, dirname(Y))
     if let Ok(Some(path)) = load_package_self(ctx, x, &dirname_y, is_esm) {
         trace!("+- Resolved by `LOAD_PACKAGE_SELF`: {}\n", path);
-        return to_abs_path(path.into());
+        return Ok(path.into());
     }
 
     // 6. LOAD_NODE_MODULES(X, dirname(Y))

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -433,7 +433,7 @@ fn load_package_imports(ctx: &Ctx<'_>, x: &str, dir: &str) -> Result<Option<Stri
         if let Some(module_path) = package_imports_resolve(&package_json, x) {
             trace!("|  load_package_imports(6): {}", module_path);
             let dir = path.as_ref().trim_end_matches("package.json");
-            let module_path = to_abs_path(correct_extensions([dir, module_path].concat()))?;
+            let module_path = correct_extensions([dir, module_path].concat());
             return Ok(Some(module_path.into()));
         }
     };

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -534,7 +534,7 @@ fn load_package_self(ctx: &Ctx<'_>, x: &str, dir: &str, is_esm: bool) -> Result<
     // 1. Find the closest package scope SCOPE to DIR.
     let mut package_json_file: Vec<u8>;
     let package_json: BorrowedValue;
-    match find_the_closest_package_scope(dir) {
+    let package_json_path: Box<str> = match find_the_closest_package_scope(dir) {
         // 2. If no scope was found, return.
         None => {
             return Ok(None);
@@ -552,6 +552,7 @@ fn load_package_self(ctx: &Ctx<'_>, x: &str, dir: &str, is_esm: bool) -> Result<
                     return Ok(None);
                 }
             }
+            path
         },
     };
     // 5. let MATCH = PACKAGE_EXPORTS_RESOLVE(pathToFileURL(SCOPE),
@@ -560,7 +561,9 @@ fn load_package_self(ctx: &Ctx<'_>, x: &str, dir: &str, is_esm: bool) -> Result<
     // 6. RESOLVE_ESM_MATCH(MATCH)
     if let Ok((path, _)) = package_exports_resolve(&package_json, &name, is_esm) {
         trace!("|  load_package_self(2.c): {}", path);
-        return Ok(Some(path.into()));
+        let dir = package_json_path.trim_end_matches("package.json");
+        let module_path = to_abs_path(correct_extensions([dir, path].concat()))?;
+        return Ok(Some(module_path.into()));
     }
 
     Ok(None)

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -503,10 +503,11 @@ fn load_package_exports<'a>(
 
     if let Some(sub_module) = sub_module {
         if package_json.get_str("type") != Some("module") {
+            let sub_module = to_abs_path(sub_module.into())?;
             if is_esm {
                 return Ok([CJS_LOADER_PREFIX, &sub_module].concat().into());
             }
-            return Ok(sub_module.into());
+            return Ok(sub_module);
         }
         return Ok(sub_module.into());
     }

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -194,7 +194,7 @@ fn resolved_by_bytecode_cache(x: Cow<'_, str>) -> Result<Cow<'_, str>> {
 
 fn resolved_by_file_exists(path: Cow<'_, str>) -> Result<Cow<'_, str>> {
     trace!("+- Resolved by `FILE`: {}\n", path);
-    Ok(path)
+    to_abs_path(path)
 }
 
 fn to_abs_path(path: Cow<'_, str>) -> Result<Cow<'_, str>> {

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -168,7 +168,7 @@ pub fn require_resolve<'a>(
     // 5. LOAD_PACKAGE_SELF(X, dirname(Y))
     if let Ok(Some(path)) = load_package_self(ctx, x, &dirname_y, is_esm) {
         trace!("+- Resolved by `LOAD_PACKAGE_SELF`: {}\n", path);
-        return Ok(path.into());
+        return to_abs_path(path.into());
     }
 
     // 6. LOAD_NODE_MODULES(X, dirname(Y))

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -194,7 +194,7 @@ fn resolved_by_bytecode_cache(x: Cow<'_, str>) -> Result<Cow<'_, str>> {
 
 fn resolved_by_file_exists(path: Cow<'_, str>) -> Result<Cow<'_, str>> {
     trace!("+- Resolved by `FILE`: {}\n", path);
-    to_abs_path(path)
+    Ok(path)
 }
 
 fn to_abs_path(path: Cow<'_, str>) -> Result<Cow<'_, str>> {

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -433,7 +433,7 @@ fn load_package_imports(ctx: &Ctx<'_>, x: &str, dir: &str) -> Result<Option<Stri
         if let Some(module_path) = package_imports_resolve(&package_json, x) {
             trace!("|  load_package_imports(6): {}", module_path);
             let dir = path.as_ref().trim_end_matches("package.json");
-            let module_path = correct_extensions([dir, module_path].concat());
+            let module_path = to_abs_path(correct_extensions([dir, module_path].concat()))?;
             return Ok(Some(module_path.into()));
         }
     };
@@ -562,7 +562,7 @@ fn load_package_self(ctx: &Ctx<'_>, x: &str, dir: &str, is_esm: bool) -> Result<
     if let Ok((path, _)) = package_exports_resolve(&package_json, &name, is_esm) {
         trace!("|  load_package_self(2.c): {}", path);
         let dir = package_json_path.trim_end_matches("package.json");
-        let module_path = to_abs_path(correct_extensions([dir, path].concat()))?;
+        let module_path = correct_extensions([dir, path].concat());
         return Ok(Some(module_path.into()));
     }
 

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -143,6 +143,10 @@ it("require `uuid` module element", () => {
   _require(`${CWD}/fixtures/test_modules/test-uuid.js`);
 });
 
+it("require `react-dom` module element", () => {
+  _require(`${CWD}/fixtures/test_modules/test-react-dom.js`);
+});
+
 //create a test that spawns a subprocess and executes require.mjs from fixtures and captures stdout
 it("should handle blocking requires", (done) => {
   const proc = spawn(process.argv0, [`${CWD}/fixtures/require.mjs`]);


### PR DESCRIPTION
### Description of changes

For example, when `react-dom/server.edge` was called, this issue occurred because `react-dom` was required again inside the package.

```javascript
// reproduction.js
import * as dom from "react-dom/server.edge";
console.log(dom);
```

```
% llrt reproduction.js 
Error: IO Error: No such file or directory (os error 2)
  at <anonymous> (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/react-dom/cjs/react-dom-server.edge.development.js:7330:18)
      at <anonymous> (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/react-dom/cjs/react-dom-server.edge.development.js:8975:3)
      at <anonymous> (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/react-dom/server.edge.js:9:7)

% bun reproduction.js
Module {
  default: {
    version: "19.0.0",
    renderToReadableStream: [Function],
    renderToString: [Function],
    renderToStaticMarkup: [Function],
  },
  renderToReadableStream: [Function],
  renderToStaticMarkup: [Function],
  renderToString: [Function],
  version: "19.0.0",
}
```

This PR fixes this by storing the correct path when referencing self, to avoid IO errors.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
