### PR TITLE
(perf): Fetch improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,6 +1844,7 @@ dependencies = [
  "rustls",
  "ryu",
  "tokio",
+ "tower-service",
  "tracing",
  "webpki-roots",
  "wiremock",

--- a/llrt_core/src/http.rs
+++ b/llrt_core/src/http.rs
@@ -1,4 +1,4 @@
-use std::{env, fs::File, io, result::Result as StdResult, time::Duration};
+use std::{env, fs::File, io, result::Result as StdResult};
 
 use llrt_modules::http::HttpVersion;
 use rustls::{pki_types::CertificateDer, version, SupportedProtocolVersion};
@@ -8,7 +8,7 @@ use crate::environment;
 
 pub fn init() -> StdResult<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some(pool_idle_timeout) = build_pool_idle_timeout() {
-        llrt_modules::http::set_pool_idle_timeout(pool_idle_timeout);
+        llrt_modules::http::set_pool_idle_timeout_seconds(pool_idle_timeout);
     }
 
     if let Some(extra_ca_certs) = buid_extra_ca_certs()? {
@@ -22,7 +22,7 @@ pub fn init() -> StdResult<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
-fn build_pool_idle_timeout() -> Option<Duration> {
+fn build_pool_idle_timeout() -> Option<u64> {
     let Ok(env_value) = env::var(environment::ENV_LLRT_NET_POOL_IDLE_TIMEOUT) else {
         return None;
     };
@@ -36,7 +36,7 @@ fn build_pool_idle_timeout() -> Option<Duration> {
             environment::ENV_LLRT_NET_POOL_IDLE_TIMEOUT
         )
     }
-    Some(Duration::from_secs(pool_idle_timeout))
+    Some(pool_idle_timeout)
 }
 
 fn buid_extra_ca_certs() -> StdResult<Option<Vec<CertificateDer<'static>>>, io::Error> {
@@ -64,7 +64,7 @@ fn build_tls_versions() -> Vec<&'static SupportedProtocolVersion> {
 
 fn build_http_version() -> HttpVersion {
     match env::var(environment::ENV_LLRT_HTTP_VERSION).as_deref() {
-        Ok("1.1") => HttpVersion::Http1_1,
-        _ => HttpVersion::Http2,
+        Ok("2") => HttpVersion::Http2,
+        _ => HttpVersion::Http1_1,
     }
 }

--- a/llrt_core/src/vm.rs
+++ b/llrt_core/src/vm.rs
@@ -158,7 +158,7 @@ impl Vm {
         let source = [
             r#"import(""#,
             &filename.as_ref().replace('\\', "/"),
-            r#"").catch((e) => {{console.error(e);process.exit(1)}})"#,
+            r#"").catch((e) => {console.error(e);process.exit(1)})"#,
         ]
         .concat();
 

--- a/modules/llrt_http/Cargo.toml
+++ b/modules/llrt_http/Cargo.toml
@@ -52,6 +52,7 @@ ryu = "1"
 tokio = "1"
 tracing = "0.1"
 webpki-roots = "0.26"
+tower-service = "0.3.3"
 
 [dev-dependencies]
 llrt_compression = { version = "0.4.0-beta", path = "../../libs/llrt_compression" }

--- a/modules/llrt_http/src/cached_dns_resolver.rs
+++ b/modules/llrt_http/src/cached_dns_resolver.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::future::Future;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{self, Poll};
+use std::time::{Duration, Instant};
+use std::{fmt, io, vec};
+
+use hyper_util::client::legacy::connect::dns::Name;
+use hyper_util::client::legacy::connect::HttpConnector;
+use tokio::sync::Semaphore;
+use tokio::{sync::RwLock, task::JoinHandle};
+use tower_service::Service;
+
+#[derive(Clone)]
+struct CacheEntry {
+    timestamp: Instant,
+    gai_addrs: GaiAddrs,
+}
+
+struct CacheLock {
+    semaphore: Arc<Semaphore>,
+    entry: Option<CacheEntry>,
+}
+
+/// A resolver using blocking `getaddrinfo` calls in a threadpool.
+#[derive(Clone)]
+pub struct CachedDnsResolver {
+    cache: Arc<RwLock<HashMap<Name, Arc<CacheLock>>>>,
+    cache_duration: Duration,
+}
+
+/// An iterator of IP addresses returned from `getaddrinfo`.
+#[derive(Clone)]
+pub struct GaiAddrs {
+    inner: SocketAddrs,
+}
+
+/// A future to resolve a name returned by `GaiResolver`.
+pub struct GaiFuture {
+    inner: JoinHandle<Result<GaiAddrs, io::Error>>,
+}
+
+/// Error indicating a given string was not a valid domain name.
+#[derive(Debug)]
+pub struct InvalidNameError(());
+
+impl fmt::Display for InvalidNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Not a valid domain name")
+    }
+}
+
+impl Error for InvalidNameError {}
+
+impl Default for CachedDnsResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CachedDnsResolver {
+    pub fn new() -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            cache_duration: Duration::from_secs(300),
+        }
+    }
+
+    pub fn into_http_connector(self) -> HttpConnector<Self> {
+        HttpConnector::<Self>::new_with_resolver(self)
+    }
+}
+
+impl Service<Name> for CachedDnsResolver {
+    type Response = GaiAddrs;
+    type Error = io::Error;
+    type Future = GaiFuture;
+
+    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, name: Name) -> Self::Future {
+        let cache = self.cache.clone();
+        let duration = self.cache_duration;
+        let handle = tokio::task::spawn(async move {
+            let entry = {
+                let cache_read = cache.read().await;
+                if let Some(entry) = cache_read.get(&name) {
+                    entry.clone()
+                } else {
+                    drop(cache_read); // Release read lock before acquiring write lock
+                    let mut cache_write = cache.write().await;
+                    cache_write
+                        .entry(name.clone())
+                        .or_insert_with(|| {
+                            Arc::new(CacheLock {
+                                semaphore: Arc::new(Semaphore::new(5)),
+                                entry: None,
+                            })
+                        })
+                        .clone()
+                }
+            };
+
+            if let Some(cache) = &entry.entry {
+                if cache.timestamp.elapsed() < duration {
+                    return Ok(cache.gai_addrs.clone());
+                }
+            }
+
+            let lock = entry.semaphore.acquire().await.unwrap();
+
+            if let Some(entry) = cache.read().await.get(&name).and_then(|v| v.entry.clone()) {
+                return Ok(entry.gai_addrs.clone());
+            }
+
+            let name2 = name.clone();
+
+            let address = tokio::task::spawn_blocking(move || {
+                (name2.as_str(), 0)
+                    .to_socket_addrs()
+                    .map(|i| SocketAddrs { iter: i })
+            })
+            .await;
+
+            let addres = match address {
+                Ok(Ok(addrs)) => {
+                    let gai_addrs = GaiAddrs { inner: addrs };
+
+                    let mut write = cache.write().await;
+                    write.insert(
+                        name,
+                        Arc::new(CacheLock {
+                            semaphore: Arc::new(Semaphore::new(5)),
+                            entry: Some(CacheEntry {
+                                timestamp: Instant::now(),
+                                gai_addrs: gai_addrs.clone(),
+                            }),
+                        }),
+                    );
+                    Ok(gai_addrs)
+                },
+                Ok(Err(err)) => Err(err),
+                Err(join_err) => {
+                    if join_err.is_cancelled() {
+                        Err(io::Error::new(io::ErrorKind::Interrupted, join_err))
+                    } else {
+                        panic!("gai background task failed: {:?}", join_err)
+                    }
+                },
+            };
+            drop(lock);
+            addres
+        });
+
+        GaiFuture { inner: handle }
+    }
+}
+
+impl fmt::Debug for CachedDnsResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("GaiResolver")
+    }
+}
+
+impl Future for GaiFuture {
+    type Output = Result<GaiAddrs, io::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner).poll(cx).map(|res| match res {
+            Ok(Ok(addrs)) => Ok(addrs),
+            Ok(Err(err)) => Err(err),
+            Err(join_err) => {
+                if join_err.is_cancelled() {
+                    Err(io::Error::new(io::ErrorKind::Interrupted, join_err))
+                } else {
+                    panic!("gai background task failed: {:?}", join_err)
+                }
+            },
+        })
+    }
+}
+
+impl fmt::Debug for GaiFuture {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("GaiFuture")
+    }
+}
+
+impl Drop for GaiFuture {
+    fn drop(&mut self) {
+        self.inner.abort();
+    }
+}
+
+impl Iterator for GaiAddrs {
+    type Item = SocketAddr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl fmt::Debug for GaiAddrs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("GaiAddrs")
+    }
+}
+
+#[derive(Clone)]
+pub struct SocketAddrs {
+    iter: vec::IntoIter<SocketAddr>,
+}
+
+impl Iterator for SocketAddrs {
+    type Item = SocketAddr;
+    #[inline]
+    fn next(&mut self) -> Option<SocketAddr> {
+        self.iter.next()
+    }
+}

