### PR TITLE
fix(core): fix bytecode cache index generation error

### DIFF
--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -146,7 +146,7 @@ fn generate_bytecode_cache(out_dir: &str) -> StdResult<(), Box<dyn Error>> {
             let source = fs::read_to_string(dir_ent.path())
                 .unwrap_or_else(|_| panic!("Unable to load: {}", dir_ent.path().to_string_lossy()));
 
-            let module_name = if !path_str.starts_with("llrt-chunk-") {
+            let module_name = if !path_str.starts_with("llrt-") {
                 path.with_extension("")
                     .to_string_lossy()
                     .replace('\\', "/")


### PR DESCRIPTION
### Issue # (if available)

fix #846 

### Description of changes

There was an error in the index generation process for the bytecode cache.
Specifically, the index was generated in a format different from the chunk file name written in the code (specifically, the extension was missing), which caused a resolution error.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
