### PR TITLE
feat(buffer): implement some static and prototype methods

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,7 +37,15 @@
 
 [write](https://nodejs.org/api/buffer.html#bufwritestring-offset-length-encoding)
 
+[writeInt8](https://nodejs.org/api/buffer.html#bufwriteint8value-offset)
+
+[writeInt16BE](https://nodejs.org/api/buffer.html#bufwriteint16bevalue-offset)
+
+[writeInt16LE](https://nodejs.org/api/buffer.html#bufwriteint16levalue-offset)
+
 [writeInt32BE](https://nodejs.org/api/buffer.html#bufwriteint32bevalue-offset)
+
+[writeInt32LE](https://nodejs.org/api/buffer.html#bufwriteint32levalue-offset)
 
 ### constants
 

--- a/API.md
+++ b/API.md
@@ -9,17 +9,41 @@
 
 ## buffer
 
+### static methods
+
 [alloc](https://nodejs.org/api/buffer.html#static-method-bufferallocsize-fill-encoding)
+
+[allocUnsafe](https://nodejs.org/api/buffer.html#static-method-bufferallocunsafesize)
+
+[allocUnsafeSlow](https://nodejs.org/api/buffer.html#static-method-bufferallocunsafeslowsize)
 
 [byteLength](https://nodejs.org/api/buffer.html#static-method-bufferbytelengthstring-encoding)
 
 [concat](https://nodejs.org/api/buffer.html#static-method-bufferconcatlist-totallength)
 
+[from](https://nodejs.org/api/buffer.html#static-method-bufferfromarray)
+
+[isBuffer](https://nodejs.org/api/buffer.html#static-method-bufferisbufferobj)
+
+[isEncoding](https://nodejs.org/api/buffer.html#static-method-bufferisencodingencoding)
+
+### prototype methods
+
+[copy](https://nodejs.org/api/buffer.html#bufcopytarget-targetstart-sourcestart-sourceend)
+
+[subarray](https://nodejs.org/api/buffer.html#bufsubarraystart-end)
+
+[toString](https://nodejs.org/api/buffer.html#buftostringencoding-start-end)
+
+[write](https://nodejs.org/api/buffer.html#bufwritestring-offset-length-encoding)
+
+[writeInt32BE](https://nodejs.org/api/buffer.html#bufwriteint32bevalue-offset)
+
+### constants
+
 [constants.MAX_LENGTH](https://nodejs.org/api/buffer.html#bufferconstantsmax_length)
 
 [constants.MAX_STRING_LENGTH](https://nodejs.org/api/buffer.html#bufferconstantsmax_string_length)
-
-[from](https://nodejs.org/api/buffer.html#static-method-bufferfromarray)
 
 Everything else inherited from [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
 

--- a/API.md
+++ b/API.md
@@ -37,6 +37,18 @@
 
 [write](https://nodejs.org/api/buffer.html#bufwritestring-offset-length-encoding)
 
+[writeBigInt64BE](https://nodejs.org/api/buffer.html#bufwritebigint64bevalue-offset)
+
+[writeBigInt64LE](https://nodejs.org/api/buffer.html#bufwritebigint64levalue-offset)
+
+[writeDoubleBE](https://nodejs.org/api/buffer.html#bufwritedoublebevalue-offset)
+
+[writeDoubleLE](https://nodejs.org/api/buffer.html#bufwritedoublelevalue-offset)
+
+[writeFloatBE](https://nodejs.org/api/buffer.html#bufwritefloatbevalue-offset)
+
+[writeFloatLE](https://nodejs.org/api/buffer.html#bufwritefloatlevalue-offset)
+
 [writeInt8](https://nodejs.org/api/buffer.html#bufwriteint8value-offset)
 
 [writeInt16BE](https://nodejs.org/api/buffer.html#bufwriteint16bevalue-offset)
@@ -46,6 +58,16 @@
 [writeInt32BE](https://nodejs.org/api/buffer.html#bufwriteint32bevalue-offset)
 
 [writeInt32LE](https://nodejs.org/api/buffer.html#bufwriteint32levalue-offset)
+
+[writeUInt8](https://nodejs.org/api/buffer.html#bufwriteuint8value-offset)
+
+[writeUInt16BE](https://nodejs.org/api/buffer.html#bufwriteuint16bevalue-offset)
+
+[writeUInt16LE](https://nodejs.org/api/buffer.html#bufwriteuint16levalue-offset)
+
+[writeUInt32BE](https://nodejs.org/api/buffer.html#bufwriteuint32bevalue-offset)
+
+[writeUInt32LE](https://nodejs.org/api/buffer.html#bufwriteuint32levalue-offset)
 
 ### constants
 

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -479,7 +479,7 @@ pub enum Endian {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn write_value<'js>(
+fn write_buf<'js>(
     this: &This<Object<'js>>,
     ctx: &Ctx<'js>,
     value: &Value<'js>,
@@ -619,131 +619,67 @@ fn set_prototype<'js>(ctx: &Ctx<'js>, constructor: Object<'js>) -> Result<()> {
     prototype.set("write", Func::from(write))?;
     prototype.set(
         "writeBigInt64BE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Big, 64, true, false, true)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Big, 64, true, false, true)),
     )?;
     prototype.set(
         "writeBigInt64LE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 64, true, false, true)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 64, true, false, true)),
     )?;
     prototype.set(
         "writeDoubleBE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Big, 64, true, true, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Big, 64, true, true, false)),
     )?;
     prototype.set(
         "writeDoubleLE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 64, true, true, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 64, true, true, false)),
     )?;
     prototype.set(
         "writeFloatBE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Big, 32, true, true, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Big, 32, true, true, false)),
     )?;
     prototype.set(
         "writeFloatLE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 32, true, true, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 32, true, true, false)),
     )?;
     prototype.set(
         "writeInt8",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 8, true, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 8, true, false, false)),
     )?;
     prototype.set(
         "writeInt16BE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Big, 16, true, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Big, 16, true, false, false)),
     )?;
     prototype.set(
         "writeInt16LE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 16, true, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 16, true, false, false)),
     )?;
     prototype.set(
         "writeInt32BE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Big, 32, true, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Big, 32, true, false, false)),
     )?;
     prototype.set(
         "writeInt32LE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 32, true, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 32, true, false, false)),
     )?;
     prototype.set(
         "writeUInt8",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 8, false, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 8, false, false, false)),
     )?;
     prototype.set(
         "writeUInt16BE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Big, 16, false, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Big, 16, false, false, false)),
     )?;
     prototype.set(
         "writeUInt16LE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 16, false, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 16, false, false, false)),
     )?;
     prototype.set(
         "writeUInt32BE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Big, 32, false, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Big, 32, false, false, false)),
     )?;
     prototype.set(
         "writeUInt32LE",
-        Func::from(
-            |t: This<Object<'js>>, c: Ctx<'js>, v: Value<'js>, o: Opt<usize>| {
-                write_value(&t, &c, &v, &o, Endian::Little, 32, false, false, false)
-            },
-        ),
+        Func::from(|t, c, v, o| write_buf(&t, &c, &v, &o, Endian::Little, 32, false, false, false)),
     )?;
     //not assessable from js
     prototype.prop(PredefinedAtom::Meta, stringify!(Buffer))?;

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -318,10 +318,14 @@ fn copy<'js>(
     let source_start = args_iter.next().unwrap_or_default();
     let source_end = args_iter.next().unwrap_or_else(|| this.0.len());
 
+    let mut copyable_length = 0;
+
+    if source_start >= source_end {
+        return Ok(copyable_length);
+    }
+
     let source_bytes = ObjectBytes::from(&ctx, this.0.as_inner())?;
     let source_bytes = source_bytes.as_bytes(&ctx)?;
-
-    let mut copyable_length = 0;
 
     if let Some((array_buffer, _, _)) = target.get_array_buffer()? {
         let raw = array_buffer

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -149,6 +149,12 @@ fn maybeuninit_to_u8(vec: Vec<MaybeUninit<u8>>) -> Vec<u8> {
 
     std::mem::forget(vec);
 
+    // This conversion is safe because MaybeUninit has the same memory layout as u8, meaning the underlying bytes are identical.
+    // Since Vec<MaybeUninit> and Vec share the same memory representation, a simple reinterpretation of the pointer is valid.
+    // Additionally, Vec::from_raw_parts correctly reconstructs the vector using the original length and capacity, ensuring that memory ownership remains consistent.
+    // The call to std::mem::forget(vec) prevents the original Vec<MaybeUninit> from being dropped, avoiding double frees or memory corruption.
+    // However, this conversion is only safe if all elements of MaybeUninit are properly initialized.
+    // If any uninitialized values exist, reading them as u8 would lead to undefined behavior.
     unsafe { Vec::from_raw_parts(ptr, len, capacity) }
 }
 

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1,3 +1,4 @@
+// Test static methods
 describe("Buffer.alloc", () => {
   it("should create a buffer with specified size and fill with zeros (default fill)", () => {
     const size = 10;
@@ -58,6 +59,168 @@ describe("Buffer.alloc", () => {
     for (const byte of buffer) {
       expect(byte).toEqual(0);
     }
+  });
+});
+
+describe("Buffer.allocUnsafe", () => {
+  it("should create a buffer of the specified size", () => {
+    const size = 10;
+    const buffer = Buffer.allocUnsafe(size);
+
+    expect(buffer.length).toEqual(size);
+    for (const byte of buffer) {
+      expect(byte).toBeDefined();
+    }
+  });
+
+  it("should create an empty buffer when size is 0", () => {
+    const size = 0;
+    const buffer = Buffer.allocUnsafe(size);
+
+    expect(buffer.length).toEqual(size);
+  });
+
+  it("should throw a TypeError when size is negative", () => {
+    expect(() => {
+      const size = -1;
+      const buffer = Buffer.allocUnsafe(size);
+    }).toThrow(TypeError);
+  });
+});
+
+describe("Buffer.allocUnsafeSlow", () => {
+  it("should create a buffer of the specified size", () => {
+    const size = 10;
+    const buffer = Buffer.allocUnsafeSlow(size);
+
+    expect(buffer.length).toEqual(size);
+    for (const byte of buffer) {
+      expect(byte).toBeDefined();
+    }
+  });
+
+  it("should create an empty buffer when size is 0", () => {
+    const size = 0;
+    const buffer = Buffer.allocUnsafeSlow(size);
+
+    expect(buffer.length).toEqual(size);
+  });
+
+  it("should throw a TypeError when size is negative", () => {
+    expect(() => {
+      const size = -1;
+      const buffer = Buffer.allocUnsafeSlow(size);
+    }).toThrow(TypeError);
+  });
+});
+
+describe("Buffer.byteLength", () => {
+  it("should return the correct byte length for ASCII string", () => {
+    const length = Buffer.byteLength("Hello");
+
+    expect(length).toEqual(5);
+  });
+
+  it("should return the correct byte length for UTF-8 string", () => {
+    const length = Buffer.byteLength("👋");
+
+    expect(length).toEqual(4);
+  });
+
+  it("should return the correct byte length for UTF-8 string", () => {
+    const length = Buffer.byteLength("你好");
+
+    expect(length).toEqual(6);
+  });
+
+  it("should return the correct byte length for a buffer", () => {
+    const buffer = Buffer.from([1, 2, 3, 4, 5]);
+    const length = Buffer.byteLength(buffer);
+
+    expect(length).toEqual(5);
+  });
+
+  it("should return the correct byte length for a hex-encoded string", () => {
+    const length = Buffer.byteLength("deadbeef", "hex");
+
+    expect(length).toEqual(4);
+  });
+
+  it("should return the correct byte length for a base64-encoded string", () => {
+    const length = Buffer.byteLength("SGVsbG8gV29ybGQ=", "base64");
+
+    expect(length).toEqual(11);
+  });
+});
+
+describe("Buffer.concat", () => {
+  it("should concatenate buffers", () => {
+    const buffer1 = Buffer.from("Hello");
+    const buffer2 = Buffer.from(" ");
+    const buffer3 = Buffer.from("World");
+    const resultBuffer = Buffer.concat([buffer1, buffer2, buffer3]);
+
+    expect(resultBuffer.toString()).toEqual("Hello World");
+  });
+
+  it("should handle empty buffers in the array", () => {
+    const buffer1 = Buffer.from("Hello");
+    const buffer2 = Buffer.from("");
+    const buffer3 = Buffer.from("World");
+    const resultBuffer = Buffer.concat([buffer1, buffer2, buffer3]);
+
+    expect(resultBuffer.toString()).toEqual("HelloWorld");
+  });
+
+  it("should handle an array with a single buffer", () => {
+    const buffer = Buffer.from("SingleBuffer");
+    const resultBuffer = Buffer.concat([buffer]);
+
+    expect(resultBuffer.toString()).toEqual("SingleBuffer");
+  });
+
+  it("should handle an empty array of buffers", () => {
+    const resultBuffer = Buffer.concat([]);
+
+    expect(resultBuffer.toString()).toEqual("");
+  });
+
+  it("should throw an error when the list contains a non-buffer", () => {
+    expect(() => {
+      const buffer1 = Buffer.from("Hello");
+      const invalidBuffer = "InvalidBuffer";
+      Buffer.concat([buffer1, invalidBuffer as any]);
+    }).toThrow(TypeError);
+  });
+
+  it("should throw an error when the totalLength is too large", () => {
+    expect(() => {
+      const buffer1 = Buffer.from("Hello");
+      const buffer2 = Buffer.alloc(2 ** 32); // 1 GB buffer
+      Buffer.concat([buffer1, buffer2], 2 ** 33); // totalLength exceeding maximum allowed
+    }).toThrow(RangeError);
+  });
+
+  it("should concatenate buffers with specified totalLength", () => {
+    const buffer1 = Buffer.from("123");
+    const buffer2 = Buffer.from("4567");
+    const buffer3 = Buffer.from("89");
+    const resultBuffer = Buffer.concat([buffer1, buffer2, buffer3], 4);
+
+    expect(resultBuffer.toString()).toEqual("1234");
+
+    const resultBuffer2 = Buffer.concat([buffer1, buffer2, buffer3], 3);
+
+    expect(resultBuffer2.toString()).toEqual("123");
+  });
+
+  it("should throw an error when totalLength is less than the actual length of concatenated buffers", () => {
+    const buffer1 = Buffer.from("Hello");
+    const buffer2 = Buffer.from("World");
+    const resultBuffer = Buffer.concat([buffer1, buffer2], 999);
+
+    expect(resultBuffer.toString()).toEqual("HelloWorld");
+    expect(resultBuffer.length).toEqual(buffer1.length + buffer2.length);
   });
 });
 
@@ -170,140 +333,76 @@ describe("Buffer.from", () => {
   });
 });
 
-describe("toString", () => {
-  it("should convert buffer to a string with utf-8 encoding", () => {
-    const input = "Hello, world!";
-    const buffer = Buffer.from(input);
+describe("Buffer.isBuffer", () => {
+  it("should return true when the object being tested is an instance of Buffer", () => {
+    const buffer = Buffer.from("Hello, world!");
 
-    expect(buffer.toString("utf-8")).toEqual(input);
+    expect(Buffer.isBuffer(buffer)).toEqual(true);
   });
 
-  it("should convert buffer to a string with base64 encoding", () => {
-    const input = "SGVsbG8sIHdvcmxkIQ==";
-    const buffer = Buffer.from(input, "base64");
-
-    expect(buffer.toString("base64")).toEqual(input);
-  });
-
-  it("should convert buffer to a string with hex encoding", () => {
-    const input = "48656c6c6f2c20776f726c6421";
-    const buffer = Buffer.from(input, "hex");
-
-    expect(buffer.toString("hex")).toEqual(input);
+  it("should return false when the object being tested is not an instance of Buffer", () => {
+    expect(Buffer.isBuffer(false)).toEqual(false);
+    expect(Buffer.isBuffer(undefined)).toEqual(false);
+    expect(Buffer.isBuffer(null)).toEqual(false);
+    expect(Buffer.isBuffer("Buffer")).toEqual(false);
+    expect(Buffer.isBuffer(Buffer)).toEqual(false);
   });
 });
 
-describe("Buffer.concat", () => {
-  it("should concatenate buffers", () => {
-    const buffer1 = Buffer.from("Hello");
-    const buffer2 = Buffer.from(" ");
-    const buffer3 = Buffer.from("World");
-    const resultBuffer = Buffer.concat([buffer1, buffer2, buffer3]);
-
-    expect(resultBuffer.toString()).toEqual("Hello World");
+describe("Buffer.isEncoding", () => {
+  it("should return true when input is a valid encoding name", () => {
+    expect(Buffer.isEncoding("utf8")).toEqual(true);
+    expect(Buffer.isEncoding("hex")).toEqual(true);
+    expect(Buffer.isEncoding("base64")).toEqual(true);
   });
 
-  it("should handle empty buffers in the array", () => {
-    const buffer1 = Buffer.from("Hello");
-    const buffer2 = Buffer.from("");
-    const buffer3 = Buffer.from("World");
-    const resultBuffer = Buffer.concat([buffer1, buffer2, buffer3]);
-
-    expect(resultBuffer.toString()).toEqual("HelloWorld");
-  });
-
-  it("should handle an array with a single buffer", () => {
-    const buffer = Buffer.from("SingleBuffer");
-    const resultBuffer = Buffer.concat([buffer]);
-
-    expect(resultBuffer.toString()).toEqual("SingleBuffer");
-  });
-
-  it("should handle an empty array of buffers", () => {
-    const resultBuffer = Buffer.concat([]);
-
-    expect(resultBuffer.toString()).toEqual("");
-  });
-
-  it("should throw an error when the list contains a non-buffer", () => {
-    expect(() => {
-      const buffer1 = Buffer.from("Hello");
-      const invalidBuffer = "InvalidBuffer";
-      Buffer.concat([buffer1, invalidBuffer as any]);
-    }).toThrow(TypeError);
-  });
-
-  it("should throw an error when the totalLength is too large", () => {
-    expect(() => {
-      const buffer1 = Buffer.from("Hello");
-      const buffer2 = Buffer.alloc(2 ** 32); // 1 GB buffer
-      Buffer.concat([buffer1, buffer2], 2 ** 33); // totalLength exceeding maximum allowed
-    }).toThrow(RangeError);
-  });
-
-  it("should concatenate buffers with specified totalLength", () => {
-    const buffer1 = Buffer.from("123");
-    const buffer2 = Buffer.from("4567");
-    const buffer3 = Buffer.from("89");
-    const resultBuffer = Buffer.concat([buffer1, buffer2, buffer3], 4);
-
-    expect(resultBuffer.toString()).toEqual("1234");
-
-    const resultBuffer2 = Buffer.concat([buffer1, buffer2, buffer3], 3);
-
-    expect(resultBuffer2.toString()).toEqual("123");
-  });
-
-  it("should throw an error when totalLength is less than the actual length of concatenated buffers", () => {
-    const buffer1 = Buffer.from("Hello");
-    const buffer2 = Buffer.from("World");
-    const resultBuffer = Buffer.concat([buffer1, buffer2], 999);
-
-    expect(resultBuffer.toString()).toEqual("HelloWorld");
-    expect(resultBuffer.length).toEqual(buffer1.length + buffer2.length);
+  it("should return false when input is not a valid encoding name", () => {
+    expect(Buffer.isEncoding(false as unknown as string)).toEqual(false);
+    expect(Buffer.isEncoding(undefined as unknown as string)).toEqual(false);
+    expect(Buffer.isEncoding(null as unknown as string)).toEqual(false);
+    expect(Buffer.isEncoding("utf8/8")).toEqual(false);
   });
 });
 
-describe("Buffer.byteLength", () => {
-  it("should return the correct byte length for ASCII string", () => {
-    const length = Buffer.byteLength("Hello");
-
-    expect(length).toEqual(5);
+// Test prototype methods
+describe("copy", () => {
+  it("should copy the entire source buffer to the destination buffer", () => {
+    const bufSrc = Buffer.from("abcdefghijklmnopqrstuvwxyz");
+    const bufDest = Buffer.from("**************************");
+    expect(bufSrc.copy(bufDest)).toEqual(26);
+    expect(bufDest.toString()).toEqual("abcdefghijklmnopqrstuvwxyz");
   });
 
-  it("should return the correct byte length for UTF-8 string", () => {
-    const length = Buffer.byteLength("👋");
-
-    expect(length).toEqual(4);
+  it("should copy the entire source buffer starting from a specified offset in the destination buffer", () => {
+    const bufSrc = Buffer.from("abcdefghijklmnopqrstuvwxyz");
+    const bufDest = Buffer.from("**************************");
+    expect(bufSrc.copy(bufDest, 5)).toEqual(21);
+    expect(bufDest.toString()).toEqual("*****abcdefghijklmnopqrstu");
   });
 
-  it("should return the correct byte length for UTF-8 string", () => {
-    const length = Buffer.byteLength("你好");
-
-    expect(length).toEqual(6);
+  it("should copy a portion of the source buffer starting from a specified source offset to the destination buffer at a specified offset", () => {
+    const bufSrc = Buffer.from("abcdefghijklmnopqrstuvwxyz");
+    const bufDest = Buffer.from("**************************");
+    expect(bufSrc.copy(bufDest, 5, 10)).toEqual(16);
+    expect(bufDest.toString()).toEqual("*****klmnopqrstuvwxyz*****");
   });
 
-  it("should return the correct byte length for a buffer", () => {
-    const buffer = Buffer.from([1, 2, 3, 4, 5]);
-    const length = Buffer.byteLength(buffer);
-
-    expect(length).toEqual(5);
+  it("should copy a specific range of the source buffer to the destination buffer at a specified offset", () => {
+    const bufSrc = Buffer.from("abcdefghijklmnopqrstuvwxyz");
+    const bufDest = Buffer.from("**************************");
+    expect(bufSrc.copy(bufDest, 5, 10, 15)).toEqual(5);
+    expect(bufDest.toString()).toEqual("*****klmno****************");
   });
 
-  it("should return the correct byte length for a hex-encoded string", () => {
-    const length = Buffer.byteLength("deadbeef", "hex");
-
-    expect(length).toEqual(4);
-  });
-
-  it("should return the correct byte length for a base64-encoded string", () => {
-    const length = Buffer.byteLength("SGVsbG8gV29ybGQ=", "base64");
-
-    expect(length).toEqual(11);
+  it("should return 0 and not modify the destination buffer when the source start index is greater than the source end index", () => {
+    const bufSrc = Buffer.from("abcdefghijklmnopqrstuvwxyz");
+    const bufDest = Buffer.from("**************************");
+    expect(bufSrc.copy(bufDest, 5, 10, 9)).toEqual(0);
+    expect(bufDest.toString()).toEqual("**************************");
   });
 });
 
-describe("Buffer.subarray", () => {
+describe("subarray", () => {
   it("should create a subarray from a buffer with the specified start and end indices", () => {
     const buffer = Buffer.from("Hello, world!");
     const subBuffer = buffer.subarray(7, 12);
@@ -373,33 +472,108 @@ describe("Buffer.subarray", () => {
   });
 });
 
-describe("Buffer.isBuffer", () => {
-  it("should return true when the object being tested is an instance of Buffer", () => {
-    const buffer = Buffer.from("Hello, world!");
+describe("toString", () => {
+  it("should convert buffer to a string with utf-8 encoding", () => {
+    const input = "Hello, world!";
+    const buffer = Buffer.from(input);
 
-    expect(Buffer.isBuffer(buffer)).toEqual(true);
+    expect(buffer.toString("utf-8")).toEqual(input);
   });
 
-  it("should return false when the object being tested is not an instance of Buffer", () => {
-    expect(Buffer.isBuffer(false)).toEqual(false);
-    expect(Buffer.isBuffer(undefined)).toEqual(false);
-    expect(Buffer.isBuffer(null)).toEqual(false);
-    expect(Buffer.isBuffer("Buffer")).toEqual(false);
-    expect(Buffer.isBuffer(Buffer)).toEqual(false);
+  it("should convert buffer to a string with base64 encoding", () => {
+    const input = "SGVsbG8sIHdvcmxkIQ==";
+    const buffer = Buffer.from(input, "base64");
+
+    expect(buffer.toString("base64")).toEqual(input);
+  });
+
+  it("should convert buffer to a string with hex encoding", () => {
+    const input = "48656c6c6f2c20776f726c6421";
+    const buffer = Buffer.from(input, "hex");
+
+    expect(buffer.toString("hex")).toEqual(input);
   });
 });
 
-describe("Buffer.isEncoding", () => {
-  it("should return true when input is a valid encoding name", () => {
-    expect(Buffer.isEncoding("utf8")).toEqual(true);
-    expect(Buffer.isEncoding("hex")).toEqual(true);
-    expect(Buffer.isEncoding("base64")).toEqual(true);
+describe("write", () => {
+  it("should write a UTF-8 string into a buffer and return the correct byte length", () => {
+    const buf1 = Buffer.alloc(15);
+    expect(buf1.write("こんにちは", "utf-8")).toEqual(15); // "こんにちは" means 'hello' in japanese.
+    expect(buf1.toString("utf8")).toEqual("こんにちは");
   });
 
-  it("should return false when input is not a valid encoding name", () => {
-    expect(Buffer.isEncoding(false as unknown as string)).toEqual(false);
-    expect(Buffer.isEncoding(undefined as unknown as string)).toEqual(false);
-    expect(Buffer.isEncoding(null as unknown as string)).toEqual(false);
-    expect(Buffer.isEncoding("utf8/8")).toEqual(false);
+  it("should write a hex string into a buffer and correctly convert it to UTF-8", () => {
+    const buf2 = Buffer.alloc(15);
+    expect(buf2.write("68656c6c6f", "hex")).toEqual(5); // 68656c6c6f -> 'hello'
+    expect(buf2.toString("utf8").substring(0, 5)).toEqual("hello");
+  });
+
+  it("should write a UTF-8 string into a buffer with an explicit offset of 0", () => {
+    const buf1 = Buffer.alloc(15);
+    expect(buf1.write("こんにちは", 0, "utf-8")).toEqual(15);
+    expect(buf1.toString("utf8")).toEqual("こんにちは");
+  });
+
+  it("should write a hex string into a buffer with an explicit offset of 0", () => {
+    const buf2 = Buffer.alloc(15);
+    expect(buf2.write("68656c6c6f", 0, "hex")).toEqual(5);
+    expect(buf2.toString("utf8").substring(0, 5)).toEqual("hello");
+  });
+
+  it("should write a UTF-8 string at offset 12 and store only part of it", () => {
+    const buf1 = Buffer.alloc(15);
+    expect(buf1.write("こんにちは", 12, "utf-8")).toEqual(3);
+    expect(buf1.toString("utf8").substring(12)).toEqual("こ");
+  });
+
+  it("should write a hex string at offset 12 and store only part of it", () => {
+    const buf2 = Buffer.alloc(15);
+    expect(buf2.write("68656c6c6f", 12, "hex")).toEqual(3);
+    expect(buf2.toString("utf8").substring(12)).toEqual("hel");
+  });
+
+  it("should write only the first 3 bytes of a UTF-8 string and store a partial character", () => {
+    const buf1 = Buffer.alloc(15);
+    expect(buf1.write("こんにちは", 0, 3, "utf-8")).toEqual(3);
+    expect(buf1.toString("utf8").substring(0, 1)).toEqual("こ"); // Returning characters instead of bytes
+  });
+
+  it("should write only the first 3 bytes of a hex string and correctly store the data", () => {
+    const buf2 = Buffer.alloc(15);
+    expect(buf2.write("68656c6c6f", 0, 3, "hex")).toEqual(3);
+    expect(buf2.toString("utf8").substring(0, 3)).toEqual("hel");
+  });
+
+  it("should write a UTF-8 string at offset 9 with a length of 12 bytes and store part of it", () => {
+    const buf1 = Buffer.alloc(15);
+    expect(buf1.write("こんにちは", 9, 12, "utf-8")).toEqual(6);
+    expect(buf1.toString("utf8").substring(9, 12)).toEqual("こん");
+  });
+
+  it("should write a hex string at offset 9 with a length of 12 bytes and store part of it", () => {
+    const buf2 = Buffer.alloc(15);
+    expect(buf2.write("68656c6c6f", 9, 12, "hex")).toEqual(5);
+    expect(buf2.toString("utf8").substring(9, 12)).toEqual("hel");
+  });
+});
+
+describe("writeInt32BE", () => {
+  it("should write a 32-bit integer in big-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeInt32BE(0x01020304)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([1, 2, 3, 4, 0, 0, 0, 0]));
+  });
+
+  it("should write a 32-bit integer in big-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeInt32BE(0x01020304, 4)).toEqual(8);
+    expect(buf).toEqual(Buffer.from([0, 0, 0, 0, 1, 2, 3, 4]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(8);
+      buf.writeInt32BE(0x01020304, 5);
+    }).toThrow(RangeError);
   });
 });

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -557,6 +557,148 @@ describe("write", () => {
   });
 });
 
+describe("writeBigInt64BE", () => {
+  it("should write a 64-bit BigInteger in big-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.writeBigInt64BE(0x0102030405060708n)).toEqual(8);
+    expect(buf).toEqual(
+      Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0])
+    );
+  });
+
+  it("should write a 64-bit BigInteger in big-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.writeBigInt64BE(0x0102030405060708n, 8)).toEqual(16);
+    expect(buf).toEqual(
+      Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8])
+    );
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(16);
+      buf.writeBigInt64BE(0x0102030405060708n, 9);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeBigInt64LE", () => {
+  it("should write a 64-bit BigInteger in little-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.writeBigInt64LE(0x0102030405060708n)).toEqual(8);
+    expect(buf).toEqual(
+      Buffer.from([8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0])
+    );
+  });
+
+  it("should write a 64-bit BigInteger in little-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.writeBigInt64LE(0x0102030405060708n, 8)).toEqual(16);
+    expect(buf).toEqual(
+      Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 8, 7, 6, 5, 4, 3, 2, 1])
+    );
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(16);
+      buf.writeBigInt64LE(0x0102030405060708n, 9);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeDoubleBE", () => {
+  it("should write a 64-bit Double in big-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.writeDoubleBE(123.456)).toEqual(8);
+    expect(buf).toEqual(
+      Buffer.from([64, 94, 221, 47, 26, 159, 190, 119, 0, 0, 0, 0, 0, 0, 0, 0])
+    );
+  });
+
+  it("should write a 64-bit Double in big-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.writeDoubleBE(123.456, 8)).toEqual(16);
+    expect(buf).toEqual(
+      Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 64, 94, 221, 47, 26, 159, 190, 119])
+    );
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(16);
+      buf.writeDoubleBE(123.456, 9);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeDoubleLE", () => {
+  it("should write a 64-bit Double in little-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.writeDoubleLE(123.456)).toEqual(8);
+    expect(buf).toEqual(
+      Buffer.from([119, 190, 159, 26, 47, 221, 94, 64, 0, 0, 0, 0, 0, 0, 0, 0])
+    );
+  });
+
+  it("should write a 64-bit Double in little-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(16);
+    expect(buf.writeDoubleLE(123.456, 8)).toEqual(16);
+    expect(buf).toEqual(
+      Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 119, 190, 159, 26, 47, 221, 94, 64])
+    );
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(16);
+      buf.writeDoubleLE(123.456, 9);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeFloatBE", () => {
+  it("should write a 32-bit Float in big-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeFloatBE(0xcafebabe)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([79, 74, 254, 187, 0, 0, 0, 0]));
+  });
+
+  it("should write a 32-bit Float in big-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeFloatBE(0xcafebabe, 4)).toEqual(8);
+    expect(buf).toEqual(Buffer.from([0, 0, 0, 0, 79, 74, 254, 187]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(8);
+      buf.writeFloatBE(0xcafebabe, 5);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeFloatLE", () => {
+  it("should write a 32-bit Float in little-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeFloatLE(0xcafebabe)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([187, 254, 74, 79, 0, 0, 0, 0]));
+  });
+
+  it("should write a 32-bit Float in little-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeFloatLE(0xcafebabe, 4)).toEqual(8);
+    expect(buf).toEqual(Buffer.from([0, 0, 0, 0, 187, 254, 74, 79]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(8);
+      buf.writeFloatLE(0xcafebabe, 5);
+    }).toThrow(RangeError);
+  });
+});
+
 describe("writeInt8", () => {
   it("should write a 8-bit integer at the beginning of the buffer", () => {
     const buf = Buffer.alloc(2);
@@ -644,8 +786,116 @@ describe("writeInt32BE", () => {
 describe("writeInt32LE", () => {
   it("should write a 32-bit integer in little-endian format at the beginning of the buffer", () => {
     const buf = Buffer.alloc(8);
-    expect(buf.writeInt32LE(0x01020304)).toEqual(4);
-    expect(buf).toEqual(Buffer.from([4, 3, 2, 1, 0, 0, 0, 0]));
+    expect(buf.writeInt32LE(0x05060708)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([8, 7, 6, 5, 0, 0, 0, 0]));
+  });
+
+  it("should write a 32-bit integer in little-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeInt32LE(0x05060708, 4)).toEqual(8);
+    expect(buf).toEqual(Buffer.from([0, 0, 0, 0, 8, 7, 6, 5]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(8);
+      buf.writeInt32LE(0x05060708, 5);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeUInt8", () => {
+  it("should write a 8-bit integer at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(2);
+    expect(buf.writeUInt8(2)).toEqual(1);
+    expect(buf).toEqual(Buffer.from([2, 0]));
+  });
+
+  it("should write a 8-bit integer at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeUInt8(0x3, 0)).toEqual(1);
+    expect(buf.writeUInt8(0x4, 1)).toEqual(2);
+    expect(buf.writeUInt8(0x23, 2)).toEqual(3);
+    expect(buf.writeUInt8(0x42, 3)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([3, 4, 35, 66]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(2);
+      buf.writeInt8(0x01, 3);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeUInt16BE", () => {
+  it("should write a 16-bit integer in big-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeUInt16BE(0xdead)).toEqual(2);
+    expect(buf).toEqual(Buffer.from([222, 173, 0, 0]));
+  });
+
+  it("should write a 16-bit integer in big-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeUInt16BE(0xbeef, 2)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([0, 0, 190, 239]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(4);
+      buf.writeUInt16BE(0x0102, 3);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeUInt16LE", () => {
+  it("should write a 16-bit integer in little-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeUInt16LE(0xdead)).toEqual(2);
+    expect(buf).toEqual(Buffer.from([173, 222, 0, 0]));
+  });
+
+  it("should write a 16-bit integer in little-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeUInt16LE(0xbeef, 2)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([0, 0, 239, 190]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(4);
+      buf.writeUInt16LE(0x0304, 3);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeUInt32BE", () => {
+  it("should write a 32-bit integer in big-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeUInt32BE(0xfeedface)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([254, 237, 250, 206, 0, 0, 0, 0]));
+  });
+
+  it("should write a 32-bit integer in big-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeUInt32BE(0xfeedface, 4)).toEqual(8);
+    expect(buf).toEqual(Buffer.from([0, 0, 0, 0, 254, 237, 250, 206]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(8);
+      buf.writeUInt32BE(0x01020304, 5);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeInt32LE", () => {
+  it("should write a 32-bit integer in little-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeUInt32LE(0xfeedface)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([206, 250, 237, 254, 0, 0, 0, 0]));
   });
 
   it("should write a 32-bit integer in little-endian format at the specified offset in the buffer", () => {

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -805,13 +805,13 @@ describe("writeInt32LE", () => {
 });
 
 describe("writeUInt8", () => {
-  it("should write a 8-bit integer at the beginning of the buffer", () => {
+  it("should write a 8-bit unsigned integer at the beginning of the buffer", () => {
     const buf = Buffer.alloc(2);
     expect(buf.writeUInt8(2)).toEqual(1);
     expect(buf).toEqual(Buffer.from([2, 0]));
   });
 
-  it("should write a 8-bit integer at the specified offset in the buffer", () => {
+  it("should write a 8-bit unsigned integer at the specified offset in the buffer", () => {
     const buf = Buffer.alloc(4);
     expect(buf.writeUInt8(0x3, 0)).toEqual(1);
     expect(buf.writeUInt8(0x4, 1)).toEqual(2);
@@ -829,13 +829,13 @@ describe("writeUInt8", () => {
 });
 
 describe("writeUInt16BE", () => {
-  it("should write a 16-bit integer in big-endian format at the beginning of the buffer", () => {
+  it("should write a 16-bit unsigned integer in big-endian format at the beginning of the buffer", () => {
     const buf = Buffer.alloc(4);
     expect(buf.writeUInt16BE(0xdead)).toEqual(2);
     expect(buf).toEqual(Buffer.from([222, 173, 0, 0]));
   });
 
-  it("should write a 16-bit integer in big-endian format at the specified offset in the buffer", () => {
+  it("should write a 16-bit unsigned integer in big-endian format at the specified offset in the buffer", () => {
     const buf = Buffer.alloc(4);
     expect(buf.writeUInt16BE(0xbeef, 2)).toEqual(4);
     expect(buf).toEqual(Buffer.from([0, 0, 190, 239]));
@@ -850,13 +850,13 @@ describe("writeUInt16BE", () => {
 });
 
 describe("writeUInt16LE", () => {
-  it("should write a 16-bit integer in little-endian format at the beginning of the buffer", () => {
+  it("should write a 16-bit unsigned integer in little-endian format at the beginning of the buffer", () => {
     const buf = Buffer.alloc(4);
     expect(buf.writeUInt16LE(0xdead)).toEqual(2);
     expect(buf).toEqual(Buffer.from([173, 222, 0, 0]));
   });
 
-  it("should write a 16-bit integer in little-endian format at the specified offset in the buffer", () => {
+  it("should write a 16-bit unsigned integer in little-endian format at the specified offset in the buffer", () => {
     const buf = Buffer.alloc(4);
     expect(buf.writeUInt16LE(0xbeef, 2)).toEqual(4);
     expect(buf).toEqual(Buffer.from([0, 0, 239, 190]));
@@ -871,13 +871,13 @@ describe("writeUInt16LE", () => {
 });
 
 describe("writeUInt32BE", () => {
-  it("should write a 32-bit integer in big-endian format at the beginning of the buffer", () => {
+  it("should write a 32-bit unsigned integer in big-endian format at the beginning of the buffer", () => {
     const buf = Buffer.alloc(8);
     expect(buf.writeUInt32BE(0xfeedface)).toEqual(4);
     expect(buf).toEqual(Buffer.from([254, 237, 250, 206, 0, 0, 0, 0]));
   });
 
-  it("should write a 32-bit integer in big-endian format at the specified offset in the buffer", () => {
+  it("should write a 32-bit unsigned integer in big-endian format at the specified offset in the buffer", () => {
     const buf = Buffer.alloc(8);
     expect(buf.writeUInt32BE(0xfeedface, 4)).toEqual(8);
     expect(buf).toEqual(Buffer.from([0, 0, 0, 0, 254, 237, 250, 206]));
@@ -891,23 +891,23 @@ describe("writeUInt32BE", () => {
   });
 });
 
-describe("writeInt32LE", () => {
-  it("should write a 32-bit integer in little-endian format at the beginning of the buffer", () => {
+describe("writeUInt32LE", () => {
+  it("should write a 32-bit unsigned integer in little-endian format at the beginning of the buffer", () => {
     const buf = Buffer.alloc(8);
     expect(buf.writeUInt32LE(0xfeedface)).toEqual(4);
     expect(buf).toEqual(Buffer.from([206, 250, 237, 254, 0, 0, 0, 0]));
   });
 
-  it("should write a 32-bit integer in little-endian format at the specified offset in the buffer", () => {
+  it("should write a 32-bit unsigned integer in little-endian format at the specified offset in the buffer", () => {
     const buf = Buffer.alloc(8);
-    expect(buf.writeInt32LE(0x01020304, 4)).toEqual(8);
+    expect(buf.writeUInt32LE(0x01020304, 4)).toEqual(8);
     expect(buf).toEqual(Buffer.from([0, 0, 0, 0, 4, 3, 2, 1]));
   });
 
   it("should throw a RangeError if the offset is out of bounds", () => {
     expect(() => {
       const buf = Buffer.alloc(8);
-      buf.writeInt32LE(0x01020304, 5);
+      buf.writeUInt32LE(0x01020304, 5);
     }).toThrow(RangeError);
   });
 });

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -557,6 +557,69 @@ describe("write", () => {
   });
 });
 
+describe("writeInt8", () => {
+  it("should write a 8-bit integer at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(2);
+    expect(buf.writeInt8(0x01)).toEqual(1);
+    expect(buf).toEqual(Buffer.from([1, 0]));
+  });
+
+  it("should write a 8-bit integer at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(2);
+    expect(buf.writeInt8(0x01, 1)).toEqual(2);
+    expect(buf).toEqual(Buffer.from([0, 1]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(2);
+      buf.writeInt8(0x01, 3);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeInt16BE", () => {
+  it("should write a 16-bit integer in big-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeInt16BE(0x0102)).toEqual(2);
+    expect(buf).toEqual(Buffer.from([1, 2, 0, 0]));
+  });
+
+  it("should write a 16-bit integer in big-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeInt16BE(0x0102, 2)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([0, 0, 1, 2]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(4);
+      buf.writeInt16BE(0x0102, 3);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeInt16LE", () => {
+  it("should write a 16-bit integer in little-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeInt16LE(0x0102)).toEqual(2);
+    expect(buf).toEqual(Buffer.from([2, 1, 0, 0]));
+  });
+
+  it("should write a 16-bit integer in little-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.writeInt16LE(0x0102, 2)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([0, 0, 2, 1]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(4);
+      buf.writeInt16LE(0x0102, 3);
+    }).toThrow(RangeError);
+  });
+});
+
 describe("writeInt32BE", () => {
   it("should write a 32-bit integer in big-endian format at the beginning of the buffer", () => {
     const buf = Buffer.alloc(8);
@@ -574,6 +637,27 @@ describe("writeInt32BE", () => {
     expect(() => {
       const buf = Buffer.alloc(8);
       buf.writeInt32BE(0x01020304, 5);
+    }).toThrow(RangeError);
+  });
+});
+
+describe("writeInt32LE", () => {
+  it("should write a 32-bit integer in little-endian format at the beginning of the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeInt32LE(0x01020304)).toEqual(4);
+    expect(buf).toEqual(Buffer.from([4, 3, 2, 1, 0, 0, 0, 0]));
+  });
+
+  it("should write a 32-bit integer in little-endian format at the specified offset in the buffer", () => {
+    const buf = Buffer.alloc(8);
+    expect(buf.writeInt32LE(0x01020304, 4)).toEqual(8);
+    expect(buf).toEqual(Buffer.from([0, 0, 0, 0, 4, 3, 2, 1]));
+  });
+
+  it("should throw a RangeError if the offset is out of bounds", () => {
+    expect(() => {
+      const buf = Buffer.alloc(8);
+      buf.writeInt32LE(0x01020304, 5);
     }).toThrow(RangeError);
   });
 });

--- a/types/buffer.d.ts
+++ b/types/buffer.d.ts
@@ -220,6 +220,64 @@ declare module "buffer" {
   }
   interface Buffer extends Uint8Array {
     /**
+     * Copies data from a region of `buf` to a region in `target`, even if the `target`memory region overlaps with `buf`.
+     *
+     * [`TypedArray.prototype.set()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set) performs the same operation, and is available
+     * for all TypedArrays, including `Buffer`s, although it takes
+     * different function arguments.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * // Create two `Buffer` instances.
+     * const buf1 = Buffer.allocUnsafe(26);
+     * const buf2 = Buffer.allocUnsafe(26).fill('!');
+     *
+     * for (let i = 0; i < 26; i++) {
+     *   // 97 is the decimal ASCII value for 'a'.
+     *   buf1[i] = i + 97;
+     * }
+     *
+     * // Copy `buf1` bytes 16 through 19 into `buf2` starting at byte 8 of `buf2`.
+     * buf1.copy(buf2, 8, 16, 20);
+     * // This is equivalent to:
+     * // buf2.set(buf1.subarray(16, 20), 8);
+     *
+     * console.log(buf2.toString('ascii', 0, 25));
+     * // Prints: !!!!!!!!qrst!!!!!!!!!!!!!
+     * ```
+     *
+     * ```js
+     * import { Buffer } from 'node:buffer';
+     *
+     * // Create a `Buffer` and copy data from one region to an overlapping region
+     * // within the same `Buffer`.
+     *
+     * const buf = Buffer.allocUnsafe(26);
+     *
+     * for (let i = 0; i < 26; i++) {
+     *   // 97 is the decimal ASCII value for 'a'.
+     *   buf[i] = i + 97;
+     * }
+     *
+     * buf.copy(buf, 0, 4, 10);
+     *
+     * console.log(buf.toString());
+     * // Prints: efghijghijklmnopqrstuvwxyz
+     * ```
+     * @param target A `Buffer` or {@link Uint8Array} to copy into.
+     * @param [targetStart=0] The offset within `target` at which to begin writing.
+     * @param [sourceStart=0] The offset within `buf` from which to begin copying.
+     * @param [sourceEnd=buf.length] The offset within `buf` at which to stop copying (not inclusive).
+     * @return The number of bytes copied.
+     */
+    copy(
+      target: Uint8Array,
+      targetStart?: number,
+      sourceStart?: number,
+      sourceEnd?: number
+    ): number;
+    /**
      * Returns a new `Buffer` that references the same memory as the original, but
      * offset and cropped by the `start` and `end` indices.
      *
@@ -305,6 +363,27 @@ declare module "buffer" {
      * @param [encoding='utf8'] The character encoding to use.
      */
     toString(encoding?: BufferEncoding): string;
+    /**
+     * Writes `value` to `buf` at the specified `offset` as big-endian. The `value` must be a valid signed 32-bit integer. Behavior is undefined when `value` is
+     * anything other than a signed 32-bit integer.
+     *
+     * The `value` is interpreted and written as a two's complement signed integer.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(4);
+     *
+     * buf.writeInt32BE(0x01020304, 0);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer 01 02 03 04>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 4`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeInt32BE(value: number, offset?: number): number;
   }
   var Buffer: BufferConstructor;
   /**

--- a/types/buffer.d.ts
+++ b/types/buffer.d.ts
@@ -364,6 +364,82 @@ declare module "buffer" {
      */
     toString(encoding?: BufferEncoding): string;
     /**
+     * Writes `value` to `buf` at the specified `offset` as little-endian. The `value` must be a JavaScript number. Behavior is undefined when `value` is anything
+     * other than a JavaScript number.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(8);
+     *
+     * buf.writeDoubleLE(123.456, 0);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer 77 be 9f 1a 2f dd 5e 40>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 8`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeDoubleLE(value: number, offset?: number): number;
+    /**
+     * Writes `value` to `buf` at the specified `offset` as big-endian. The `value` must be a JavaScript number. Behavior is undefined when `value` is anything
+     * other than a JavaScript number.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(8);
+     *
+     * buf.writeDoubleBE(123.456, 0);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer 40 5e dd 2f 1a 9f be 77>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 8`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeDoubleBE(value: number, offset?: number): number;
+    /**
+     * Writes `value` to `buf` at the specified `offset` as little-endian. Behavior is
+     * undefined when `value` is anything other than a JavaScript number.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(4);
+     *
+     * buf.writeFloatLE(0xcafebabe, 0);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer bb fe 4a 4f>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 4`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeFloatLE(value: number, offset?: number): number;
+    /**
+     * Writes `value` to `buf` at the specified `offset` as big-endian. Behavior is
+     * undefined when `value` is anything other than a JavaScript number.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(4);
+     *
+     * buf.writeFloatBE(0xcafebabe, 0);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer 4f 4a fe bb>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 4`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeFloatBE(value: number, offset?: number): number;
+    /**
      * Writes `value` to `buf` at the specified `offset`. `value` must be a valid
      * signed 8-bit integer. Behavior is undefined when `value` is anything other than
      * a signed 8-bit integer.

--- a/types/buffer.d.ts
+++ b/types/buffer.d.ts
@@ -248,7 +248,7 @@ declare module "buffer" {
      * ```
      *
      * ```js
-     * import { Buffer } from 'node:buffer';
+     * import { Buffer } from 'buffer';
      *
      * // Create a `Buffer` and copy data from one region to an overlapping region
      * // within the same `Buffer`.
@@ -364,6 +364,92 @@ declare module "buffer" {
      */
     toString(encoding?: BufferEncoding): string;
     /**
+     * Writes `value` to `buf` at the specified `offset`. `value` must be a valid
+     * signed 8-bit integer. Behavior is undefined when `value` is anything other than
+     * a signed 8-bit integer.
+     *
+     * `value` is interpreted and written as a two's complement signed integer.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(2);
+     *
+     * buf.writeInt8(2, 0);
+     * buf.writeInt8(-2, 1);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer 02 fe>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 1`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeInt8(value: number, offset?: number): number;
+    /**
+     * Writes `value` to `buf` at the specified `offset` as little-endian.  The `value` must be a valid signed 16-bit integer. Behavior is undefined when `value` is
+     * anything other than a signed 16-bit integer.
+     *
+     * The `value` is interpreted and written as a two's complement signed integer.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(2);
+     *
+     * buf.writeInt16LE(0x0304, 0);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer 04 03>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 2`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeInt16LE(value: number, offset?: number): number;
+    /**
+     * Writes `value` to `buf` at the specified `offset` as big-endian.  The `value` must be a valid signed 16-bit integer. Behavior is undefined when `value` is
+     * anything other than a signed 16-bit integer.
+     *
+     * The `value` is interpreted and written as a two's complement signed integer.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(2);
+     *
+     * buf.writeInt16BE(0x0102, 0);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer 01 02>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 2`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeInt16BE(value: number, offset?: number): number;
+    /**
+     * Writes `value` to `buf` at the specified `offset` as little-endian. The `value` must be a valid signed 32-bit integer. Behavior is undefined when `value` is
+     * anything other than a signed 32-bit integer.
+     *
+     * The `value` is interpreted and written as a two's complement signed integer.
+     *
+     * ```js
+     * import { Buffer } from 'buffer';
+     *
+     * const buf = Buffer.allocUnsafe(4);
+     *
+     * buf.writeInt32LE(0x05060708, 0);
+     *
+     * console.log(buf);
+     * // Prints: <Buffer 08 07 06 05>
+     * ```
+     * @param value Number to be written to `buf`.
+     * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 4`.
+     * @return `offset` plus the number of bytes written.
+     */
+    writeInt32LE(value: number, offset?: number): number;
+    /**
      * Writes `value` to `buf` at the specified `offset` as big-endian. The `value` must be a valid signed 32-bit integer. Behavior is undefined when `value` is
      * anything other than a signed 32-bit integer.
      *
@@ -379,7 +465,6 @@ declare module "buffer" {
      * console.log(buf);
      * // Prints: <Buffer 01 02 03 04>
      * ```
-     * @param value Number to be written to `buf`.
      * @param [offset=0] Number of bytes to skip before starting to write. Must satisfy `0 <= offset <= buf.length - 4`.
      * @return `offset` plus the number of bytes written.
      */


### PR DESCRIPTION
### Description of changes

This PR implements some methods that I need for my project.
- [Static method: Buffer.allocUnsafe(size)](https://nodejs.org/api/buffer.html#static-method-bufferallocunsafesize)
- [Static method: Buffer.allocUnsafeSlow(size)](https://nodejs.org/api/buffer.html#static-method-bufferallocunsafeslowsize)
- [buf.copy(target[, targetStart[, sourceStart[, sourceEnd]]])](https://nodejs.org/api/buffer.html#bufcopytarget-targetstart-sourcestart-sourceend)
- [buf.write(string[, offset[, length]][, encoding])](https://nodejs.org/api/buffer.html#bufwritestring-offset-length-encoding)
- [buf.writeInt32BE(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteint32bevalue-offset)

By generalizing `buf.writeInt32BE()`, we also support:
- [buf.writeBigInt64BE(value[, offset])](https://nodejs.org/api/buffer.html#bufwritebigint64bevalue-offset)
- [buf.writeBigInt64LE(value[, offset])](https://nodejs.org/api/buffer.html#bufwritebigint64levalue-offset)
- [buf.writeDoubleBE(value[, offset])](https://nodejs.org/api/buffer.html#bufwritedoublebevalue-offset)
- [buf.writeDoubleLE(value[, offset])](https://nodejs.org/api/buffer.html#bufwritedoublelevalue-offset)
- [buf.writeFloatBE(value[, offset])](https://nodejs.org/api/buffer.html#bufwritefloatbevalue-offset)
- [buf.writeFloatLE(value[, offset])](https://nodejs.org/api/buffer.html#bufwritefloatlevalue-offset)
- [buf.writeInt8(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteint8value-offset)
- [buf.writeInt16BE(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteint16bevalue-offset)
- [buf.writeInt16LE(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteint16levalue-offset)
- [buf.writeInt32LE(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteint32levalue-offset)
- [buf.writeUInt8(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteuint8value-offset)
- [buf.writeUInt16BE(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteuint16bevalue-offset)
- [buf.writeUInt16LE(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteuint16levalue-offset)
- [buf.writeUInt32BE(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteuint32bevalue-offset)
- [buf.writeUInt32LE(value[, offset])](https://nodejs.org/api/buffer.html#bufwriteuint32levalue-offset)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