--- a/modules/llrt_http/src/cached_dns_resolver.rs
+++ b/modules/llrt_http/src/cached_dns_resolver.rs
@@ -74,6 +74,8 @@ impl CachedDnsResolver {
     }
 }
 
+const DNS_PERMITS: usize = 5;
+
 impl Service<Name> for CachedDnsResolver {
     type Response = GaiAddrs;
     type Error = io::Error;
@@ -98,7 +100,7 @@ impl Service<Name> for CachedDnsResolver {
                         .entry(name.clone())
                         .or_insert_with(|| {
                             Arc::new(CacheLock {
-                                semaphore: Arc::new(Semaphore::new(5)),
+                                semaphore: Arc::new(Semaphore::new(DNS_PERMITS)),
                                 entry: None,
                             })
                         })
@@ -135,7 +137,7 @@ impl Service<Name> for CachedDnsResolver {
                     write.insert(
                         name,
                         Arc::new(CacheLock {
-                            semaphore: Arc::new(Semaphore::new(5)),
+                            semaphore: Arc::new(Semaphore::new(DNS_PERMITS)),
                             entry: Some(CacheEntry {
                                 timestamp: Instant::now(),
                                 gai_addrs: gai_addrs.clone(),

--- a/modules/llrt_http/src/fetch.rs
+++ b/modules/llrt_http/src/fetch.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use std::convert::Infallible;
+use std::sync::Arc;
 use std::{collections::HashSet, time::Instant};
 
 use bytes::Bytes;
@@ -19,6 +20,7 @@ use rquickjs::{
     Class, Coerced, Ctx, Exception, FromJs, Function, IntoJs, Object, Result, Value,
 };
 use tokio::select;
+use tokio::sync::Semaphore;
 
 use super::{blob::Blob, headers::Headers, response::Response, security::ensure_url_access};
 
@@ -28,14 +30,18 @@ pub(crate) fn init<C>(client: Client<C, BoxBody<Bytes, Infallible>>, globals: &O
 where
     C: Clone + Send + Sync + Connect + 'static,
 {
+    let connections = Arc::new(Semaphore::new(500));
+
     globals.set(
         "fetch",
         Func::from(Async(move |ctx, resource, args| {
             let client = client.clone();
+            let connections = connections.clone();
             let start = Instant::now();
             let options = get_fetch_options(&ctx, resource, args);
 
             async move {
+                let lock = connections.acquire().await;
                 let options = options?;
 
                 if let Some(data_url) = options.url.strip_prefix("data:") {
@@ -52,6 +58,7 @@ where
 
                 let mut redirect_count = 0;
                 let mut response_status = 0;
+                let mut retry_count = 0;
                 let res = loop {
                     let req = build_request(
                         &ctx,
@@ -65,13 +72,38 @@ where
 
                     let res = if let Some(abort_receiver) = &abort_receiver {
                         select! {
-                            res = client.request(req) => res.or_throw(&ctx)?,
+                            res = client.request(req) => res,
                             reason = abort_receiver.recv() => return Err(ctx.throw(reason))
                         }
                     } else {
-                        client.request(req).await.or_throw(&ctx)?
+                        client.request(req).await
+                    };
+                    let res = match res {
+                        Ok(res) => res,
+                        Err(err) => {
+                            let error =
+                                &format!("{:?}", err)["hyper_util::client::legacy::Error(".len()..];
+                            let max_retry_count = if error.starts_with("SendRequest") {
+                                2
+                            } else if error.starts_with("Connect") {
+                                if error.contains("dns error") {
+                                    0
+                                } else {
+                                    2
+                                }
+                            } else {
+                                0
+                            };
+
+                            if retry_count <= max_retry_count {
+                                retry_count += 1;
+                                continue;
+                            }
+                            return Err(err).or_throw(&ctx)?;
+                        },
                     };
 
+                    retry_count = 0;
                     match res.headers().get(HeaderName::from_static("location")) {
                         Some(location_headers) => {
                             if let Ok(location_str) = location_headers.to_str() {
@@ -95,6 +127,8 @@ where
 
                     response_status = res.status().as_u16();
                 };
+
+                drop(lock);
 
                 Response::from_incoming(
                     ctx,
@@ -201,7 +235,6 @@ fn build_request(
     if !detected_headers.contains("accept") {
         req = req.header("accept", "*/*");
     }
-
     req.body(BoxBody::new(
         body.map(|b| b.body.clone()).unwrap_or_default(),
     ))
@@ -640,7 +673,7 @@ mod tests {
 
                     let response_promise: Promise = fetch.call((url, options.clone()))?;
                     let response: Class<Response> = response_promise.into_future().await?;
-                    let mut response = response.borrow_mut();
+                    let response = response.borrow_mut();
                     let response_text = response.text(ctx.clone()).await?;
 
                     assert_eq!(response.status(), 200);
@@ -704,7 +737,7 @@ mod tests {
 
                     let response_promise: Promise = fetch.call((url, options.clone()))?;
                     let response: Class<Response> = response_promise.into_future().await?;
-                    let mut response = response.borrow_mut();
+                    let response = response.borrow_mut();
                     let response_text = response.text(ctx.clone()).await?;
 
                     assert_eq!(response_text, welcome_message);
@@ -717,7 +750,7 @@ mod tests {
 
                     let response_promise: Promise = fetch.call((url, options.clone()))?;
                     let response: Class<Response> = response_promise.into_future().await?;
-                    let mut response = response.borrow_mut();
+                    let response = response.borrow_mut();
                     let response_text = response.text(ctx.clone()).await?;
 
                     assert_eq!(response_text, welcome_message);
@@ -730,7 +763,7 @@ mod tests {
 
                     let response_promise: Promise = fetch.call((url, options.clone()))?;
                     let response: Class<Response> = response_promise.into_future().await?;
-                    let mut response = response.borrow_mut();
+                    let response = response.borrow_mut();
                     let response_text = response.text(ctx.clone()).await?;
 
                     assert_eq!(response_text, welcome_message);
@@ -743,7 +776,7 @@ mod tests {
 
                     let response_promise: Promise = fetch.call((url, options.clone()))?;
                     let response: Class<Response> = response_promise.into_future().await?;
-                    let mut response = response.borrow_mut();
+                    let response = response.borrow_mut();
                     let response_text = response.text(ctx.clone()).await?;
 
                     assert_eq!(response_text, welcome_message);

--- a/modules/llrt_http/src/fetch.rs
+++ b/modules/llrt_http/src/fetch.rs
@@ -81,6 +81,7 @@ where
                     let res = match res {
                         Ok(res) => res,
                         Err(err) => {
+                            //FIXME: Hyper does not currently the error kinds
                             let error =
                                 &format!("{:?}", err)["hyper_util::client::legacy::Error(".len()..];
                             let max_retry_count = if error.starts_with("SendRequest") {

--- a/modules/llrt_http/src/incoming.rs
+++ b/modules/llrt_http/src/incoming.rs
@@ -243,8 +243,8 @@ mod tests {
 
                         let response_promise: Promise = fetch.call((url, options.clone()))?;
                         let response: Class<Response> = response_promise.into_future().await?;
-                        let mut response = response.borrow_mut();
-                        let mut response2 = response.clone(ctx.clone()).unwrap();
+                        let response = response.borrow_mut();
+                        let response2 = response.clone(ctx.clone()).unwrap();
 
                         let (response_res, response2_res) =
                             tokio::join!(response.text(ctx.clone()), response2.text(ctx.clone()));
@@ -293,7 +293,7 @@ mod tests {
                         {
                             let response_promise: Promise = fetch.call((url, options.clone()))?;
                             let response: Class<Response> = response_promise.into_future().await?;
-                            let mut response = response.borrow_mut();
+                            let response = response.borrow_mut();
                             let _response2 = response.clone(ctx.clone()).unwrap();
                         }
 
@@ -333,8 +333,8 @@ mod tests {
 
                     let response_promise: Promise = fetch.call((url, options.clone()))?;
                     let response: Class<Response> = response_promise.into_future().await?;
-                    let mut response = response.borrow_mut();
-                    let mut response2 = response.clone(ctx.clone()).unwrap();
+                    let response = response.borrow_mut();
+                    let response2 = response.clone(ctx.clone()).unwrap();
 
                     let response_text = response.text(ctx.clone()).await.unwrap();
                     assert_eq!(response.status(), 200);

--- a/modules/llrt_http/src/lib.rs
+++ b/modules/llrt_http/src/lib.rs
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use std::convert::Infallible;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{io, sync::OnceLock, time::Duration};
 
 use bytes::Bytes;
+use cached_dns_resolver::CachedDnsResolver;
 use http_body_util::combinators::BoxBody;
 use hyper_rustls::HttpsConnector;
 use hyper_util::{
@@ -24,6 +26,7 @@ use self::{file::File, headers::Headers, request::Request, response::Response};
 
 mod blob;
 mod body;
+mod cached_dns_resolver;
 mod fetch;
 mod file;
 mod headers;
@@ -32,18 +35,14 @@ mod request;
 mod response;
 mod security;
 
-const DEFAULT_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
+static CONNECTION_POOL_IDLE_TIMEOUT: AtomicU64 = AtomicU64::new(15);
 
-static CONNECTION_POOL_IDLE_TIMEOUT: OnceLock<Duration> = OnceLock::new();
-
-pub fn set_pool_idle_timeout(timeout: Duration) {
-    _ = CONNECTION_POOL_IDLE_TIMEOUT.set(timeout);
+pub fn set_pool_idle_timeout_seconds(seconds: u64) {
+    CONNECTION_POOL_IDLE_TIMEOUT.store(seconds, Ordering::Relaxed);
 }
 
 fn get_pool_idle_timeout() -> Duration {
-    *CONNECTION_POOL_IDLE_TIMEOUT
-        .get()
-        .unwrap_or(&DEFAULT_CONNECTION_POOL_IDLE_TIMEOUT)
+    Duration::from_secs(CONNECTION_POOL_IDLE_TIMEOUT.load(Ordering::Relaxed))
 }
 
 static EXTRA_CA_CERTS: OnceLock<Vec<CertificateDer<'static>>> = OnceLock::new();
@@ -53,7 +52,12 @@ pub fn set_extra_ca_certs(certs: Vec<CertificateDer<'static>>) {
 }
 
 fn get_extra_ca_certs() -> Option<Vec<CertificateDer<'static>>> {
-    EXTRA_CA_CERTS.get().cloned()
+    let certs = EXTRA_CA_CERTS.get_or_init(Vec::new).clone();
+    if certs.is_empty() {
+        None
+    } else {
+        Some(certs)
+    }
 }
 
 static TLS_VERSIONS: OnceLock<Vec<&'static SupportedProtocolVersion>> = OnceLock::new();
@@ -63,7 +67,12 @@ pub fn set_tls_versions(versions: Vec<&'static SupportedProtocolVersion>) {
 }
 
 fn get_tls_versions() -> Option<Vec<&'static SupportedProtocolVersion>> {
-    TLS_VERSIONS.get().cloned()
+    let versions = TLS_VERSIONS.get_or_init(Vec::new).clone();
+    if versions.is_empty() {
+        None
+    } else {
+        Some(versions)
+    }
 }
 
 static TLS_CONFIG: Lazy<io::Result<ClientConfig>> = Lazy::new(|| {
@@ -79,20 +88,19 @@ static TLS_CONFIG: Lazy<io::Result<ClientConfig>> = Lazy::new(|| {
 
     let builder = ClientConfig::builder_with_provider(ring::default_provider().into());
 
-    Ok(match get_tls_versions() {
+    let client_config = match get_tls_versions() {
         Some(versions) => builder.with_protocol_versions(&versions),
         None => builder.with_safe_default_protocol_versions(),
     }
     .expect("TLS configuration failed")
     .with_root_certificates(root_certificates)
-    .with_no_client_auth())
+    .with_no_client_auth();
+    Ok(client_config)
 });
 
 #[derive(Debug, Clone, Copy)]
 pub enum HttpVersion {
-    #[cfg(feature = "http1")]
     Http1_1,
-    #[cfg(feature = "http2")]
     Http2,
 }
 
@@ -103,8 +111,12 @@ pub fn set_http_version(version: HttpVersion) {
 }
 
 fn get_http_version() -> HttpVersion {
-    HTTP_VERSION.get().cloned().unwrap_or({
-        #[cfg(feature = "http2")]
+    *HTTP_VERSION.get_or_init(|| {
+        #[cfg(any(feature = "http2", feature = "http1"))]
+        {
+            HttpVersion::Http1_1
+        }
+        #[cfg(all(not(feature = "http1"), feature = "http2"))]
         {
             HttpVersion::Http2
         }
@@ -119,7 +131,8 @@ fn get_http_version() -> HttpVersion {
     })
 }
 
-pub type HyperClient = Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, Infallible>>;
+pub type HyperClient =
+    Client<HttpsConnector<HttpConnector<CachedDnsResolver>>, BoxBody<Bytes, Infallible>>;
 pub static HTTP_CLIENT: Lazy<io::Result<HyperClient>> = Lazy::new(|| {
     let pool_idle_timeout = get_pool_idle_timeout();
 
@@ -132,11 +145,15 @@ pub static HTTP_CLIENT: Lazy<io::Result<HyperClient>> = Lazy::new(|| {
         .with_tls_config(maybe_tls_config?)
         .https_or_http();
 
+    let mut cache_dns_connector = CachedDnsResolver::new().into_http_connector();
+    cache_dns_connector.enforce_http(false);
+
     let https = match get_http_version() {
-        #[cfg(feature = "http1")]
-        HttpVersion::Http1_1 => builder.enable_http1().build(),
         #[cfg(feature = "http2")]
-        HttpVersion::Http2 => builder.enable_all_versions().build(),
+        HttpVersion::Http2 => builder
+            .enable_all_versions()
+            .wrap_connector(cache_dns_connector),
+        _ => builder.enable_http1().wrap_connector(cache_dns_connector),
     };
 
     Ok(Client::builder(TokioExecutor::new())

--- a/modules/llrt_http/src/response.rs
+++ b/modules/llrt_http/src/response.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     io::Read,
+    sync::{Mutex, MutexGuard},
     time::Instant,
 };
 
@@ -101,7 +102,22 @@ static STATUS_TEXTS: Lazy<HashMap<u16, &'static str>> = Lazy::new(|| {
 enum BodyVariant<'js> {
     Incoming(Option<hyper::Response<Incoming>>),
     Cloned(Option<hyper::Response<IncomingReceiver>>),
-    Provided(Value<'js>),
+    Provided(Option<Value<'js>>),
+    Empty,
+}
+
+#[rquickjs::class]
+pub struct Response<'js> {
+    body: Mutex<BodyVariant<'js>>,
+    content_encoding: Option<String>,
+    method: String,
+    url: String,
+    start: Instant,
+    status: u16,
+    status_text: Option<String>,
+    redirected: bool,
+    headers: Class<'js, Headers>,
+    abort_receiver: Option<mc_oneshot::Receiver<Value<'js>>>,
 }
 
 impl<'js> Response<'js> {
@@ -131,7 +147,8 @@ impl<'js> Response<'js> {
         let status = response.status();
 
         Ok(Self {
-            body: Some(BodyVariant::Incoming(Some(response))),
+            body: Mutex::new(BodyVariant::Incoming(Some(response))),
+            content_encoding,
             method,
             url,
             start,
@@ -139,17 +156,16 @@ impl<'js> Response<'js> {
             status_text: None,
             redirected,
             headers,
-            content_encoding,
             abort_receiver,
         })
     }
 
-    async fn take_bytes_body<T>(&mut self, ctx: &Ctx<'js>, body: T) -> Result<Vec<u8>>
+    async fn take_bytes_body<T>(&self, ctx: &Ctx<'js>, body: T) -> Result<Vec<u8>>
     where
         T: Body,
         T::Error: std::fmt::Display,
     {
-        let bytes = if let Some(abort_signal) = &self.abort_receiver {
+        let bytes = if let Some(abort_signal) = self.abort_receiver.as_ref() {
             select! {
                 err = abort_signal.recv() => return Err(ctx.throw(err)),
                 collected_body = body.collect() => collected_body.or_throw(ctx)?.to_bytes()
@@ -158,9 +174,9 @@ impl<'js> Response<'js> {
             body.collect().await.or_throw(ctx)?.to_bytes()
         };
 
-        if let Some(content_encoding) = &self.content_encoding {
+        if let Some(content_encoding) = self.content_encoding.as_deref() {
             let mut data: Vec<u8> = Vec::with_capacity(bytes.len());
-            match content_encoding.as_str() {
+            match content_encoding {
                 "zstd" => llrt_compression::zstd::decoder(&bytes[..])?.read_to_end(&mut data)?,
                 "br" => llrt_compression::brotli::decoder(&bytes[..]).read_to_end(&mut data)?,
                 "gzip" => llrt_compression::gz::decoder(&bytes[..]).read_to_end(&mut data)?,
@@ -173,48 +189,47 @@ impl<'js> Response<'js> {
         }
     }
 
-    async fn take_bytes(&mut self, ctx: &Ctx<'js>) -> Result<Option<Vec<u8>>> {
-        let bytes = match &mut self.body {
-            Some(BodyVariant::Incoming(incoming)) => {
+    fn get_body(&self, ctx: &Ctx<'js>) -> Result<MutexGuard<'_, BodyVariant<'js>>> {
+        let inner = self
+            .body
+            .try_lock()
+            .map_err(|_| Exception::throw_message(ctx, "Response already read"))?;
+        Ok(inner)
+    }
+
+    async fn take_bytes(&self, ctx: &Ctx<'js>) -> Result<Option<Vec<u8>>> {
+        let mut body = self.get_body(ctx)?;
+        let body = &mut *body;
+        let bytes = match body {
+            BodyVariant::Incoming(ref mut incoming) => {
                 let response = incoming
                     .take()
-                    .ok_or(Exception::throw_type(ctx, "Already read"))?;
+                    .ok_or(Exception::throw_message(ctx, "Already read"))?;
                 self.take_bytes_body(ctx, response.into_body()).await?
             },
-            Some(BodyVariant::Cloned(incoming)) => {
+            BodyVariant::Cloned(ref mut incoming) => {
                 let body = incoming
                     .take()
-                    .ok_or(Exception::throw_type(ctx, "Already read"))?;
+                    .ok_or(Exception::throw_message(ctx, "Already read"))?;
                 self.take_bytes_body(ctx, body.into_body()).await?
             },
-            Some(BodyVariant::Provided(provided)) => {
+            BodyVariant::Provided(provided) => {
+                let provided = provided
+                    .take()
+                    .ok_or(Exception::throw_message(ctx, "Already read"))?;
                 if let Some(blob) = provided.as_object().and_then(Class::<Blob>::from_object) {
                     let blob = blob.borrow();
                     blob.get_bytes()
                 } else {
-                    let bytes = ObjectBytes::from(ctx, provided)?;
+                    let bytes = ObjectBytes::from(ctx, &provided)?;
                     bytes.as_bytes().to_vec()
                 }
             },
-            None => return Ok(None),
+            BodyVariant::Empty => return Ok(None),
         };
 
         Ok(Some(bytes))
     }
-}
-
-#[rquickjs::class]
-pub struct Response<'js> {
-    body: Option<BodyVariant<'js>>,
-    method: String,
-    url: String,
-    start: Instant,
-    status: u16,
-    status_text: Option<String>,
-    redirected: bool,
-    headers: Class<'js, Headers>,
-    content_encoding: Option<String>,
-    abort_receiver: Option<mc_oneshot::Receiver<Value<'js>>>,
 }
 
 unsafe impl<'js> JsLifetime<'js> for Response<'js> {
@@ -253,16 +268,19 @@ impl<'js> Response<'js> {
         let headers = Class::instance(ctx.clone(), headers.unwrap_or_default())?;
         let content_encoding = headers.get("content-encoding")?;
 
-        let body = body.0.and_then(|body| {
-            if body.is_null() || body.is_undefined() {
-                None
-            } else {
-                Some(BodyVariant::Provided(body))
-            }
-        });
+        let body = body
+            .0
+            .and_then(|body| {
+                if body.is_null() || body.is_undefined() {
+                    None
+                } else {
+                    Some(BodyVariant::Provided(Some(body)))
+                }
+            })
+            .unwrap_or_else(|| BodyVariant::Empty);
 
         Ok(Self {
-            body,
+            body: Mutex::new(body),
             method: "GET".into(),
             url,
             start: Instant::now(),
@@ -323,42 +341,48 @@ impl<'js> Response<'js> {
     }
 
     #[qjs(get)]
-    fn body_used(&self) -> bool {
-        if let Some(BodyVariant::Incoming(body)) = &self.body {
-            return body.is_none();
+    fn body_used(&self, ctx: Ctx<'js>) -> bool {
+        if let Ok(body) = self.get_body(&ctx) {
+            let body = &*body;
+            return match body {
+                BodyVariant::Incoming(response) => response.is_none(),
+                BodyVariant::Cloned(response) => response.is_none(),
+                BodyVariant::Provided(value) => value.is_none(),
+                BodyVariant::Empty => false,
+            };
         }
-        false
+        true
     }
 
-    pub(crate) async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
+    pub(crate) async fn text(&self, ctx: Ctx<'js>) -> Result<String> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             return Ok(String::from_utf8_lossy(&bytes).to_string());
         }
         Ok("".into())
     }
 
-    pub(crate) async fn json(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+    pub(crate) async fn json(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             return json_parse(&ctx, bytes);
         }
         Err(Exception::throw_syntax(&ctx, "JSON input is empty"))
     }
 
-    async fn array_buffer(&mut self, ctx: Ctx<'js>) -> Result<ArrayBuffer<'js>> {
+    async fn array_buffer(&self, ctx: Ctx<'js>) -> Result<ArrayBuffer<'js>> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             return ArrayBuffer::new(ctx, bytes);
         }
         ArrayBuffer::new(ctx, Vec::<u8>::new())
     }
 
-    async fn bytes(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+    async fn bytes(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             return TypedArray::new(ctx, bytes).map(|m| m.into_value());
         }
         TypedArray::new(ctx, Vec::<u8>::new()).map(|m| m.into_value())
     }
 
-    async fn blob(&mut self, ctx: Ctx<'js>) -> Result<Blob> {
+    async fn blob(&self, ctx: Ctx<'js>) -> Result<Blob> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             let headers = Headers::from_value(&ctx, self.headers().as_value().clone())?;
             let mime_type = headers
@@ -369,29 +393,35 @@ impl<'js> Response<'js> {
         Ok(Blob::from_bytes(Vec::<u8>::new(), None))
     }
 
-    pub(crate) fn clone(&mut self, ctx: Ctx<'js>) -> Result<Self> {
-        let body = match &mut self.body {
-            Some(BodyVariant::Incoming(incoming)) => match incoming.take() {
-                Some(response) => {
-                    let (head, body) = response.into_parts();
-                    let (sender, receiver) = incoming::channel(body);
+    pub(crate) fn clone(&self, ctx: Ctx<'js>) -> Result<Self> {
+        //not async so should not block
+        let mut body = self.get_body(&ctx)?;
+        let body_mutex = &mut *body;
+        let body = match body_mutex {
+            BodyVariant::Incoming(incoming) => {
+                if let Some(response) = incoming.take() {
+                    let (head, incoming_response) = response.into_parts();
+                    let (sender, receiver) = incoming::channel(incoming_response);
+                    let response = hyper::Response::from_parts(head, receiver);
+
+                    *body_mutex = BodyVariant::Cloned(Some(response.clone()));
+
                     ctx.spawn_exit_simple(async move {
                         sender.process().await;
                         Ok(())
                     });
-                    let response = hyper::Response::from_parts(head, receiver);
-                    self.body = Some(BodyVariant::Cloned(Some(response.clone())));
-                    Some(BodyVariant::Cloned(Some(response)))
-                },
-                None => Some(BodyVariant::Incoming(None)),
+                    BodyVariant::Cloned(Some(response))
+                } else {
+                    BodyVariant::Incoming(None)
+                }
             },
-            Some(BodyVariant::Cloned(incoming)) => Some(BodyVariant::Cloned(incoming.clone())),
-            Some(BodyVariant::Provided(provided)) => Some(BodyVariant::Provided(provided.clone())),
-            None => None,
+            BodyVariant::Cloned(incoming) => BodyVariant::Cloned(incoming.clone()),
+            BodyVariant::Provided(provided) => BodyVariant::Provided(provided.clone()),
+            BodyVariant::Empty => BodyVariant::Empty,
         };
 
         Ok(Self {
-            body,
+            body: Mutex::new(body),
             method: self.method.clone(),
             url: self.url.clone(),
             start: self.start,
@@ -407,7 +437,7 @@ impl<'js> Response<'js> {
     #[qjs(static)]
     fn error(ctx: Ctx<'js>) -> Result<Self> {
         Ok(Self {
-            body: None,
+            body: Mutex::new(BodyVariant::Empty),
             method: "".into(),
             url: "".into(),
             start: Instant::now(),
@@ -441,10 +471,10 @@ impl<'js> Response<'js> {
         let headers = Class::instance(ctx.clone(), headers.unwrap_or_default())?;
         let content_encoding = headers.get("content-encoding")?;
 
-        let body = Some(BodyVariant::Provided(body));
+        let body = BodyVariant::Provided(Some(body));
 
         Ok(Self {
-            body,
+            body: Mutex::new(body),
             method: "".into(),
             url: "".into(),
             start: Instant::now(),
@@ -475,7 +505,7 @@ impl<'js> Response<'js> {
         let headers = Class::instance(ctx.clone(), headers)?;
 
         Ok(Self {
-            body: None,
+            body: Mutex::new(BodyVariant::Empty),
             method: "".into(),
             url: "".into(),
             start: Instant::now(),
@@ -492,7 +522,9 @@ impl<'js> Response<'js> {
 impl<'js> Trace<'js> for Response<'js> {
     fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
         self.headers.trace(tracer);
-        if let Some(BodyVariant::Provided(body)) = &self.body {
+        let body = self.body.lock().unwrap();
+        let body = &*body;
+        if let BodyVariant::Provided(Some(body)) = body {
             body.trace(tracer);
         }
     }

--- a/shims/sdk-stream-mixin.js
+++ b/shims/sdk-stream-mixin.js
@@ -7,7 +7,7 @@ const transformToWebStream = () => {
 };
 
 async function transformToByteArray() {
-  return await this.typedArray();
+  return await this.bytes();
 }
 
 async function transformToString(encoding) {


### PR DESCRIPTION
### Description of changes

Limit parallel fetches to 500 to reduce contention on network stack. This significantly improves performance when a lot of requests are executed in parallel. 
This PR also contains a DNS cache implemementation that caches DNS lookups for 300 seconds. DNS parallel lookups are also limited to 5 per host to limit excessive thread spawning.
`Response` also now also only allows for a body to be read once.

```javascript
const res = await fetch("https:///www.amazon.com");
await res.text() //OK
await res.text() //Error
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
