### PR TITLE
repl: skip release KeyEventKind on windows

### DIFF
--- a/llrt/src/repl.rs
+++ b/llrt/src/repl.rs
@@ -113,9 +113,17 @@ pub(crate) async fn run_repl(ctx: &AsyncContext) {
             )?;
 
             if let Event::Key(KeyEvent {
-                code, modifiers, ..
+                code,
+                modifiers,
+                #[cfg(windows)]
+                kind,
+                ..
             }) = event::read()?
             {
+                #[cfg(windows)]
+                if kind == event::KeyEventKind::Release {
+                  continue;
+                }
                 match code {
                     KeyCode::Enter => {
                         println!();


### PR DESCRIPTION
### Issue # (if available)

On Windows, each key event has two kinds, press and release, so duplicate output may occur.
On Unix platforms there is only a press event

### Description of changes

close https://github.com/awslabs/llrt/issues/826

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
