### PR TITLE
chore(core/vm): clean up initial process

### DIFF
--- a/libs/llrt_numbers/src/lib.rs
+++ b/libs/llrt_numbers/src/lib.rs
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use rquickjs::{
+    atom::PredefinedAtom,
     function::{Opt, This},
-    Ctx, Exception, Result, Value,
+    prelude::Func,
+    Ctx, Exception, Function, Object, Result, Value,
 };
 use std::result::Result as StdResult;
 
@@ -10,6 +12,14 @@ const DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
 const BUF_SIZE: usize = 80;
 const BIN_MAX_DIGITS: usize = 64;
 const OCT_MAX_DIGITS: usize = 21;
+
+pub fn redefine_prototype(ctx: &Ctx<'_>) -> Result<()> {
+    let globals = ctx.globals();
+    let number: Function = globals.get(PredefinedAtom::Number)?;
+    let number_proto: Object = number.get(PredefinedAtom::Prototype)?;
+    number_proto.set(PredefinedAtom::ToString, Func::from(number_to_string))?;
+    Ok(())
+}
 
 #[inline(always)]
 pub fn to_dec(number: i64) -> String {
@@ -246,7 +256,7 @@ fn check_radix(ctx: &Ctx, radix: u8) -> Result<()> {
     Ok(())
 }
 
-pub fn number_to_string(ctx: Ctx, this: This<Value>, radix: Opt<u8>) -> Result<String> {
+fn number_to_string(ctx: Ctx, this: This<Value>, radix: Opt<u8>) -> Result<String> {
     if let Some(int) = this.as_int() {
         if let Some(radix) = radix.0 {
             check_radix(&ctx, radix)?;


### PR DESCRIPTION
### Description of changes

`vm:init()` contained implementation for redefining built-in objects, so we moved it into its own crate.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
