### PR TITLE
fix(core): fix incompatibilities caused by the latest cargo fix

### DIFF
--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -183,7 +183,8 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
 #[inline(always)]
 fn write_sep(result: &mut String, add_comma: bool, has_indentation: bool, newline: bool) {
     const SEPARATOR_TABLE: [&str; 8] = ["", ",", "\r", ",\r", " ", ", ", "\n", ",\n"];
-    let index = (add_comma as usize) | (has_indentation as usize) << 1 | (newline as usize) << 2;
+    let index =
+        (add_comma as usize) | ((has_indentation as usize) << 1) | ((newline as usize) << 2);
     result.push_str(SEPARATOR_TABLE[index]);
 }
 

--- a/llrt_core/src/modules/llrt/uuid.rs
+++ b/llrt_core/src/modules/llrt/uuid.rs
@@ -102,18 +102,18 @@ fn uuidv6_to_v1<'js>(ctx: Ctx<'js>, v6_value: Value<'js>) -> Result<String> {
     let mut v1_bytes = [0u8; 16];
 
     // time_low
-    v1_bytes[0] = (v6_bytes[3] & 0x0f) << 4 | (v6_bytes[4] & 0xf0) >> 4;
-    v1_bytes[1] = (v6_bytes[4] & 0x0f) << 4 | (v6_bytes[5] & 0xf0) >> 4;
-    v1_bytes[2] = (v6_bytes[5] & 0x0f) << 4 | (v6_bytes[6] & 0x0f);
+    v1_bytes[0] = ((v6_bytes[3] & 0x0f) << 4) | ((v6_bytes[4] & 0xf0) >> 4);
+    v1_bytes[1] = ((v6_bytes[4] & 0x0f) << 4) | ((v6_bytes[5] & 0xf0) >> 4);
+    v1_bytes[2] = ((v6_bytes[5] & 0x0f) << 4) | (v6_bytes[6] & 0x0f);
     v1_bytes[3] = v6_bytes[7];
 
     // time_mid
-    v1_bytes[4] = (v6_bytes[1] & 0x0f) << 4 | (v6_bytes[2] & 0xf0) >> 4;
-    v1_bytes[5] = (v6_bytes[2] & 0x0f) << 4 | (v6_bytes[3] & 0xf0) >> 4;
+    v1_bytes[4] = ((v6_bytes[1] & 0x0f) << 4) | ((v6_bytes[2] & 0xf0) >> 4);
+    v1_bytes[5] = ((v6_bytes[2] & 0x0f) << 4) | ((v6_bytes[3] & 0xf0) >> 4);
 
     // version and time_high
-    v1_bytes[6] = 0x10 | (v6_bytes[0] & 0xf0) >> 4;
-    v1_bytes[7] = (v6_bytes[0] & 0x0f) << 4 | (v6_bytes[1] & 0xf0) >> 4;
+    v1_bytes[6] = 0x10 | ((v6_bytes[0] & 0xf0) >> 4);
+    v1_bytes[7] = ((v6_bytes[0] & 0x0f) << 4) | ((v6_bytes[1] & 0xf0) >> 4);
 
     // clock_seq and node
     v1_bytes[8..16].copy_from_slice(&v6_bytes[8..16]);


### PR DESCRIPTION
### Description of changes

After applying the latest rust toolchain, we found new incompatibilities and have fixed them.

```
% rustup update
info: syncing channel updates for 'stable-aarch64-apple-darwin'
info: syncing channel updates for 'nightly-aarch64-apple-darwin'
info: checking for self-update

   stable-aarch64-apple-darwin unchanged - rustc 1.85.0 (4d91de4e4 2025-02-17)
  nightly-aarch64-apple-darwin unchanged - rustc 1.87.0-nightly (f04bbc60f 2025-02-20)
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
