### PR TITLE
fix: dns test

### DIFF
--- a/llrt_core/src/modules/js/@llrt/test/index.ts
+++ b/llrt_core/src/modules/js/@llrt/test/index.ts
@@ -179,6 +179,20 @@ class TestServer {
     socket.on("error", (error) => {
       const workerId = this.workerIdBySocket.get(socket);
       if (!workerId || !this.workerData[workerId].completed) {
+        if (workerId) {
+          const workerData = this.workerData[workerId];
+          const stdErr = workerData.stdErrBuffer.getContent().toString();
+          const stdOut = workerData.stdOutBuffer.getContent().toString();
+          let errorOutput = Color.RED_BACKGROUND(Color.BOLD("Worker Error:\n"));
+
+          if (stdErr) {
+            errorOutput += Color.RED(`\nStd Err:\n${stdErr}`);
+          }
+          if (stdOut) {
+            errorOutput += Color.RED(`\nStd Out:\n${stdOut}`);
+          }
+          console.error(errorOutput);
+        }
         this.handleError(TestServer.ERROR_CODE_SOCKET_ERROR, error, {
           socket,
         });

--- a/tests/unit/dns.test.ts
+++ b/tests/unit/dns.test.ts
@@ -20,9 +20,7 @@ describe("lookup", () => {
   });
 
   it("Name resolution for localhost2 should result in an error (optionless)", async () => {
-    await expect(dnsLookupAsync("localhost2")).rejects.toThrow(
-      "failed to lookup address information: nodename nor servname provided, or not known"
-    );
+    await expect(dnsLookupAsync("localhost2")).rejects.toThrow("known");
   });
 
   it("localhost name resolution should be possible (integer option)", async () => {
@@ -32,9 +30,7 @@ describe("lookup", () => {
   });
 
   it("Name resolution for localhost2 should result in an error (integer option)", async () => {
-    await expect(dnsLookupAsync("localhost2", 4)).rejects.toThrow(
-      "failed to lookup address information: nodename nor servname provided, or not known"
-    );
+    await expect(dnsLookupAsync("localhost2", 4)).rejects.toThrow("known");
   });
 
   it("localhost name resolution should be possible (record option)", async () => {
@@ -47,7 +43,7 @@ describe("lookup", () => {
 
   it("Name resolution for localhost2 should result in an error (record option)", async () => {
     await expect(dnsLookupAsync("localhost2", { family: 4 })).rejects.toThrow(
-      "failed to lookup address information: nodename nor servname provided, or not known"
+      "known"
     );
   });
 });

--- a/tests/unit/dns.test.ts
+++ b/tests/unit/dns.test.ts
@@ -1,54 +1,53 @@
-const dns = require("dns");
+import dns from "dns";
+
+// Promise wrapper for dns.lookup
+const dnsLookupAsync = (
+  hostname: string,
+  options?: number | dns.LookupOptions
+) =>
+  new Promise<dns.LookupAddress>((resolve, reject) => {
+    dns.lookup(hostname, options as any, (err, address, family) => {
+      if (err) reject(err);
+      else resolve({ address, family });
+    });
+  });
 
 describe("lookup", () => {
-  it("localhost name resolution should be possible (optionless)", (done) => {
-    dns.lookup("localhost", (err, address, family) => {
-      expect(err).toBeNull();
-      expect(address === "::1" || address === "127.0.0.1").toBeTruthy();
-      expect(family === 4 || family === 6).toBeTruthy();
-      done();
-    });
+  it("localhost name resolution should be possible (optionless)", async () => {
+    const { address, family } = await dnsLookupAsync("localhost");
+    expect(address === "::1" || address === "127.0.0.1").toBeTruthy();
+    expect(family === 4 || family === 6).toBeTruthy();
   });
 
-  it("Name resolution for localhost2 should result in an error (optionless)", () => {
-    dns.lookup("localhost2", (err, address, family) => {
-      expect(err.message).toEqual(
-        "failed to lookup address information: nodename nor servname provided, or not known"
-      );
-    });
+  it("Name resolution for localhost2 should result in an error (optionless)", async () => {
+    await expect(dnsLookupAsync("localhost2")).rejects.toThrow(
+      "failed to lookup address information: nodename nor servname provided, or not known"
+    );
   });
 
-  it("localhost name resolution should be possible (integer option)", (done) => {
-    dns.lookup("localhost", 4, (err, address, family) => {
-      expect(err).toBeNull();
-      expect(address).toEqual("127.0.0.1");
-      expect(family).toEqual(4);
-      done();
-    });
+  it("localhost name resolution should be possible (integer option)", async () => {
+    const { address, family } = await dnsLookupAsync("localhost", 4);
+    expect(address).toEqual("127.0.0.1");
+    expect(family).toEqual(4);
   });
 
-  it("Name resolution for localhost2 should result in an error (integer option)", () => {
-    dns.lookup("localhost2", 4, (err, address, family) => {
-      expect(err.message).toEqual(
-        "failed to lookup address information: nodename nor servname provided, or not known"
-      );
-    });
+  it("Name resolution for localhost2 should result in an error (integer option)", async () => {
+    await expect(dnsLookupAsync("localhost2", 4)).rejects.toThrow(
+      "failed to lookup address information: nodename nor servname provided, or not known"
+    );
   });
 
-  it("localhost name resolution should be possible (record option)", (done) => {
-    dns.lookup("localhost", { family: 4 }, (err, address, family) => {
-      expect(err).toBeNull();
-      expect(address).toEqual("127.0.0.1");
-      expect(family).toEqual(4);
-      done();
+  it("localhost name resolution should be possible (record option)", async () => {
+    const { address, family } = await dnsLookupAsync("localhost", {
+      family: 4,
     });
+    expect(address).toEqual("127.0.0.1");
+    expect(family).toEqual(4);
   });
 
-  it("Name resolution for localhost2 should result in an error (record option)", () => {
-    dns.lookup("localhost2", { family: 4 }, (err, address, family) => {
-      expect(err.message).toEqual(
-        "failed to lookup address information: nodename nor servname provided, or not known"
-      );
-    });
+  it("Name resolution for localhost2 should result in an error (record option)", async () => {
+    await expect(dnsLookupAsync("localhost2", { family: 4 })).rejects.toThrow(
+      "failed to lookup address information: nodename nor servname provided, or not known"
+    );
   });
 });

--- a/tests/unit/dns.test.ts
+++ b/tests/unit/dns.test.ts
@@ -19,18 +19,10 @@ describe("lookup", () => {
     expect(family === 4 || family === 6).toBeTruthy();
   });
 
-  it("Name resolution for localhost2 should result in an error (optionless)", async () => {
-    await expect(dnsLookupAsync("localhost2")).rejects.toThrow("known");
-  });
-
   it("localhost name resolution should be possible (integer option)", async () => {
     const { address, family } = await dnsLookupAsync("localhost", 4);
     expect(address).toEqual("127.0.0.1");
     expect(family).toEqual(4);
-  });
-
-  it("Name resolution for localhost2 should result in an error (integer option)", async () => {
-    await expect(dnsLookupAsync("localhost2", 4)).rejects.toThrow("known");
   });
 
   it("localhost name resolution should be possible (record option)", async () => {
@@ -41,9 +33,19 @@ describe("lookup", () => {
     expect(family).toEqual(4);
   });
 
-  it("Name resolution for localhost2 should result in an error (record option)", async () => {
-    await expect(dnsLookupAsync("localhost2", { family: 4 })).rejects.toThrow(
-      "known"
-    );
-  });
+  if (process.platform !== "linux") {
+    it("Name resolution for localhost2 should result in an error (integer option)", async () => {
+      await expect(dnsLookupAsync("localhost2", 4)).rejects.toThrow("known");
+    });
+
+    it("Name resolution for localhost2 should result in an error (optionless)", async () => {
+      await expect(dnsLookupAsync("localhost2")).rejects.toThrow("known");
+    });
+
+    it("Name resolution for localhost2 should result in an error (record option)", async () => {
+      await expect(dnsLookupAsync("localhost2", { family: 4 })).rejects.toThrow(
+        "known"
+      );
+    });
+  }
 });


### PR DESCRIPTION
### Description of changes

Test introduced by https://github.com/awslabs/llrt/pull/825 had assertions in callbacks of non-asynchronous functions. This will (by design) crash the process if not handled correctly.

Throwing an error in a callback will result in process exit. This PR fixes the assertions by wrapping the lookup in a promise. Another option would be to use the `done` callback and an inner try catch in the callback.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
