### PR TITLE
fix: JSON.stringify with replacer returning new object

### DIFF
--- a/tests/unit/json.test.ts
+++ b/tests/unit/json.test.ts
@@ -299,7 +299,7 @@ describe("JSON Stringified", () => {
   });
 
   it("should stringify and remove objects that are not valid json", () => {
-    const now = new Date()
+    const now = new Date();
     const dateString = now.toJSON();
     const data = {
       a: "123",
@@ -326,5 +326,25 @@ describe("JSON Stringified", () => {
         v: 1n,
       })
     ).toThrow(/Do not know how to serialize a BigInt/);
+  });
+
+  it("should allow replacer that returns new non-primitive objects", () => {
+    const json = JSON.stringify({ key: "value" });
+
+    const obj = {
+      simple: "text",
+      nested: json,
+    };
+
+    const replacer = (key: any, value: any) => {
+      try {
+        return typeof value === "string" ? JSON.parse(value) : value;
+      } catch {
+        return value;
+      }
+    };
+
+    const result = JSON.stringify(obj, replacer);
+    expect(result).toEqual('{"simple":"text","nested":{"key":"value"}}');
   });
 });


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/854

### Description of changes

New objects returned by replacer was treated as primitives.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
