### PR TITLE
fix(core): resolve symbolic links

### DIFF
--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -118,6 +118,18 @@ pub fn require_resolve<'a>(
     y: &str,
     is_esm: bool,
 ) -> Result<Cow<'a, str>> {
+    // resolve symlink
+    let y = if let Ok(path) = Path::new(y).read_link() {
+        if path.is_absolute() {
+            path.to_string_lossy().to_string()
+        } else {
+            [y, "/../", path.to_string_lossy().as_ref()].concat()
+        }
+    } else {
+        y.to_string()
+    };
+    let y = y.as_str();
+
     trace!("require_resolve(x, y):({}, {})", x, y);
 
     // 1'. If X is a bytecode cache,


### PR DESCRIPTION
### Issue # (if available)

Fixed #875 

### Description of changes

Fixed an issue where paths could not be resolved correctly in require/import when the base path contained a symbolic link.

```
% pwd
/Users/shinya/Workspaces/llrt-test/symlink

% ls -lFa .    
total 16
drwxr-xr-x   5 shinya  staff   160  3  8 22:36 ./
drwxr-xr-x  90 shinya  staff  2880  3  8 12:27 ../
-rw-r--r--   1 shinya  staff    72  3  8 12:28 bar.js
drwxr-xr-x   7 shinya  staff   224  3  8 22:37 bin/
-rw-r--r--   1 shinya  staff    42  3  8 22:29 foo.js

% ls -lFa bin
total 16
drwxr-xr-x  7 shinya  staff  224  3  8 22:37 ./
drwxr-xr-x  5 shinya  staff  160  3  8 22:36 ../
lrwxr-xr-x  1 shinya  staff   54  3  8 22:37 absolute@ -> /Users/shinya/Workspaces/llrt-test/symlink/bin/hoge.js
lrwxr-xr-x  1 shinya  staff    9  3  8 12:29 foo@ -> ../foo.js
-rw-r--r--  1 shinya  staff   75  3  8 22:26 fuga.js
lrwxr-xr-x  1 shinya  staff    9  3  8 22:31 hoge@ -> ./hoge.js
-rw-r--r--  1 shinya  staff   45  3  8 22:30 hoge.js
```

<details>
<summary>File contents</summary>

```
% cat bin/fuga.js
function fuga() {
    console.log('fuga.js');
}
module.exports = {
    fuga
};

% cat bin/hoge.js
const { fuga } = require("./fuga");

fuga();

cat bar.js
function bar() {
    console.log('bar.js');
}
module.exports = {
    bar
};

% cat foo.js
const { bar } = require("./bar");

bar();
```

</details>

Result:
```
% llrt bin/foo
bar.js

% llrt bin/hoge
fuga.js

% llrt bin/absolute 
fuga.js
```

NOTE:
I couldn't create a reproducible environment in the fixtures directory because it contains symbolic links, so I couldn't write test code.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
