### PR TITLE
fix(core): fix for relative paths being accidentally stripped

### DIFF
--- a/fixtures/test903/bar.mjs
+++ b/fixtures/test903/bar.mjs
@@ -1,0 +1,3 @@
+export function bar() {
+  return "bar";
+}

--- a/fixtures/test903/foo.mjs
+++ b/fixtures/test903/foo.mjs
@@ -1,0 +1,2 @@
+import { bar } from "../bar.mjs";
+console.log(bar());

--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -141,6 +141,10 @@ pub fn require_resolve<'a>(
     let (_, ext_name) = name_extname(x);
     let is_supported_ext = is_supported_ext(ext_name);
 
+    let x_is_absolute = path::is_absolute(x);
+    let x_starts_with_current_dir = x.starts_with("./");
+    let x_starts_with_parent_dir = x.starts_with("../");
+
     if is_supported_ext && Path::new(x).is_file() {
         return resolved_by_file_exists(x.into());
     }
@@ -150,12 +154,9 @@ pub fn require_resolve<'a>(
         return resolved_by_bytecode_cache(x_normalized.into());
     }
 
-    if is_supported_ext && Path::new(&x_normalized).is_file() {
+    if !x_starts_with_parent_dir && is_supported_ext && Path::new(&x_normalized).is_file() {
         return resolved_by_file_exists(x_normalized.into());
     }
-
-    let x_is_absolute = path::is_absolute(x);
-    let x_starts_with_current_dir = x.starts_with("./");
 
     // 2. If X begins with '/'
     let y = if path::is_absolute(x) {
@@ -174,7 +175,7 @@ pub fn require_resolve<'a>(
     };
 
     // 3. If X begins with './' or '/' or '../'
-    if x_starts_with_current_dir || x_is_absolute || x.starts_with("../") {
+    if x_starts_with_current_dir || x_is_absolute || x_starts_with_parent_dir {
         let y_plus_x = if x_is_absolute {
             x.into()
         } else if x_starts_with_current_dir {

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -153,6 +153,12 @@ it("require `@aws-lambda-powertools` module element", () => {
   );
 });
 
+it("regression testing for issue #903", () => {
+  expect(() => _require(`${CWD}/fixtures/test903/foo.mjs`)).toThrow(
+    /Error resolving module /
+  );
+});
+
 //create a test that spawns a subprocess and executes require.mjs from fixtures and captures stdout
 it("should handle blocking requires", (done) => {
   const proc = spawn(process.argv0, [`${CWD}/fixtures/require.mjs`]);


### PR DESCRIPTION
### Issue # (if available)

Fixed #903

### Description of changes

Fixed an issue where path::normalize() was incorrectly removing relative paths when the path started with "../", resulting in a different file path when combined with the base directory.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
