### PR TITLE
chore: Remove bitwise BS

### DIFF
--- a/libs/llrt_json/src/stringify.rs
+++ b/libs/llrt_json/src/stringify.rs
@@ -250,10 +250,12 @@ fn write_primitive2<'js>(
     match type_of {
         Type::Null | Type::Undefined => context.result.push_str("null"),
         Type::Bool => {
-            const BOOL_STRINGS: [&str; 2] = ["false", "true"];
-            context
-                .result
-                .push_str(BOOL_STRINGS[unsafe { value.as_bool().unwrap_unchecked() } as usize]);
+            let bool_str = if unsafe { value.as_bool().unwrap_unchecked() } {
+                "true"
+            } else {
+                "false"
+            };
+            context.result.push_str(bool_str);
         },
         Type::Int => context.result.push_str(
             context
@@ -381,21 +383,20 @@ fn append_value(context: &mut StringifyContext<'_, '_>, add_comma: bool) -> Resu
 fn write_key(string: &mut String, key: &str, indent: bool) {
     string.push('"');
     escape_json_string(string, key.as_bytes());
-    const SUFFIXES: [&str; 2] = ["\":", "\": "];
-    string.push_str(SUFFIXES[indent as usize]);
+    string.push_str("\":");
+    if indent {
+        string.push(' ');
+    }
 }
 
 #[inline(always)]
 fn write_sep(result: &mut String, add_comma: bool, has_indentation: bool) {
-    const SEPARATOR_TABLE: [&str; 4] = [
-        "",    // add_comma = false, has_indentation = false
-        ",",   // add_comma = false, has_indentation = true
-        "\n",  // add_comma = true, has_indentation = false
-        ",\n", // add_comma = true, has_indentation = true
-    ];
-
-    let index = (add_comma as usize) | ((has_indentation as usize) << 1);
-    result.push_str(SEPARATOR_TABLE[index]);
+    if add_comma {
+        result.push(',');
+    }
+    if has_indentation {
+        result.push('\n');
+    }
 }
 
 #[inline(always)]

--- a/libs/llrt_logging/src/lib.rs
+++ b/libs/llrt_logging/src/lib.rs
@@ -324,8 +324,12 @@ fn format_raw_inner<'js>(
             if color_enabled {
                 Color::YELLOW.push(result);
             }
-            const BOOL_STRINGS: [&str; 2] = ["false", "true"];
-            result.push_str(BOOL_STRINGS[unsafe { value.as_bool().unwrap_unchecked() } as usize]);
+            let bool_str = if unsafe { value.as_bool().unwrap_unchecked() } {
+                "true"
+            } else {
+                "false"
+            };
+            result.push_str(bool_str);
         },
         Type::BigInt => {
             if color_enabled {


### PR DESCRIPTION
### Description of changes

In console refactor we introduced a lot of bitwise premature optimizations to reduce branches. Compiler does a much better job of optimizing since we can use chars instead of slices etc. Code is also way more maintainable/readable now.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
