### PR TITLE
Fix readdir ending with slash

### DIFF
--- a/modules/llrt_fs/src/read_dir.rs
+++ b/modules/llrt_fs/src/read_dir.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
-use std::{
-    fs::Metadata,
-    path::{PathBuf, MAIN_SEPARATOR_STR},
-};
+use std::{fs::Metadata, path::PathBuf};
 
 use llrt_path::{ends_with_sep, CURRENT_DIR_STR};
 use llrt_utils::fs::DirectoryWalker;
@@ -172,7 +169,7 @@ fn process_options_and_create_directory_walker(
             .unwrap_or_default();
     };
 
-    if ends_with_sep(&path) {
+    if ends_with_sep(path) {
         path.pop();
     }
 

--- a/modules/llrt_fs/src/read_dir.rs
+++ b/modules/llrt_fs/src/read_dir.rs
@@ -7,7 +7,7 @@ use std::{
     path::{PathBuf, MAIN_SEPARATOR_STR},
 };
 
-use llrt_path::CURRENT_DIR_STR;
+use llrt_path::{ends_with_sep, CURRENT_DIR_STR};
 use llrt_utils::fs::DirectoryWalker;
 use rquickjs::{
     atom::PredefinedAtom, prelude::Opt, Array, Class, Ctx, IntoJs, Object, Result, Value,
@@ -172,7 +172,7 @@ fn process_options_and_create_directory_walker(
             .unwrap_or_default();
     };
 
-    if path.ends_with(MAIN_SEPARATOR_STR) {
+    if ends_with_sep(&path) {
         path.pop();
     }
 

--- a/modules/llrt_fs/src/read_dir.rs
+++ b/modules/llrt_fs/src/read_dir.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
-use std::{fs::Metadata, path::PathBuf};
+use std::{
+    fs::Metadata,
+    path::{PathBuf, MAIN_SEPARATOR_STR},
+};
 
-use llrt_path::{is_absolute, CURRENT_DIR_STR};
+use llrt_path::CURRENT_DIR_STR;
 use llrt_utils::fs::DirectoryWalker;
 use rquickjs::{
     atom::PredefinedAtom, prelude::Opt, Array, Class, Ctx, IntoJs, Object, Result, Value,
@@ -169,19 +172,16 @@ fn process_options_and_create_directory_walker(
             .unwrap_or_default();
     };
 
+    if path.ends_with(MAIN_SEPARATOR_STR) {
+        path.pop();
+    }
+
     let skip_root_pos = {
         match path.as_str() {
             // . | ./
-            "." | CURRENT_DIR_STR => CURRENT_DIR_STR.len(),
-            // ./path
-            _ if path.starts_with(CURRENT_DIR_STR) => path.len() + 1,
+            "." | CURRENT_DIR_STR => path.len(),
             // path
-            _ => {
-                if !is_absolute(path) {
-                    path.insert_str(0, CURRENT_DIR_STR);
-                }
-                path.len() + 1
-            },
+            _ => path.len() + 1,
         }
     };
 

--- a/modules/llrt_path/src/lib.rs
+++ b/modules/llrt_path/src/lib.rs
@@ -487,12 +487,12 @@ fn starts_with_sep(path: &str) -> bool {
 }
 
 #[cfg(windows)]
-fn ends_with_sep(path: &str) -> bool {
+pub fn ends_with_sep(path: &str) -> bool {
     matches!(path.as_bytes().last().unwrap_or(&0), b'/' | b'\\')
 }
 
 #[cfg(not(windows))]
-fn ends_with_sep(path: &str) -> bool {
+pub fn ends_with_sep(path: &str) -> bool {
     path.ends_with(MAIN_SEPARATOR)
 }
 

--- a/tests/unit/fs.test.ts
+++ b/tests/unit/fs.test.ts
@@ -17,7 +17,18 @@ describe("readdir", () => {
     expect(dir).toEqual([
       {
         name: "config.toml",
-        parentPath: IS_WINDOWS ? ".\\.cargo" : "./.cargo",
+        parentPath: ".cargo",
+      },
+    ]);
+    expect(dir[0].isFile()).toBeTruthy();
+  });
+
+  it("should read a directory with types", async () => {
+    const dir = await fs.readdir(".cargo/", { withFileTypes: true });
+    expect(dir).toEqual([
+      {
+        name: "config.toml",
+        parentPath: ".cargo",
       },
     ]);
     expect(dir[0].isFile()).toBeTruthy();
@@ -57,7 +68,7 @@ describe("readdirSync", () => {
     expect(dir).toEqual([
       {
         name: "config.toml",
-        parentPath: IS_WINDOWS ? ".\\.cargo" : "./.cargo",
+        parentPath: ".cargo",
       },
     ]);
     expect(dir[0].isFile()).toBeTruthy();


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/786

### Description of changes

Pops last char if ending with separator.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
