### PR TITLE
fix: Print utf8 replacement char for broken surrogate pairs

### DIFF
--- a/libs/llrt_logging/src/lib.rs
+++ b/libs/llrt_logging/src/lib.rs
@@ -3,7 +3,9 @@
 use std::{
     collections::HashSet,
     io::{stdout, IsTerminal},
+    mem,
     ops::Deref,
+    slice,
 };
 
 use llrt_json::stringify::json_stringify;
@@ -15,8 +17,14 @@ use llrt_utils::{
     primordials::{BasePrimordials, Primordial},
 };
 use rquickjs::{
-    atom::PredefinedAtom, function::This, object::Filter, prelude::Rest, promise::PromiseState,
-    Coerced, Ctx, Error, Function, Object, Result, Symbol, Type, Value,
+    atom::PredefinedAtom,
+    function::This,
+    object::Filter,
+    prelude::Rest,
+    promise::PromiseState,
+    qjs, Coerced, Ctx,
+    Error::{self},
+    Function, Object, Result, Symbol, Type, Value,
 };
 
 pub const NEWLINE: char = '\n';
@@ -357,18 +365,9 @@ fn format_raw_inner<'js>(
             }));
         },
         Type::String => {
-            format_raw_string_inner(
-                result,
-                unsafe {
-                    value
-                        .as_string()
-                        .unwrap_unchecked()
-                        .to_string()
-                        .unwrap_unchecked()
-                },
-                !is_root,
-                color_enabled,
-            );
+            //FIXME can be removed if https://github.com/DelSkayn/rquickjs/pull/447 is merged
+            let lossy_string = get_lossy_string(value)?;
+            format_raw_string_inner(result, lossy_string, !is_root, color_enabled);
         },
         Type::Symbol => {
             if color_enabled {
@@ -601,6 +600,33 @@ fn format_raw_inner<'js>(
     Ok(())
 }
 
+fn get_lossy_string(string_value: Value) -> Result<String> {
+    if !string_value.is_string() {
+        return Err(Error::FromJs {
+            from: "Value",
+            to: "JSString",
+            message: Some("Value is not a string".into()),
+        });
+    }
+
+    let mut len = mem::MaybeUninit::uninit();
+
+    let ctx_ptr = string_value.ctx().as_raw().as_ptr();
+
+    let ptr = unsafe { qjs::JS_ToCStringLen(ctx_ptr, len.as_mut_ptr(), string_value.as_raw()) };
+    if ptr.is_null() {
+        // Might not ever happen but I am not 100% sure
+        // so just incase check it.
+        return Err(Error::Unknown);
+    }
+    let len = unsafe { len.assume_init() };
+    let bytes: &[u8] = unsafe { slice::from_raw_parts(ptr as _, len as _) };
+    let string = replace_invalid_utf8_and_utf16(bytes);
+    unsafe { qjs::JS_FreeCString(ctx_ptr, ptr) };
+
+    Ok(string)
+}
+
 fn format_raw_string(result: &mut String, value: String, options: &FormatOptions<'_>) {
     format_raw_string_inner(result, value, false, options.color);
 }
@@ -728,4 +754,98 @@ pub fn replace_newline_with_carriage_return(result: &mut str) {
         str_bytes[pos + index] = b'\r';
         pos += index + 1; // Move the position after the found '\n'
     }
+}
+
+fn replace_invalid_utf8_and_utf16(bytes: &[u8]) -> String {
+    let mut result = String::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let current = bytes[i];
+        match current {
+            // ASCII (1-byte)
+            0x00..=0x7F => {
+                result.push(current as char);
+                i += 1;
+            },
+            // 2-byte UTF-8 sequence
+            0xC0..=0xDF => {
+                if i + 1 < bytes.len() {
+                    let next = bytes[i + 1];
+                    if (next & 0xC0) == 0x80 {
+                        let code_point = ((current as u32 & 0x1F) << 6) | (next as u32 & 0x3F);
+                        if let Some(c) = char::from_u32(code_point) {
+                            result.push(c);
+                        } else {
+                            result.push('�');
+                        }
+                        i += 2;
+                    } else {
+                        result.push('�');
+                        i += 1;
+                    }
+                } else {
+                    result.push('�');
+                    i += 1;
+                }
+            },
+            // 3-byte UTF-8 sequence
+            0xE0..=0xEF => {
+                if i + 2 < bytes.len() {
+                    let next1 = bytes[i + 1];
+                    let next2 = bytes[i + 2];
+                    if (next1 & 0xC0) == 0x80 && (next2 & 0xC0) == 0x80 {
+                        let code_point = ((current as u32 & 0x0F) << 12)
+                            | ((next1 as u32 & 0x3F) << 6)
+                            | (next2 as u32 & 0x3F);
+                        if let Some(c) = char::from_u32(code_point) {
+                            result.push(c);
+                        } else {
+                            result.push('�');
+                        }
+                        i += 3;
+                    } else {
+                        result.push('�');
+                        i += 1;
+                    }
+                } else {
+                    result.push('�');
+                    i += 1;
+                }
+            },
+            // 4-byte UTF-8 sequence
+            0xF0..=0xF7 => {
+                if i + 3 < bytes.len() {
+                    let next1 = bytes[i + 1];
+                    let next2 = bytes[i + 2];
+                    let next3 = bytes[i + 3];
+                    if (next1 & 0xC0) == 0x80 && (next2 & 0xC0) == 0x80 && (next3 & 0xC0) == 0x80 {
+                        let code_point = ((current as u32 & 0x07) << 18)
+                            | ((next1 as u32 & 0x3F) << 12)
+                            | ((next2 as u32 & 0x3F) << 6)
+                            | (next3 as u32 & 0x3F);
+                        if let Some(c) = char::from_u32(code_point) {
+                            result.push(c);
+                        } else {
+                            result.push('�');
+                        }
+                        i += 4;
+                    } else {
+                        result.push('�');
+                        i += 1;
+                    }
+                } else {
+                    result.push('�');
+                    i += 1;
+                }
+            },
+            // Invalid starting byte
+            _ => {
+                result.push('�');
+                i += 1;
+            },
+        }
+    }
+
+    result
 }

