### PR TITLE
feat(core): Support load module from file URL

### DIFF
--- a/llrt_core/src/module_loader/resolver.rs
+++ b/llrt_core/src/module_loader/resolver.rs
@@ -118,6 +118,9 @@ pub fn require_resolve<'a>(
     y: &str,
     is_esm: bool,
 ) -> Result<Cow<'a, str>> {
+    // trim schema
+    let x = x.trim_start_matches("file://");
+
     // resolve symlink
     let y = if let Ok(path) = Path::new(y).read_link() {
         if path.is_absolute() {

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -35,6 +35,18 @@ it("should require a json file (path unspecified)", () => {
   expect(a.private).toEqual(true);
 });
 
+it("should require a file (file schema)", () => {
+  const { hello } = _require(`file://${CWD}/fixtures/hello.js`);
+
+  expect(hello).toEqual("hello world!");
+});
+
+it("should require a json file (file schema)", () => {
+  const a = _require(`file://${CWD}/package.json`);
+
+  expect(a.private).toEqual(true);
+});
+
 it("should return same module when require multiple files", () => {
   const { hello: hello1 } = _require(`${CWD}/fixtures/hello.js`);
   const { hello: hello2 } = _require(`${CWD}/fixtures/hello.js`);


### PR DESCRIPTION
### Issue # (if available)

Closed #904

### Description of changes

Supports loading assets defined in file URL format.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
