### PR TITLE
fix: Readable stream leaks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,12 @@ rustflags = ["-Ctarget-feature=+crt-static", "-Ctarget-cpu=haswell"]
 linker = "./linker/cc-x86_64-linux-musl"
 ar = "./linker/ar"
 
+[env]
+CC_aarch64_apple_darwin = "clang"
+CC_x86_64_apple_darwin = "clang"
+CXX_aarch64_apple_darwin = "clang"
+CXX_x86_64_apple_darwin = "clang"
+
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc", "std", "panic_abort"]
 build-std-features = ["panic_immediate_abort"]

--- a/modules/llrt_stream_web/src/readable/byob_reader.rs
+++ b/modules/llrt_stream_web/src/readable/byob_reader.rs
@@ -506,6 +506,22 @@ pub(super) struct ArrayConstructorPrimordials<'js> {
     constructor_data_view: Constructor<'js>,
 }
 
+impl<'js> Trace<'js> for ArrayConstructorPrimordials<'js> {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
+        self.constructor_uint8array.trace(tracer);
+        self.constructor_int8array.trace(tracer);
+        self.constructor_uint16array.trace(tracer);
+        self.constructor_int16array.trace(tracer);
+        self.constructor_uint32array.trace(tracer);
+        self.constructor_int32array.trace(tracer);
+        self.constructor_uint64array.trace(tracer);
+        self.constructor_int64array.trace(tracer);
+        self.constructor_f32array.trace(tracer);
+        self.constructor_f64array.trace(tracer);
+        self.constructor_data_view.trace(tracer);
+    }
+}
+
 impl<'js> Primordial<'js> for ArrayConstructorPrimordials<'js> {
     fn new(ctx: &Ctx<'js>) -> Result<Self>
     where

--- a/modules/llrt_stream_web/src/readable/byte_controller.rs
+++ b/modules/llrt_stream_web/src/readable/byte_controller.rs
@@ -7,7 +7,7 @@ use llrt_utils::{
     result::ResultExt,
 };
 use rquickjs::{
-    class::{OwnedBorrow, OwnedBorrowMut, Trace},
+    class::{OwnedBorrow, OwnedBorrowMut, Trace, Tracer},
     function::Constructor,
     methods,
     prelude::{Opt, This},
@@ -41,7 +41,7 @@ use crate::{
     },
 };
 
-#[derive(JsLifetime, Trace)]
+#[derive(JsLifetime)]
 #[rquickjs::class]
 pub(crate) struct ReadableByteStreamController<'js> {
     auto_allocate_chunk_size: Option<usize>,
@@ -59,12 +59,27 @@ pub(crate) struct ReadableByteStreamController<'js> {
     strategy_hwm: f64,
     pub(super) stream: ReadableStreamClass<'js>,
 
-    #[qjs(skip_trace)]
     pub(super) array_constructor_primordials: ArrayConstructorPrimordials<'js>,
-    #[qjs(skip_trace)]
     constructor_array_buffer: Constructor<'js>,
-    #[qjs(skip_trace)]
     pub(super) function_array_buffer_is_view: Function<'js>,
+}
+
+impl<'js> Trace<'js> for ReadableByteStreamController<'js> {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
+        self.auto_allocate_chunk_size.trace(tracer);
+        self.byob_request.trace(tracer);
+        self.cancel_algorithm.trace(tracer);
+        self.pull_algorithm.trace(tracer);
+        self.pending_pull_intos.trace(tracer);
+        self.queue.trace(tracer);
+        self.queue_total_size.trace(tracer);
+        self.started.trace(tracer);
+        self.strategy_hwm.trace(tracer);
+        self.stream.trace(tracer);
+        self.array_constructor_primordials.trace(tracer);
+        self.constructor_array_buffer.trace(tracer);
+        self.function_array_buffer_is_view.trace(tracer);
+    }
 }
 
 pub(crate) type ReadableByteStreamControllerClass<'js> =
@@ -1957,7 +1972,7 @@ pub(super) struct PullIntoDescriptor<'js> {
 }
 
 impl<'js> Trace<'js> for PullIntoDescriptor<'js> {
-    fn trace<'a>(&self, tracer: rquickjs::class::Tracer<'a, 'js>) {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
         self.buffer.trace(tracer);
         self.buffer_byte_length.trace(tracer);
         self.byte_offset.trace(tracer);
@@ -1990,7 +2005,7 @@ struct ReadableByteStreamQueueEntry<'js> {
 }
 
 impl<'js> Trace<'js> for ReadableByteStreamQueueEntry<'js> {
-    fn trace<'a>(&self, tracer: rquickjs::class::Tracer<'a, 'js>) {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
         self.buffer.trace(tracer);
         self.byte_offset.trace(tracer);
         self.byte_length.trace(tracer)

--- a/modules/llrt_stream_web/src/readable/stream/mod.rs
+++ b/modules/llrt_stream_web/src/readable/stream/mod.rs
@@ -56,21 +56,29 @@ pub(super) mod source;
 mod tee;
 
 #[rquickjs::class]
-#[derive(JsLifetime, Trace)]
+#[derive(JsLifetime)]
 pub(crate) struct ReadableStream<'js> {
     pub controller: ReadableStreamControllerClass<'js>,
     pub disturbed: bool,
     pub state: ReadableStreamState<'js>,
     pub reader: Option<ReadableStreamReaderClass<'js>>,
-
-    #[qjs(skip_trace)]
     pub promise_primordials: PromisePrimordials<'js>,
