### PR TITLE
Make FormatOptions immutable

### DIFF
--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -153,8 +153,8 @@ where
             return Ok(());
         }
     } else {
-        let mut options = FormatOptions::new(ctx, is_tty, true)?;
-        build_formatted_string(&mut result, ctx, args, &mut options)?;
+        let options = FormatOptions::new(ctx, is_tty, true)?;
+        build_formatted_string(&mut result, ctx, args, &options)?;
     }
 
     result.push(NEWLINE);
@@ -261,7 +261,7 @@ fn write_lambda_log<'js>(
 
             let mut exception = None;
 
-            let mut options = FormatOptions::new(ctx, is_tty, true)?;
+            let options = FormatOptions::new(ctx, is_tty, true)?;
 
             for arg in args.0.iter() {
                 if arg.is_error() && exception.is_none() {
@@ -271,7 +271,7 @@ fn write_lambda_log<'js>(
                 }
             }
 
-            build_formatted_string(&mut values_string, ctx, args, &mut options)?;
+            build_formatted_string(&mut values_string, ctx, args, &options)?;
 
             result.push_str(&escape_json(values_string.as_bytes()));
             result.push('\"');

--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -312,8 +312,8 @@ fn write_lambda_log<'js>(
 
         result.push('}');
     } else {
-        let mut options = FormatOptions::new(ctx, is_tty && !is_json_log_format, is_newline)?;
-        build_formatted_string(result, ctx, args, &mut options)?;
+        let options = FormatOptions::new(ctx, is_tty && !is_json_log_format, is_newline)?;
+        build_formatted_string(result, ctx, args, &options)?;
 
         replace_newline_with_carriage_return(result);
     }

--- a/modules/llrt_console/src/lib.rs
+++ b/modules/llrt_console/src/lib.rs
@@ -101,8 +101,8 @@ where
     let is_tty = output.is_terminal();
     let mut result = String::new();
 
-    let mut options = FormatOptions::new(ctx, is_tty, true)?;
-    build_formatted_string(&mut result, ctx, args, &mut options)?;
+    let options = FormatOptions::new(ctx, is_tty, true)?;
+    build_formatted_string(&mut result, ctx, args, &options)?;
 
     result.push(NEWLINE);
 


### PR DESCRIPTION
### Description of changes

This makes the FormatOptions immutable, allowing us to store it if we want and re-use it.
I also think it makes it clearer what is an override versus the user intention.
Let me know if you like the pattern, I am not sure.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
