### PR TITLE
fix(utils): remove expect from ObjectBytes

### DIFF
--- a/libs/llrt_json/src/parse.rs
+++ b/libs/llrt_json/src/parse.rs
@@ -6,7 +6,7 @@ use rquickjs::{Array, Ctx, Exception, IntoJs, Null, Object, Result, Undefined, V
 use simd_json::{Node, StaticNode};
 
 pub fn json_parse_string<'js>(ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<Value<'js>> {
-    let bytes = bytes.as_bytes();
+    let bytes = bytes.as_bytes(&ctx)?;
     json_parse(&ctx, bytes)
 }
 

--- a/libs/llrt_utils/src/bytes.rs
+++ b/libs/llrt_utils/src/bytes.rs
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use std::rc::Rc;
+
 use rquickjs::{
     atom::PredefinedAtom,
     class::{Trace, Tracer},
@@ -73,14 +75,14 @@ impl<'js> IntoJs<'js> for ObjectBytes<'js> {
 }
 
 impl<'js> TryFrom<ObjectBytes<'js>> for Vec<u8> {
-    type Error = String;
+    type Error = Rc<str>;
     fn try_from(value: ObjectBytes<'js>) -> std::result::Result<Self, Self::Error> {
         value.into_bytes_inner()
     }
 }
 
 impl<'a, 'js> TryFrom<&'a ObjectBytes<'js>> for &'a [u8] {
-    type Error = String;
+    type Error = Rc<str>;
     fn try_from(value: &'a ObjectBytes<'js>) -> std::result::Result<Self, Self::Error> {
         value.as_bytes_inner()
     }
@@ -133,7 +135,7 @@ impl<'js> ObjectBytes<'js> {
         self.as_bytes_inner().or_throw(ctx)
     }
 
-    fn as_bytes_inner(&self) -> std::result::Result<&[u8], String> {
+    fn as_bytes_inner(&self) -> std::result::Result<&[u8], Rc<str>> {
         match self {
             ObjectBytes::U8Array(array) => array.as_bytes(),
             ObjectBytes::I8Array(array) => array.as_bytes(),
@@ -148,14 +150,14 @@ impl<'js> ObjectBytes<'js> {
             ObjectBytes::DataView(array_buffer) => array_buffer.as_bytes(),
             ObjectBytes::Vec(bytes) => Some(bytes.as_ref()),
         }
-        .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED.to_string())
+        .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED.into())
     }
 
     pub fn into_bytes(self, ctx: &Ctx<'js>) -> Result<Vec<u8>> {
         self.into_bytes_inner().or_throw(ctx)
     }
 
-    fn into_bytes_inner(self) -> std::result::Result<Vec<u8>, String> {
+    fn into_bytes_inner(self) -> std::result::Result<Vec<u8>, Rc<str>> {
         if let ObjectBytes::Vec(bytes) = self {
             return Ok(bytes);
         }

--- a/libs/llrt_utils/src/bytes.rs
+++ b/libs/llrt_utils/src/bytes.rs
@@ -153,7 +153,7 @@ impl<'js> ObjectBytes<'js> {
         .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED.into())
     }
 
-    pub fn into_bytes(self, ctx: &Ctx<'js>) -> Result<Vec<u8>> {
+    pub fn into_bytes(self, ctx: &Ctx<'_>) -> Result<Vec<u8>> {
         self.into_bytes_inner().or_throw(ctx)
     }
 

--- a/llrt_core/src/modules/llrt/hex.rs
+++ b/llrt_core/src/modules/llrt/hex.rs
@@ -20,8 +20,8 @@ use self::encoder::{bytes_from_hex, bytes_to_hex_string};
 pub struct LlrtHexModule;
 
 impl LlrtHexModule {
-    pub fn encode(bytes: ObjectBytes<'_>) -> Result<String> {
-        Ok(bytes_to_hex_string(bytes.as_bytes()))
+    pub fn encode<'js>(ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<String> {
+        Ok(bytes_to_hex_string(bytes.as_bytes(&ctx)?))
     }
 
     pub fn decode(ctx: Ctx, encoded: String) -> Result<Value> {

--- a/llrt_core/src/modules/llrt/uuid.rs
+++ b/llrt_core/src/modules/llrt/uuid.rs
@@ -35,7 +35,7 @@ fn from_value<'js>(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Uuid> {
         Uuid::try_parse(&value.as_string().unwrap().to_string()?)
     } else {
         let bytes = ObjectBytes::from(ctx, &value)?;
-        let bytes = bytes.as_bytes();
+        let bytes = bytes.as_bytes(ctx)?;
         Uuid::from_slice(bytes)
     }
     .or_throw_msg(ctx, ERROR_MESSAGE)
@@ -134,7 +134,7 @@ fn stringify<'js>(ctx: Ctx<'js>, value: Value<'js>, offset: Opt<u8>) -> Result<S
         offset.0.map(|o| o.into()).unwrap_or_default(),
         None,
     )?;
-    let value = bytes_to_hex(bytes.as_bytes());
+    let value = bytes_to_hex(bytes.as_bytes(&ctx)?);
 
     let uuid = Uuid::try_parse_ascii(&value)
         .or_throw_msg(&ctx, ERROR_MESSAGE)?

--- a/llrt_core/src/modules/llrt/xml.rs
+++ b/llrt_core/src/modules/llrt/xml.rs
@@ -113,7 +113,7 @@ impl<'js> XMLParser<'js> {
     }
 
     pub fn parse(&self, ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<Object<'js>> {
-        let bytes = bytes.as_bytes();
+        let bytes = bytes.as_bytes(&ctx)?;
         let mut reader = Reader::from_reader(bytes);
         let config = reader.config_mut();
         config.trim_text(true);

--- a/llrt_core/src/modules/util/text_decoder.rs
+++ b/llrt_core/src/modules/util/text_decoder.rs
@@ -56,7 +56,7 @@ impl<'js> TextDecoder {
     }
 
     pub fn decode(&self, ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<String> {
-        let bytes = bytes.as_bytes();
+        let bytes = bytes.as_bytes(&ctx)?;
         let start_pos = if !self.ignore_bom {
             match bytes.get(..3) {
                 Some([0xFF, 0xFE, ..]) | Some([0xFE, 0xFF, ..]) => 2,

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -90,7 +90,7 @@ fn byte_length<'js>(ctx: Ctx<'js>, value: Value<'js>, encoding: Opt<String>) -> 
     if let Some(encoding) = encoding.0 {
         let encoder = Encoder::from_str(&encoding).or_throw(&ctx)?;
         let a = ObjectBytes::from(&ctx, &value)?;
-        let bytes = a.as_bytes();
+        let bytes = a.as_bytes(&ctx)?;
         return Ok(encoder.decode(bytes).or_throw(&ctx)?.len());
     }
     //fast path
@@ -110,7 +110,7 @@ fn byte_length<'js>(ctx: Ctx<'js>, value: Value<'js>, encoding: Opt<String>) -> 
 
     if let Some(obj) = value.as_object() {
         if let Some(ob) = ObjectBytes::from_array_buffer(obj)? {
-            return Ok(ob.as_bytes().len());
+            return Ok(ob.as_bytes(&ctx)?.len());
         }
     }
 
@@ -202,7 +202,7 @@ fn alloc<'js>(
         }
         if let Some(obj) = value.as_object() {
             if let Some(ob) = ObjectBytes::from_array_buffer(obj)? {
-                let bytes = ob.as_bytes();
+                let bytes = ob.as_bytes(&ctx)?;
                 return alloc_byte_ref(&ctx, bytes, length);
             }
         }
@@ -274,7 +274,7 @@ fn from<'js>(
 
     if let Some(obj) = value.as_object() {
         if let Some(ab_bytes) = ObjectBytes::from_array_buffer(obj)? {
-            let bytes = ab_bytes.as_bytes();
+            let bytes = ab_bytes.as_bytes(&ctx)?;
             let (start, end) = get_start_end_indexes(bytes.len(), length.0, offset);
 
             //buffers from buffer should be copied

--- a/modules/llrt_crypto/src/crc32.rs
+++ b/modules/llrt_crypto/src/crc32.rs
@@ -4,7 +4,7 @@ use std::hash::Hasher;
 
 use crc32c::Crc32cHasher;
 use llrt_utils::bytes::ObjectBytes;
-use rquickjs::{prelude::This, Class, Result};
+use rquickjs::{prelude::This, Class, Ctx, Result};
 
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace, rquickjs::JsLifetime)]
@@ -30,9 +30,10 @@ impl Crc32c {
     #[qjs(rename = "update")]
     fn crc32c_update<'js>(
         this: This<Class<'js, Self>>,
+        ctx: Ctx<'js>,
         bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        this.0.borrow_mut().hasher.write(bytes.as_bytes());
+        this.0.borrow_mut().hasher.write(bytes.as_bytes(&ctx)?);
         Ok(this.0)
     }
 }
@@ -61,9 +62,10 @@ impl Crc32 {
     #[qjs(rename = "update")]
     fn crc32_update<'js>(
         this: This<Class<'js, Self>>,
+        ctx: Ctx<'js>,
         bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        this.0.borrow_mut().hasher.write(bytes.as_bytes());
+        this.0.borrow_mut().hasher.write(bytes.as_bytes(&ctx)?);
         Ok(this.0)
     }
 }

--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -246,9 +246,12 @@ impl ModuleDef for CryptoModule {
                 let class_name: &str = sha_algorithm.class_name();
                 let algo = sha_algorithm;
 
-                let ctor = Constructor::new_class::<ShaHash, _, _>(ctx.clone(), move || {
-                    ShaHash::default(algo.clone())
-                })?;
+                let ctor =
+                    Constructor::new_class::<ShaHash, _, _>(ctx.clone(), move |ctx, secret| {
+                        struct Args<'js>(Ctx<'js>, Opt<ObjectBytes<'js>>);
+                        let Args(ctx, secret) = Args(ctx, secret);
+                        ShaHash::new(ctx, algo.clone(), secret)
+                    })?;
 
                 default.set(class_name, ctor)?;
             }

--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -246,8 +246,8 @@ impl ModuleDef for CryptoModule {
                 let class_name: &str = sha_algorithm.class_name();
                 let algo = sha_algorithm;
 
-                let ctor = Constructor::new_class::<ShaHash, _, _>(ctx.clone(), move |secret| {
-                    ShaHash::new(algo.clone(), secret)
+                let ctor = Constructor::new_class::<ShaHash, _, _>(ctx.clone(), move || {
+                    ShaHash::default(algo.clone())
                 })?;
 
                 default.set(class_name, ctor)?;

--- a/modules/llrt_crypto/src/md5_hash.rs
+++ b/modules/llrt_crypto/src/md5_hash.rs
@@ -37,9 +37,10 @@ impl Md5 {
     #[qjs(rename = "update")]
     fn md5_update<'js>(
         this: This<Class<'js, Self>>,
+        ctx: Ctx<'js>,
         bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        this.0.borrow_mut().hasher.update(bytes.as_bytes());
+        this.0.borrow_mut().hasher.update(bytes.as_bytes(&ctx)?);
         Ok(this.0)
     }
 }

--- a/modules/llrt_crypto/src/sha_hash.rs
+++ b/modules/llrt_crypto/src/sha_hash.rs
@@ -28,7 +28,7 @@ impl Hmac {
         let algorithm = *algorithm.hmac_algorithm();
 
         Ok(Self {
-            context: HmacContext::with_key(&hmac::Key::new(algorithm, key_value.as_bytes())),
+            context: HmacContext::with_key(&hmac::Key::new(algorithm, key_value.as_bytes(&ctx)?)),
         })
     }
 
@@ -44,9 +44,10 @@ impl Hmac {
 
     fn update<'js>(
         this: This<Class<'js, Self>>,
+        ctx: Ctx<'js>,
         bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = bytes.as_bytes();
+        let bytes = bytes.as_bytes(&ctx)?;
         this.0.borrow_mut().context.update(bytes);
 
         Ok(this.0)
@@ -94,9 +95,10 @@ impl Hash {
     #[qjs(rename = "update")]
     fn hash_update<'js>(
         this: This<Class<'js, Self>>,
+        ctx: Ctx<'js>,
         bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        let bytes = bytes.as_bytes();
+        let bytes = bytes.as_bytes(&ctx)?;
         this.0.borrow_mut().context.update(bytes);
         Ok(this.0)
     }
@@ -195,11 +197,27 @@ pub struct ShaHash {
 #[rquickjs::methods]
 impl ShaHash {
     #[qjs(skip)]
-    pub fn new(algorithm: ShaAlgorithm, secret: Opt<ObjectBytes<'_>>) -> Result<Self> {
-        let secret = secret.0.map(|bytes| bytes.into_bytes());
+    pub fn new<'js>(
+        ctx: &Ctx<'js>,
+        algorithm: ShaAlgorithm,
+        secret: Opt<ObjectBytes<'js>>,
+    ) -> Result<Self> {
+        let secret = secret
+            .0
+            .map(|bytes| bytes.into_bytes(ctx))
+            .and_then(|res| res.ok());
 
         Ok(ShaHash {
             secret,
+            bytes: Vec::new(),
+            algorithm,
+        })
+    }
+
+    #[qjs(skip)]
+    pub fn default(algorithm: ShaAlgorithm) -> Result<Self> {
+        Ok(ShaHash {
+            secret: None,
             bytes: Vec::new(),
             algorithm,
         })
@@ -223,9 +241,10 @@ impl ShaHash {
     #[qjs(rename = "update")]
     fn sha_update<'js>(
         this: This<Class<'js, Self>>,
+        ctx: Ctx<'js>,
         bytes: ObjectBytes<'js>,
     ) -> Result<Class<'js, Self>> {
-        this.0.borrow_mut().bytes = bytes.into();
+        this.0.borrow_mut().bytes = bytes.try_into().or_throw(&ctx)?;
         Ok(this.0)
     }
 }

--- a/modules/llrt_crypto/src/sha_hash.rs
+++ b/modules/llrt_crypto/src/sha_hash.rs
@@ -197,20 +197,11 @@ pub struct ShaHash {
 #[rquickjs::methods]
 impl ShaHash {
     #[qjs(skip)]
-    pub fn new(ctx: &Ctx, algorithm: ShaAlgorithm, secret: Opt<ObjectBytes<'_>>) -> Result<Self> {
-        let secret = secret.0.map(|bytes| bytes.into_bytes(ctx)).transpose()?;
+    pub fn new(ctx: Ctx, algorithm: ShaAlgorithm, secret: Opt<ObjectBytes<'_>>) -> Result<Self> {
+        let secret = secret.0.map(|bytes| bytes.into_bytes(&ctx)).transpose()?;
 
         Ok(ShaHash {
             secret,
-            bytes: Vec::new(),
-            algorithm,
-        })
-    }
-
-    #[qjs(skip)]
-    pub fn default(algorithm: ShaAlgorithm) -> Result<Self> {
-        Ok(ShaHash {
-            secret: None,
             bytes: Vec::new(),
             algorithm,
         })

--- a/modules/llrt_crypto/src/sha_hash.rs
+++ b/modules/llrt_crypto/src/sha_hash.rs
@@ -202,10 +202,7 @@ impl ShaHash {
         algorithm: ShaAlgorithm,
         secret: Opt<ObjectBytes<'js>>,
     ) -> Result<Self> {
-        let secret = secret
-            .0
-            .map(|bytes| bytes.into_bytes(ctx))
-            .and_then(|res| res.ok());
+        let secret = secret.0.map(|bytes| bytes.into_bytes(ctx)).transpose()?;
 
         Ok(ShaHash {
             secret,

--- a/modules/llrt_crypto/src/sha_hash.rs
+++ b/modules/llrt_crypto/src/sha_hash.rs
@@ -197,11 +197,7 @@ pub struct ShaHash {
 #[rquickjs::methods]
 impl ShaHash {
     #[qjs(skip)]
-    pub fn new<'js>(
-        ctx: &Ctx<'js>,
-        algorithm: ShaAlgorithm,
-        secret: Opt<ObjectBytes<'js>>,
-    ) -> Result<Self> {
+    pub fn new(ctx: &Ctx, algorithm: ShaAlgorithm, secret: Opt<ObjectBytes<'_>>) -> Result<Self> {
         let secret = secret.0.map(|bytes| bytes.into_bytes(ctx)).transpose()?;
 
         Ok(ShaHash {

--- a/modules/llrt_crypto/src/subtle/digest.rs
+++ b/modules/llrt_crypto/src/subtle/digest.rs
@@ -18,7 +18,7 @@ pub async fn subtle_digest<'js>(
     };
 
     let sha_algorithm = ShaAlgorithm::try_from(algorithm.as_str()).or_throw(&ctx)?;
-    let bytes = digest(&sha_algorithm, data.as_bytes());
+    let bytes = digest(&sha_algorithm, data.as_bytes(&ctx)?);
     ArrayBuffer::new(ctx, bytes)
 }
 

--- a/modules/llrt_crypto/src/subtle/encryption.rs
+++ b/modules/llrt_crypto/src/subtle/encryption.rs
@@ -28,7 +28,7 @@ pub async fn subtle_decrypt<'js>(
         &ctx,
         &algorithm,
         &key,
-        data.as_bytes(),
+        data.as_bytes(&ctx)?,
         EncryptionMode::Encryption,
         EncryptionOperation::Decrypt,
     )?;
@@ -48,7 +48,7 @@ pub async fn subtle_encrypt<'js>(
         &ctx,
         &algorithm,
         &key,
-        data.as_bytes(),
+        data.as_bytes(&ctx)?,
         EncryptionMode::Encryption,
         EncryptionOperation::Encrypt,
     )?;

--- a/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
@@ -79,7 +79,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 let additional_data = obj
                     .get_optional::<_, ObjectBytes>("additionalData")?
                     .map(|v| v.into_bytes(ctx))
-                    .and_then(|res| res.ok())
+                    .transpose()?
                     .map(|vec| vec.into_boxed_slice());
 
                 let tag_length = obj.get_optional::<_, u8>("tagLength")?.unwrap_or(128);
@@ -102,7 +102,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 let label = obj
                     .get_optional::<_, ObjectBytes>("label")?
                     .map(|bytes| bytes.into_bytes(ctx))
-                    .and_then(|res| res.ok())
+                    .transpose()?
                     .map(|vec| vec.into_boxed_slice());
 
                 Ok(EncryptionAlgorithm::RsaOaep { label })

--- a/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
@@ -99,10 +99,6 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 })
             },
             "RSA-OAEP" => {
-                // let label = obj
-                //     .get_optional::<_, ObjectBytes>("label")?
-                //     .map(|bytes| bytes.into_bytes(&ctx)?.into_boxed_slice());
-
                 let label = obj
                     .get_optional::<_, ObjectBytes>("label")?
                     .map(|bytes| bytes.into_bytes(ctx))

--- a/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
@@ -33,7 +33,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
             "AES-CBC" => {
                 let iv = obj
                     .get_required::<_, ObjectBytes>("iv", "algorithm")?
-                    .into_bytes()
+                    .into_bytes(ctx)?
                     .into_boxed_slice();
 
                 if iv.len() != 16 {
@@ -48,7 +48,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
             "AES-CTR" => {
                 let counter = obj
                     .get_required::<_, ObjectBytes>("counter", "algorithm")?
-                    .into_bytes()
+                    .into_bytes(ctx)?
                     .into_boxed_slice();
 
                 let length = obj.get_required::<_, u32>("length", "algorithm")?;
@@ -65,7 +65,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
             "AES-GCM" => {
                 let iv = obj
                     .get_required::<_, ObjectBytes>("iv", "algorithm")?
-                    .into_bytes()
+                    .into_bytes(ctx)?
                     .into_boxed_slice();
 
                 //FIXME only 12? 96 maybe recommended?
@@ -78,7 +78,9 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
 
                 let additional_data = obj
                     .get_optional::<_, ObjectBytes>("additionalData")?
-                    .map(|v| v.into_bytes().into_boxed_slice());
+                    .map(|v| v.into_bytes(ctx))
+                    .and_then(|res| res.ok())
+                    .map(|vec| vec.into_boxed_slice());
 
                 let tag_length = obj.get_optional::<_, u8>("tagLength")?.unwrap_or(128);
 
@@ -97,9 +99,16 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 })
             },
             "RSA-OAEP" => {
+                // let label = obj
+                //     .get_optional::<_, ObjectBytes>("label")?
+                //     .map(|bytes| bytes.into_bytes(&ctx)?.into_boxed_slice());
+
                 let label = obj
                     .get_optional::<_, ObjectBytes>("label")?
-                    .map(|bytes| bytes.into_bytes().into_boxed_slice());
+                    .map(|bytes| bytes.into_bytes(ctx))
+                    .and_then(|res| res.ok())
+                    .map(|vec| vec.into_boxed_slice());
+
                 Ok(EncryptionAlgorithm::RsaOaep { label })
             },
             "AES-KW" => Ok(EncryptionAlgorithm::AesKw),

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -187,12 +187,12 @@ impl KeyDerivation {
 
         let salt = obj
             .get_required::<_, ObjectBytes>("salt", "algorithm")?
-            .into_bytes()
+            .into_bytes(ctx)?
             .into_boxed_slice();
 
         let info = obj
             .get_required::<_, ObjectBytes>("info", "algorithm")?
-            .into_bytes()
+            .into_bytes(ctx)?
             .into_boxed_slice();
 
         Ok(KeyDerivation::Hkdf { hash, salt, info })
@@ -203,7 +203,7 @@ impl KeyDerivation {
 
         let salt = obj
             .get_required::<_, ObjectBytes>("salt", "algorithm")?
-            .into_bytes()
+            .into_bytes(ctx)?
             .into_boxed_slice();
 
         let iterations = obj.get_required("iterations", "algorithm")?;
@@ -655,7 +655,7 @@ fn import_derive_key<'js>(
     algorithm_name: &str,
 ) -> Result<()> {
     if let KeyFormatData::Raw(object_bytes) = format {
-        *data = object_bytes.into_bytes();
+        *data = object_bytes.into_bytes(ctx)?;
         *kind = KeyKind::Secret;
     } else {
         return Err(Exception::throw_message(
@@ -782,11 +782,11 @@ fn import_rsa_key<'js>(
         },
         KeyFormatData::Raw(object_bytes) => {
             let public_key =
-                rsa::pkcs1::RsaPublicKey::from_der(object_bytes.as_bytes()).or_throw(ctx)?;
+                rsa::pkcs1::RsaPublicKey::from_der(object_bytes.as_bytes(ctx)?).or_throw(ctx)?;
             public_key_info(ctx, kind, data, public_key)?
         },
         KeyFormatData::Pkcs8(object_bytes) => {
-            let pk_info = PrivateKeyInfo::from_der(object_bytes.as_bytes()).or_throw(ctx)?;
+            let pk_info = PrivateKeyInfo::from_der(object_bytes.as_bytes(ctx)?).or_throw(ctx)?;
             let object_identifier = pk_info.algorithm.oid;
             validate_oid(object_identifier)?;
 
@@ -801,8 +801,8 @@ fn import_rsa_key<'js>(
             (modulus_length, public_exponent)
         },
         KeyFormatData::Spki(object_bytes) => {
-            let pk_info =
-                spki::SubjectPublicKeyInfoRef::try_from(object_bytes.as_bytes()).or_throw(ctx)?;
+            let pk_info = spki::SubjectPublicKeyInfoRef::try_from(object_bytes.as_bytes(ctx)?)
+                .or_throw(ctx)?;
 
             let object_identifier = pk_info.algorithm.oid;
             validate_oid(object_identifier)?;
@@ -863,7 +863,7 @@ fn import_symmetric_key<'js>(
             }
         },
         KeyFormatData::Raw(object_bytes) => {
-            let bytes = object_bytes.into_bytes();
+            let bytes = object_bytes.into_bytes(ctx)?;
 
             *data = bytes;
             return Ok(data.len() * 8);
@@ -982,7 +982,7 @@ fn import_ec_key<'js>(
             }
         },
         KeyFormatData::Raw(object_bytes) => {
-            let bytes = object_bytes.into_bytes();
+            let bytes = object_bytes.into_bytes(ctx)?;
             if bytes.len() != 32 {
                 return Err(Exception::throw_type(
                     ctx,
@@ -993,16 +993,16 @@ fn import_ec_key<'js>(
             *kind = KeyKind::Public;
         },
         KeyFormatData::Spki(object_bytes) => {
-            let spki =
-                spki::SubjectPublicKeyInfoRef::try_from(object_bytes.as_bytes()).or_throw(ctx)?;
+            let spki = spki::SubjectPublicKeyInfoRef::try_from(object_bytes.as_bytes(ctx)?)
+                .or_throw(ctx)?;
             validate_oid(spki.algorithm.oid)?;
             *data = spki.subject_public_key.raw_bytes().into();
             *kind = KeyKind::Public;
         },
         KeyFormatData::Pkcs8(object_bytes) => {
-            let pkcs8 = PrivateKeyInfo::try_from(object_bytes.as_bytes()).or_throw(ctx)?;
+            let pkcs8 = PrivateKeyInfo::try_from(object_bytes.as_bytes(ctx)?).or_throw(ctx)?;
             validate_oid(pkcs8.algorithm.oid)?;
-            *data = object_bytes.into_bytes();
+            *data = object_bytes.into_bytes(ctx)?;
             *kind = KeyKind::Private;
         },
     };
@@ -1052,7 +1052,7 @@ fn import_okp_key<'js>(
             }
         },
         KeyFormatData::Raw(object_bytes) => {
-            let bytes = object_bytes.into_bytes();
+            let bytes = object_bytes.into_bytes(ctx)?;
             if bytes.len() != 32 {
                 return Err(Exception::throw_type(
                     ctx,
@@ -1063,16 +1063,16 @@ fn import_okp_key<'js>(
             *kind = KeyKind::Public;
         },
         KeyFormatData::Spki(object_bytes) => {
-            let spki =
-                spki::SubjectPublicKeyInfoRef::try_from(object_bytes.as_bytes()).or_throw(ctx)?;
+            let spki = spki::SubjectPublicKeyInfoRef::try_from(object_bytes.as_bytes(ctx)?)
+                .or_throw(ctx)?;
             validate_oid(spki.algorithm.oid)?;
             *data = spki.subject_public_key.raw_bytes().into();
             *kind = KeyKind::Public;
         },
         KeyFormatData::Pkcs8(object_bytes) => {
-            let pkcs8 = PrivateKeyInfo::try_from(object_bytes.as_bytes()).or_throw(ctx)?;
+            let pkcs8 = PrivateKeyInfo::try_from(object_bytes.as_bytes(ctx)?).or_throw(ctx)?;
             validate_oid(pkcs8.algorithm.oid)?;
-            *data = object_bytes.into_bytes();
+            *data = object_bytes.into_bytes(ctx)?;
             *kind = KeyKind::Private;
         },
     };

--- a/modules/llrt_crypto/src/subtle/sign.rs
+++ b/modules/llrt_crypto/src/subtle/sign.rs
@@ -29,7 +29,7 @@ pub async fn subtle_sign<'js>(
     let key = key.borrow();
     key.check_validity("sign").or_throw(&ctx)?;
 
-    let bytes = sign(&ctx, &algorithm, &key, data.as_bytes())?;
+    let bytes = sign(&ctx, &algorithm, &key, data.as_bytes(&ctx)?)?;
     ArrayBuffer::new(ctx, bytes)
 }
 

--- a/modules/llrt_crypto/src/subtle/verify.rs
+++ b/modules/llrt_crypto/src/subtle/verify.rs
@@ -37,8 +37,8 @@ pub async fn subtle_verify<'js>(
         &ctx,
         &algorithm,
         &key,
-        signature.as_bytes(),
-        data.as_bytes(),
+        signature.as_bytes(&ctx)?,
+        data.as_bytes(&ctx)?,
     )
 }
 

--- a/modules/llrt_fs/src/write_file.rs
+++ b/modules/llrt_fs/src/write_file.rs
@@ -14,7 +14,7 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
         .or_throw_msg(&ctx, write_error_message)?;
 
     let bytes = ObjectBytes::from(&ctx, &data)?;
-    file.write_all(bytes.as_bytes())
+    file.write_all(bytes.as_bytes(&ctx)?)
         .await
         .or_throw_msg(&ctx, write_error_message)?;
     file.flush().await.or_throw_msg(&ctx, write_error_message)?;
@@ -23,7 +23,7 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
 }
 
 pub fn write_file_sync<'js>(ctx: Ctx<'js>, path: String, bytes: ObjectBytes<'js>) -> Result<()> {
-    std::fs::write(&path, bytes.as_bytes())
+    std::fs::write(&path, bytes.as_bytes(&ctx)?)
         .or_throw_msg(&ctx, &["Can't write \"{}\"", &path].concat())?;
 
     Ok(())

--- a/modules/llrt_http/src/body.rs
+++ b/modules/llrt_http/src/body.rs
@@ -166,7 +166,7 @@ impl<'js> Body<'js> {
                     blob.get_bytes()
                 } else {
                     let bytes = ObjectBytes::from(ctx, provided)?;
-                    bytes.into()
+                    bytes.try_into().or_throw(ctx)?
                 }
             },
         };

--- a/modules/llrt_http/src/fetch.rs
+++ b/modules/llrt_http/src/fetch.rs
@@ -255,11 +255,11 @@ struct BodyBytes<'js> {
     body: Full<Bytes>,
 }
 impl<'js> BodyBytes<'js> {
-    fn new(object_bytes: ObjectBytes<'js>) -> Self {
+    fn new(ctx: Ctx<'js>, object_bytes: ObjectBytes<'js>) -> Result<Self> {
         //this is safe since we hold on to ObjectBytes
-        let raw_bytes: &'static [u8] = unsafe { std::mem::transmute(object_bytes.as_bytes()) };
+        let raw_bytes: &'static [u8] = unsafe { std::mem::transmute(object_bytes.as_bytes(&ctx)?) };
         let body = Full::from(Bytes::from_static(raw_bytes));
-        Self { object_bytes, body }
+        Ok(Self { object_bytes, body })
     }
 }
 
@@ -326,7 +326,7 @@ fn get_fetch_options<'js>(
             get_option::<Value>("body", arg_opts.as_ref(), resource_opts.as_ref())?
         {
             let bytes = ObjectBytes::from(ctx, &body_opt)?;
-            body = Some(BodyBytes::new(bytes));
+            body = Some(BodyBytes::new(ctx.clone(), bytes)?);
         }
 
         if let Some(url_opt) =

--- a/modules/llrt_http/src/response.rs
+++ b/modules/llrt_http/src/response.rs
@@ -193,7 +193,7 @@ impl<'js> Response<'js> {
                     blob.get_bytes()
                 } else {
                     let bytes = ObjectBytes::from(ctx, provided)?;
-                    bytes.as_bytes().to_vec()
+                    bytes.as_bytes(ctx)?.to_vec()
                 }
             },
             None => return Ok(None),

--- a/modules/llrt_stream/src/writable.rs
+++ b/modules/llrt_stream/src/writable.rs
@@ -232,6 +232,7 @@ where
 
         ctx.spawn_exit(async move {
             let ctx3 = ctx2.clone();
+            let ctx4 = ctx2.clone();
             let this2 = this.clone();
             let write_function = async move {
                 let mut writer = BufWriter::new(writable);
@@ -243,7 +244,7 @@ where
                                  match command {
                                     Some(WriteCommand::Write(value, cb, flush)) => {
                                         let bytes = ObjectBytes::from(&ctx3, &value)?;
-                                        let data = bytes.as_bytes();
+                                        let data = bytes.as_bytes(&ctx4)?;
                                         let result = async {
                                             writer.write_all(data).await?;
                                             if flush {

--- a/modules/llrt_zlib/src/lib.rs
+++ b/modules/llrt_zlib/src/lib.rs
@@ -78,7 +78,7 @@ fn zlib_converter<'js>(
     options: Opt<Value<'js>>,
     command: ZlibCommand,
 ) -> Result<Value<'js>> {
-    let src = bytes.as_bytes();
+    let src = bytes.as_bytes(&ctx)?;
 
     let mut level = llrt_compression::zlib::Compression::default();
     if let Some(options) = options.0 {
@@ -134,7 +134,7 @@ fn brotli_converter<'js>(
     _options: Opt<Value<'js>>,
     command: BrotliCommand,
 ) -> Result<Value<'js>> {
-    let src = bytes.as_bytes();
+    let src = bytes.as_bytes(&ctx)?;
 
     let mut dst: Vec<u8> = Vec::with_capacity(src.len());
 


### PR DESCRIPTION
### Issue # (if available)

Closed #700

### Description of changes

This PR removes the `expect` instruction used in ObjectBytes's `as_bytes()` and allows it to return `std::result::Result` or `rquickjs::Result` types.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