--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -469,7 +469,7 @@ fn safe_byte_slice(s: &str, end: usize) -> (&[u8], usize) {
         .char_indices()
         .map(|(i, _)| i)
         .filter(|&i| i <= end)
-        .last()
+        .next_back()
         .unwrap_or(0);
 
     (&bytes[0..valid_end], valid_end)

--- a/modules/llrt_crypto/src/subtle/derive.rs
+++ b/modules/llrt_crypto/src/subtle/derive.rs
@@ -104,7 +104,7 @@ fn derive_bits(
             return algorithm_mismatch_error(ctx, "ECDH");
         },
         DeriveAlgorithm::X25519 { public_key } => {
-            if !matches!(base_key.algorithm, KeyAlgorithm::X25519 { .. }) {
+            if !matches!(base_key.algorithm, KeyAlgorithm::X25519) {
                 return algorithm_mismatch_error(ctx, "X25519");
             }
 
@@ -116,7 +116,7 @@ fn derive_bits(
             shared_secret.as_bytes().to_vec()
         },
         DeriveAlgorithm::Derive(KeyDerivation::Hkdf { hash, salt, info }) => {
-            if !matches!(base_key.algorithm, KeyAlgorithm::HkdfImport { .. }) {
+            if !matches!(base_key.algorithm, KeyAlgorithm::HkdfImport) {
                 return algorithm_mismatch_error(ctx, "HKDF");
             }
             let hash_algorithm = match hash {
@@ -142,7 +142,7 @@ fn derive_bits(
             salt,
             iterations,
         }) => {
-            if !matches!(base_key.algorithm, KeyAlgorithm::Pbkdf2Import { .. }) {
+            if !matches!(base_key.algorithm, KeyAlgorithm::Pbkdf2Import) {
                 return algorithm_mismatch_error(ctx, "PBKDF2");
             }
             let hash_algorithm = match hash {

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -157,7 +157,7 @@ fn export_spki(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
                 }),
             };
             let alg_id = match algorithm {
-                EcAlgorithm::Ecdh { .. } => AlgorithmIdentifier {
+                EcAlgorithm::Ecdh => AlgorithmIdentifier {
                     oid: const_oid::db::rfc5912::ID_EC_PUBLIC_KEY,
                     parameters: alg_id.parameters,
                 },

--- a/tests/unit/console.test.ts
+++ b/tests/unit/console.test.ts
@@ -182,3 +182,23 @@ it("should log Headers", () => {
   foo: 'bar'
 }`);
 });
+
+it("should handle broken utf8 surrogate pairs", () => {
+  const s = "🌍🌎🌏";
+  expect(util.format(s)).toEqual(s);
+  expect(util.format(s.slice(1))).toEqual("�🌎🌏");
+
+  // Test single emoji
+  expect(util.format("🌍")).toEqual("🌍");
+
+  // Test broken surrogate at end
+  expect(util.format("abc🌍".slice(0, 4))).toEqual("abc�");
+
+  // Test multiple broken surrogates
+  const broken = "🌍".slice(0, 1) + "🌎".slice(0, 1) + "🌏";
+  expect(util.format(broken)).toEqual("��🌏");
+
+  // Test mixing regular chars and emojis
+  expect(util.format("a🌍b🌎c")).toEqual("a🌍b🌎c");
+  expect(util.format("a🌍b🌎c".slice(2))).toEqual("�b🌎c");
+});


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/911

### Description of changes

Fixes broken surrogate pairs. Thanks for reporting @ahaoboy 

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