-    #[qjs(skip_trace)]
     pub constructor_type_error: Constructor<'js>,
-    #[qjs(skip_trace)]
     pub constructor_range_error: Constructor<'js>,
-    #[qjs(skip_trace)]
     pub function_array_buffer_is_view: Function<'js>,
+}
+
+impl<'js> Trace<'js> for ReadableStream<'js> {
+    fn trace<'a>(&self, tracer: rquickjs::class::Tracer<'a, 'js>) {
+        self.controller.trace(tracer);
+        self.state.trace(tracer);
+        self.reader.trace(tracer);
+
+        self.promise_primordials.trace(tracer);
+        self.constructor_type_error.trace(tracer);
+        self.constructor_range_error.trace(tracer);
+        self.function_array_buffer_is_view.trace(tracer);
+    }
 }
 
 pub(crate) type ReadableStreamClass<'js> = Class<'js, ReadableStream<'js>>;

--- a/modules/llrt_stream_web/src/utils/promise.rs
+++ b/modules/llrt_stream_web/src/utils/promise.rs
@@ -60,6 +60,16 @@ pub struct PromisePrimordials<'js> {
     pub promise_resolved_with_undefined: Promise<'js>,
 }
 
+impl<'js> Trace<'js> for PromisePrimordials<'js> {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
+        self.promise_constructor.trace(tracer);
+        self.promise_resolve.trace(tracer);
+        self.promise_reject.trace(tracer);
+        self.promise_all.trace(tracer);
+        self.promise_resolved_with_undefined.trace(tracer);
+    }
+}
+
 impl<'js> Primordial<'js> for PromisePrimordials<'js> {
     fn new(ctx: &Ctx<'js>) -> Result<Self>
     where

--- a/modules/llrt_stream_web/src/writable/default_writer.rs
+++ b/modules/llrt_stream_web/src/writable/default_writer.rs
@@ -23,16 +23,24 @@ use crate::{
 };
 
 #[rquickjs::class]
-#[derive(JsLifetime, Trace)]
+#[derive(JsLifetime)]
 pub(crate) struct WritableStreamDefaultWriter<'js> {
     pub(crate) ready_promise: ResolveablePromise<'js>,
     pub(crate) closed_promise: ResolveablePromise<'js>,
     pub(super) stream: Option<Class<'js, WritableStream<'js>>>,
 
-    #[qjs(skip_trace)]
     constructor_type_error: Constructor<'js>,
-    #[qjs(skip_trace)]
     promise_primordials: PromisePrimordials<'js>,
+}
+
+impl<'js> Trace<'js> for WritableStreamDefaultWriter<'js> {
+    fn trace<'a>(&self, tracer: rquickjs::class::Tracer<'a, 'js>) {
+        self.ready_promise.trace(tracer);
+        self.closed_promise.trace(tracer);
+        self.stream.trace(tracer);
+        self.constructor_type_error.trace(tracer);
+        self.promise_primordials.trace(tracer);
+    }
 }
 
 pub(crate) type WritableStreamDefaultWriterClass<'js> =

--- a/modules/llrt_stream_web/src/writable/stream/mod.rs
+++ b/modules/llrt_stream_web/src/writable/stream/mod.rs
@@ -6,7 +6,7 @@ use llrt_utils::{
     primordials::{BasePrimordials, Primordial},
 };
 use rquickjs::{
-    class::{OwnedBorrowMut, Trace},
+    class::{OwnedBorrowMut, Trace, Tracer},
     function::Constructor,
     prelude::{Opt, This},
     Class, Ctx, Exception, JsLifetime, Object, Promise, Result, Value,
@@ -37,7 +37,7 @@ use sink::UnderlyingSink;
 pub(super) mod sink;
 
 #[rquickjs::class]
-#[derive(JsLifetime, Trace)]
+#[derive(JsLifetime)]
 pub struct WritableStream<'js> {
     pub(super) backpressure: bool,
     close_request: Option<ResolveablePromise<'js>>,
@@ -48,11 +48,23 @@ pub struct WritableStream<'js> {
     pub(crate) state: WritableStreamState<'js>,
     pub(crate) writer: Option<WritableStreamDefaultWriterClass<'js>>,
     write_requests: VecDeque<ResolveablePromise<'js>>,
-
-    #[qjs(skip_trace)]
     pub(super) constructor_type_error: Constructor<'js>,
-    #[qjs(skip_trace)]
     pub(crate) promise_primordials: PromisePrimordials<'js>,
+}
+
+impl<'js> Trace<'js> for WritableStream<'js> {
+    fn trace<'a>(&self, tracer: Tracer<'a, 'js>) {
+        self.close_request.trace(tracer);
+        self.controller.trace(tracer);
+        self.in_flight_write_request.trace(tracer);
+        self.in_flight_close_request.trace(tracer);
+        self.pending_abort_request.trace(tracer);
+        self.state.trace(tracer);
+        self.writer.trace(tracer);
+        self.write_requests.trace(tracer);
+        self.constructor_type_error.trace(tracer);
+        self.promise_primordials.trace(tracer);
+    }
 }
 
 pub(crate) type WritableStreamClass<'js> = Class<'js, WritableStream<'js>>;


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/926

### Description of changes

Some Stream classes did not correctly trace QJS objets leading to leaks on runtime exit. Leaks on runtime exit causes an assertion failure leading to a crash (by design). This PR adds missing traces, fixing the leaks

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
