### PR TITLE
fix(shims): fix @aws-crypto shims not loading

### DIFF
--- a/shims/@aws-crypto/crc32.js
+++ b/shims/@aws-crypto/crc32.js
@@ -1,5 +1,4 @@
 import { Crc32 as CryptoCrc32 } from "crypto";
-import { isEmptyData, numToUint8 } from "@aws-crypto/util";
 
 export const Crc32 = CryptoCrc32;
 
@@ -18,4 +17,20 @@ export class AwsCrc32 {
   reset() {
     this.#crc32 = new CryptoCrc32();
   }
+}
+
+function isEmptyData(data) {
+  if (typeof data === "string") {
+    return data.length === 0;
+  }
+  return data.byteLength === 0;
+}
+
+function numToUint8(num) {
+  return new Uint8Array([
+    (num & 0xff000000) >> 24,
+    (num & 0x00ff0000) >> 16,
+    (num & 0x0000ff00) >> 8,
+    num & 0x000000ff,
+  ]);
 }

--- a/shims/@aws-crypto/crc32c.js
+++ b/shims/@aws-crypto/crc32c.js
@@ -1,5 +1,4 @@
 import { Crc32c as CryptoCrc32c } from "crypto";
-import { isEmptyData, numToUint8 } from "@aws-crypto/util";
 
 export const Crc32c = CryptoCrc32c;
 
@@ -18,4 +17,20 @@ export class AwsCrc32c {
   reset() {
     this.#crc32c = new CryptoCrc32c();
   }
+}
+
+function isEmptyData(data) {
+  if (typeof data === "string") {
+    return data.length === 0;
+  }
+  return data.byteLength === 0;
+}
+
+function numToUint8(num) {
+  return new Uint8Array([
+    (num & 0xff000000) >> 24,
+    (num & 0x00ff0000) >> 16,
+    (num & 0x0000ff00) >> 8,
+    num & 0x000000ff,
+  ]);
 }


### PR DESCRIPTION
### Issue # (if available)

fixed #821 

### Description of changes

In the current build script, when `@aws-crypto/util` is called from shims file, it seems that the file is not generated with the correct chunk file name.
This may need to be improved in the future.
However, this time, the implementation being called is not that large, so I decided to hard-code it.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
