### PR TITLE
refactor(require/module): further separation of require and module

### DIFF
--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -5,7 +5,7 @@ pub use llrt_modules::console;
 pub use llrt_modules::{
     abort, assert, buffer, child_process, crypto, dns, events, exceptions, fs, http,
     module_builder, navigator, net, os, path, perf_hooks, process, stream_web, string_decoder,
-    timers, tty, url, util, zlib,
+    timers, tty, url, util, zlib, ModuleNames,
 };
 
 #[cfg(feature = "lambda")]

--- a/llrt_core/src/modules/module.rs
+++ b/llrt_core/src/modules/module.rs
@@ -1,44 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::{
-    cell::RefCell,
-    collections::{HashMap, HashSet},
-    fs,
-    rc::Rc,
-    sync::Mutex,
-};
+use std::{cell::RefCell, collections::HashSet};
 
+use once_cell::sync::OnceCell;
 use rquickjs::{
-    atom::PredefinedAtom,
     module::{Declarations, Exports, ModuleDef},
     object::Accessor,
     prelude::Func,
-    qjs, Ctx, Error, Filter, JsLifetime, Module, Object, Result, Value,
+    Ctx, Error, Exception, Object, Result, Value,
 };
-use tokio::time::Instant;
-use tracing::trace;
 
-use crate::bytecode::BYTECODE_FILE_EXT;
-use crate::libs::{
-    json::parse::json_parse,
-    utils::module::{export_default, ModuleInfo},
-};
-use crate::modules::{
-    path::resolve_path,
-    require::{resolver::require_resolve, CJS_IMPORT_PREFIX},
-    timers::poll_timers,
-};
+use crate::libs::utils::module::{export_default, ModuleInfo};
+use crate::modules::require::{require, RequireState, CJS_IMPORT_PREFIX};
 use crate::utils::ctx::CtxExt;
 
-#[derive(Default)]
-pub struct RequireState<'js> {
-    cache: HashMap<Rc<str>, Value<'js>>,
-    exports: HashMap<Rc<str>, Value<'js>>,
-}
-
-unsafe impl<'js> JsLifetime<'js> for RequireState<'js> {
-    type Changed<'to> = RequireState<'to>;
-}
+static MODULE_NAMES: OnceCell<HashSet<String>> = OnceCell::new();
 
 pub struct ModuleModule;
 
@@ -46,17 +22,29 @@ fn create_require(ctx: Ctx<'_>) -> Result<Value<'_>> {
     ctx.globals().get("require")
 }
 
+fn is_builtin(name: String) -> bool {
+    MODULE_NAMES.get().unwrap().contains(&name)
+}
+
 impl ModuleDef for ModuleModule {
     fn declare(declare: &Declarations) -> Result<()> {
+        declare.declare("builtinModules")?;
         declare.declare("createRequire")?;
+        declare.declare("isBuiltin")?;
         declare.declare("default")?;
 
         Ok(())
     }
 
     fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        MODULE_NAMES
+            .set(ctx.globals().get("__module_names")?)
+            .map_err(|_| Exception::throw_internal(ctx, "MODULE_NAMES already initialized"))?;
+
         export_default(ctx, exports, |default| {
+            default.set("builtinModules", MODULE_NAMES.get().unwrap())?;
             default.set("createRequire", Func::from(create_require))?;
+            default.set("isBuiltin", Func::from(is_builtin))?;
 
             Ok(())
         })?;
@@ -74,11 +62,8 @@ impl From<ModuleModule> for ModuleInfo<ModuleModule> {
     }
 }
 
-pub fn init(ctx: &Ctx, module_names: HashSet<&'static str>) -> Result<()> {
+pub fn init(ctx: &Ctx) -> Result<()> {
     let globals = ctx.globals();
-
-    let require_in_progress: Rc<Mutex<HashMap<Rc<str>, Object>>> =
-        Rc::new(Mutex::new(HashMap::new()));
 
     let _ = ctx.store_userdata(RefCell::new(RequireState::default()));
 
@@ -114,168 +99,12 @@ pub fn init(ctx: &Ctx, module_names: HashSet<&'static str>) -> Result<()> {
     .configurable()
     .enumerable();
 
+    globals.prop("exports", exports_accessor)?;
+    globals.set("require", Func::from(require))?;
+
     let module = Object::new(ctx.clone())?;
     module.prop("exports", exports_accessor)?;
-
     globals.prop("module", module)?;
-    globals.prop("exports", exports_accessor)?;
-
-    globals.set(
-        "require",
-        Func::from(move |ctx, specifier: String| -> Result<Value> {
-            struct Args<'js>(Ctx<'js>);
-            let Args(ctx) = Args(ctx);
-
-            let is_cjs_import = specifier.starts_with(CJS_IMPORT_PREFIX);
-
-            let import_name: Rc<str>;
-
-            let is_json = specifier.ends_with(".json");
-
-            trace!("Before specifier: {}", specifier);
-
-            let import_specifier: Rc<str> = if !is_cjs_import {
-                let is_bytecode = specifier.ends_with(BYTECODE_FILE_EXT);
-                let is_bytecode_or_json = is_json || is_bytecode;
-                let specifier = if is_bytecode_or_json {
-                    specifier
-                } else {
-                    specifier.trim_start_matches("node:").to_string()
-                };
-
-                if module_names.contains(specifier.as_str()) {
-                    import_name = specifier.into();
-                    import_name.clone()
-                } else {
-                    let module_name = ctx.get_script_or_module_name()?;
-                    let module_name = module_name.trim_start_matches(CJS_IMPORT_PREFIX);
-                    let abs_path = resolve_path([module_name].iter())?;
-
-                    let resolved_path =
-                        require_resolve(&ctx, &specifier, &abs_path, false)?.into_owned();
-                    import_name = resolved_path.into();
-                    if is_bytecode_or_json {
-                        import_name.clone()
-                    } else {
-                        [CJS_IMPORT_PREFIX, &import_name].concat().into()
-                    }
-                }
-            } else {
-                import_name = specifier[CJS_IMPORT_PREFIX.len()..].into();
-                specifier.into()
-            };
-
-            trace!("After specifier: {}", import_specifier);
-
-            let binding = ctx.userdata::<RefCell<RequireState>>().unwrap();
-            let mut state = binding.borrow_mut();
-
-            if let Some(cached_value) = state.cache.get(import_name.as_ref()) {
-                return Ok(cached_value.clone());
-            }
-
-            if is_json {
-                let json = fs::read_to_string(import_name.as_ref())?;
-                let json = json_parse(&ctx, json)?;
-                state.cache.insert(import_name, json.clone());
-                return Ok(json);
-            }
-
-            let mut require_in_progress_map = require_in_progress.lock().unwrap();
-            if let Some(obj) = require_in_progress_map.get(&import_name) {
-                let value = obj.clone().into_value();
-                return Ok(value);
-            }
-
-            trace!("Require: {}", import_specifier);
-
-            let obj = Object::new(ctx.clone())?;
-            require_in_progress_map.insert(import_name.clone(), obj.clone());
-            drop(require_in_progress_map);
-            drop(state);
-
-            let import_promise = Module::import(&ctx, import_specifier.as_bytes())?;
-
-            let rt = unsafe { qjs::JS_GetRuntime(ctx.as_raw().as_ptr()) };
-
-            let mut deadline = Instant::now();
-
-            let mut executing_timers = Vec::new();
-
-            let imported_object = loop {
-                if let Some(x) = import_promise.result::<Object>() {
-                    break x?;
-                }
-
-                if deadline < Instant::now() {
-                    poll_timers(rt, &mut executing_timers, None, Some(&mut deadline))?;
-                }
-
-                ctx.execute_pending_job();
-            };
-
-            let binding = ctx.userdata::<RefCell<RequireState>>().unwrap();
-            let mut state = binding.borrow_mut();
-
-            let exports_obj = state.exports.get(&import_name).cloned();
-
-            require_in_progress
-                .lock()
-                .unwrap()
-                .remove(import_name.as_ref());
-
-            if let Some(exports_obj) = exports_obj {
-                if exports_obj.type_of() == rquickjs::Type::Object {
-                    drop(state);
-                    let exports = unsafe { exports_obj.as_object().unwrap_unchecked() };
-
-                    for prop in
-                        exports.own_props::<Value, Value>(Filter::new().private().string().symbol())
-                    {
-                        let (key, value) = prop?;
-                        obj.set(key, value)?;
-                    }
-                } else {
-                    //we have explicitly set it
-                    state.cache.insert(import_name, exports_obj.clone());
-                    return Ok(exports_obj);
-                }
-            } else {
-                drop(state);
-            }
-
-            let binding = ctx.userdata::<RefCell<RequireState>>().unwrap();
-            let mut state = binding.borrow_mut();
-
-            let props = imported_object.props::<String, Value>();
-
-            let default_export: Option<Value> = imported_object.get(PredefinedAtom::Default)?;
-            if let Some(default_export) = default_export {
-                //if default export is object attach all named exports to
-                if let Some(default_object) = default_export.as_object() {
-                    for prop in props {
-                        let (key, value) = prop?;
-                        if !default_object.contains_key(&key)? {
-                            default_object.set(key, value)?;
-                        }
-                    }
-                    let default_object = default_object.clone().into_value();
-                    state.cache.insert(import_name, default_object.clone());
-                    return Ok(default_object);
-                }
-            }
-
-            for prop in props {
-                let (key, value) = prop?;
-                obj.set(key, value)?;
-            }
-
-            let value = obj.into_value();
-
-            state.cache.insert(import_name, value.clone());
-            Ok(value)
-        }),
-    )?;
 
     Ok(())
 }

--- a/llrt_core/src/modules/require/mod.rs
+++ b/llrt_core/src/modules/require/mod.rs
@@ -1,6 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::{cell::RefCell, collections::HashMap, env, fs, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    env, fs,
+    rc::Rc,
+};
 
 use once_cell::sync::Lazy;
 use rquickjs::{atom::PredefinedAtom, qjs, Ctx, Filter, JsLifetime, Module, Object, Result, Value};
@@ -52,8 +57,9 @@ pub fn require(ctx: Ctx<'_>, specifier: String) -> Result<Value<'_>> {
     struct Args<'js>(Ctx<'js>);
     let Args(ctx) = Args(ctx);
 
-    let binding = ctx.userdata::<ModuleNames>().unwrap();
-    let module_list = binding.get_list();
+    let module_list = ctx
+        .userdata::<ModuleNames>()
+        .map_or_else(HashSet::new, |v| v.get_list());
 
     let is_cjs_import = specifier.starts_with(CJS_IMPORT_PREFIX);
 

--- a/llrt_core/src/modules/require/mod.rs
+++ b/llrt_core/src/modules/require/mod.rs
@@ -52,8 +52,8 @@ pub fn require(ctx: Ctx<'_>, specifier: String) -> Result<Value<'_>> {
     struct Args<'js>(Ctx<'js>);
     let Args(ctx) = Args(ctx);
 
-    let binding = ctx.userdata::<RefCell<ModuleNames>>().unwrap();
-    let module_list = binding.borrow().get_list();
+    let binding = ctx.userdata::<ModuleNames>().unwrap();
+    let module_list = binding.get_list();
 
     let is_cjs_import = specifier.starts_with(CJS_IMPORT_PREFIX);
 

--- a/llrt_core/src/modules/require/mod.rs
+++ b/llrt_core/src/modules/require/mod.rs
@@ -1,10 +1,24 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::env;
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    env, fs,
+    rc::Rc,
+};
 
 use once_cell::sync::Lazy;
+use rquickjs::{atom::PredefinedAtom, qjs, Ctx, Filter, JsLifetime, Module, Object, Result, Value};
+use tokio::time::Instant;
+use tracing::trace;
 
+use crate::bytecode::BYTECODE_FILE_EXT;
 use crate::environment;
+use crate::libs::json::parse::json_parse;
+use crate::modules::{path::resolve_path, timers::poll_timers};
+use crate::utils::ctx::CtxExt;
+
+use self::resolver::require_resolve;
 
 pub mod loader;
 pub mod resolver;
@@ -24,3 +38,164 @@ pub static LLRT_PLATFORM: Lazy<String> = Lazy::new(|| {
 pub static COMPRESSION_DICT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/compression.dict"));
 
 include!(concat!(env!("OUT_DIR"), "/bytecode_cache.rs"));
+
+#[derive(Default)]
+pub struct RequireState<'js> {
+    pub cache: HashMap<Rc<str>, Value<'js>>,
+    pub exports: HashMap<Rc<str>, Value<'js>>,
+    pub progress: HashMap<Rc<str>, Object<'js>>,
+}
+
+unsafe impl<'js> JsLifetime<'js> for RequireState<'js> {
+    type Changed<'to> = RequireState<'to>;
+}
+
+pub fn require(ctx: Ctx<'_>, specifier: String) -> Result<Value<'_>> {
+    let globals = ctx.globals();
+    let module_names: HashSet<String> = globals.get("__module_names")?;
+
+    struct Args<'js>(Ctx<'js>);
+    let Args(ctx) = Args(ctx);
+
+    let is_cjs_import = specifier.starts_with(CJS_IMPORT_PREFIX);
+
+    let import_name: Rc<str>;
+
+    let is_json = specifier.ends_with(".json");
+
+    trace!("Before specifier: {}", specifier);
+
+    let import_specifier: Rc<str> = if !is_cjs_import {
+        let is_bytecode = specifier.ends_with(BYTECODE_FILE_EXT);
+        let is_bytecode_or_json = is_json || is_bytecode;
+        let specifier = if is_bytecode_or_json {
+            specifier
+        } else {
+            specifier.trim_start_matches("node:").to_string()
+        };
+
+        if module_names.contains(specifier.as_str()) {
+            import_name = specifier.into();
+            import_name.clone()
+        } else {
+            let module_name = ctx.get_script_or_module_name()?;
+            let module_name = module_name.trim_start_matches(CJS_IMPORT_PREFIX);
+            let abs_path = resolve_path([module_name].iter())?;
+
+            let resolved_path = require_resolve(&ctx, &specifier, &abs_path, false)?.into_owned();
+            import_name = resolved_path.into();
+            if is_bytecode_or_json {
+                import_name.clone()
+            } else {
+                [CJS_IMPORT_PREFIX, &import_name].concat().into()
+            }
+        }
+    } else {
+        import_name = specifier[CJS_IMPORT_PREFIX.len()..].into();
+        specifier.into()
+    };
+
+    trace!("After specifier: {}", import_specifier);
+
+    let binding = ctx.userdata::<RefCell<RequireState>>().unwrap();
+    let mut state = binding.borrow_mut();
+
+    if let Some(cached_value) = state.cache.get(import_name.as_ref()) {
+        return Ok(cached_value.clone());
+    }
+
+    if is_json {
+        let json = fs::read_to_string(import_name.as_ref())?;
+        let json = json_parse(&ctx, json)?;
+        state.cache.insert(import_name, json.clone());
+        return Ok(json);
+    }
+
+    if let Some(obj) = state.progress.get(&import_name) {
+        let value = obj.clone().into_value();
+        return Ok(value);
+    }
+
+    trace!("Require: {}", import_specifier);
+
+    let obj = Object::new(ctx.clone())?;
+    state.progress.insert(import_name.clone(), obj.clone());
+    drop(state);
+
+    let import_promise = Module::import(&ctx, import_specifier.as_bytes())?;
+
+    let rt = unsafe { qjs::JS_GetRuntime(ctx.as_raw().as_ptr()) };
+
+    let mut deadline = Instant::now();
+
+    let mut executing_timers = Vec::new();
+
+    let imported_object = loop {
+        if let Some(x) = import_promise.result::<Object>() {
+            break x?;
+        }
+
+        if deadline < Instant::now() {
+            poll_timers(rt, &mut executing_timers, None, Some(&mut deadline))?;
+        }
+
+        ctx.execute_pending_job();
+    };
+
+    let binding = ctx.userdata::<RefCell<RequireState>>().unwrap();
+    let mut state = binding.borrow_mut();
+
+    let exports_obj = state.exports.get(&import_name).cloned();
+
+    state.progress.remove(import_name.as_ref());
+
+    if let Some(exports_obj) = exports_obj {
+        if exports_obj.type_of() == rquickjs::Type::Object {
+            drop(state);
+            let exports = unsafe { exports_obj.as_object().unwrap_unchecked() };
+
+            for prop in exports.own_props::<Value, Value>(Filter::new().private().string().symbol())
+            {
+                let (key, value) = prop?;
+                obj.set(key, value)?;
+            }
+        } else {
+            //we have explicitly set it
+            state.cache.insert(import_name, exports_obj.clone());
+            return Ok(exports_obj);
+        }
+    } else {
+        drop(state);
+    }
+
+    let binding = ctx.userdata::<RefCell<RequireState>>().unwrap();
+    let mut state = binding.borrow_mut();
+
+    let props = imported_object.props::<String, Value>();
+
+    let default_export: Option<Value> = imported_object.get(PredefinedAtom::Default)?;
+    if let Some(default_export) = default_export {
+        //if default export is object attach all named exports to
+        if let Some(default_object) = default_export.as_object() {
+            for prop in props {
+                let (key, value) = prop?;
+                if !default_object.contains_key(&key)? {
+                    default_object.set(key, value)?;
+                }
+            }
+            let default_object = default_object.clone().into_value();
+            state.cache.insert(import_name, default_object.clone());
+            return Ok(default_object);
+        }
+    }
+
+    for prop in props {
+        let (key, value) = prop?;
+        obj.set(key, value)?;
+    }
+
+    let value = obj.into_value();
+
+    state.cache.insert(import_name, value.clone());
+    Ok(value)
+}

--- a/llrt_modules/README.md
+++ b/llrt_modules/README.md
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Error> {
     let runtime = AsyncRuntime::new()?;
 
     let module_builder = ModuleBuilder::default();
-    let (module_resolver, module_loader, _module_names, global_attachment) = module_builder.build();
+    let (module_resolver, module_loader, global_attachment) = module_builder.build();
     runtime.set_loader((module_resolver,), (module_loader,)).await;
 
     let context = AsyncContext::full(&runtime).await?;

--- a/llrt_modules/src/lib.rs
+++ b/llrt_modules/src/lib.rs
@@ -1,5 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use std::{collections::HashSet, env, marker::PhantomData};
+
+use rquickjs::JsLifetime;
+
 pub mod module_builder;
 
 pub use self::modules::*;
@@ -56,3 +60,25 @@ mod modules {
 }
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub struct ModuleNames<'js> {
+    list: HashSet<String>,
+    _marker: PhantomData<&'js ()>,
+}
+
+unsafe impl<'js> JsLifetime<'js> for ModuleNames<'js> {
+    type Changed<'to> = ModuleNames<'to>;
+}
+
+impl ModuleNames<'_> {
+    pub fn new(names: HashSet<String>) -> Self {
+        Self {
+            list: names,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn get_list(&self) -> HashSet<String> {
+        self.list.clone()
+    }
+}

--- a/llrt_modules/src/module_builder.rs
+++ b/llrt_modules/src/module_builder.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::{cell::RefCell, collections::HashSet};
+use std::collections::HashSet;
 
 use llrt_utils::module::ModuleInfo;
 use rquickjs::{
@@ -30,7 +30,7 @@ impl GlobalAttachment {
 
     pub fn attach(self, ctx: &Ctx<'_>) -> Result<()> {
         if !self.names.is_empty() {
-            let _ = ctx.store_userdata(RefCell::new(ModuleNames::new(self.names)));
+            let _ = ctx.store_userdata(ModuleNames::new(self.names));
         }
         for init in self.functions {
             init(ctx)?;

--- a/llrt_modules/src/module_builder.rs
+++ b/llrt_modules/src/module_builder.rs
@@ -11,19 +11,28 @@ use rquickjs::{
 
 #[derive(Debug, Default)]
 pub struct GlobalAttachment {
-    global_attachment: Vec<fn(&Ctx<'_>) -> Result<()>>,
+    names: HashSet<String>,
+    functions: Vec<fn(&Ctx<'_>) -> Result<()>>,
 }
 
 impl GlobalAttachment {
-    #[must_use]
-    pub fn with_global(mut self, init: fn(&Ctx<'_>) -> Result<()>) -> Self {
-        self.global_attachment.push(init);
+    pub fn add_function(mut self, init: fn(&Ctx<'_>) -> Result<()>) -> Self {
+        self.functions.push(init);
+        self
+    }
+
+    pub fn add_name<P: Into<String>>(mut self, path: P) -> Self {
+        self.names.insert(path.into());
         self
     }
 
     pub fn attach(self, ctx: &Ctx<'_>) -> Result<()> {
-        for init_function in self.global_attachment {
-            init_function(ctx)?;
+        if !self.names.is_empty() {
+            let object = ctx.globals();
+            object.set("__module_names", self.names)?;
+        }
+        for init in self.functions {
+            init(ctx)?;
         }
         Ok(())
     }
@@ -36,7 +45,7 @@ pub struct ModuleResolver {
 
 impl ModuleResolver {
     #[must_use]
-    pub fn with_module<P: Into<String>>(mut self, path: P) -> Self {
+    pub fn add_name<P: Into<String>>(mut self, path: P) -> Self {
         self.modules.insert(path.into());
         self
     }
@@ -53,17 +62,9 @@ impl Resolver for ModuleResolver {
     }
 }
 
-pub type Modules = (
-    ModuleResolver,
-    ModuleLoader,
-    HashSet<&'static str>,
-    GlobalAttachment,
-);
-
 pub struct ModuleBuilder {
     module_resolver: ModuleResolver,
     module_loader: ModuleLoader,
-    module_names: HashSet<&'static str>,
     global_attachment: GlobalAttachment,
 }
 
@@ -199,7 +200,6 @@ impl ModuleBuilder {
         Self {
             module_resolver: ModuleResolver::default(),
             module_loader: ModuleLoader::default(),
-            module_names: HashSet::new(),
             global_attachment: GlobalAttachment::default(),
         }
     }
@@ -207,25 +207,23 @@ impl ModuleBuilder {
     pub fn with_module<M: ModuleDef, I: Into<ModuleInfo<M>>>(mut self, module: I) -> Self {
         let module_info: ModuleInfo<M> = module.into();
 
-        self.module_resolver = self.module_resolver.with_module(module_info.name);
+        self.module_resolver = self.module_resolver.add_name(module_info.name);
         self.module_loader = self
             .module_loader
             .with_module(module_info.name, module_info.module);
-        self.module_names.insert(module_info.name);
-
+        self.global_attachment = self.global_attachment.add_name(module_info.name);
         self
     }
 
     pub fn with_global(mut self, init: fn(&Ctx<'_>) -> Result<()>) -> Self {
-        self.global_attachment = self.global_attachment.with_global(init);
+        self.global_attachment = self.global_attachment.add_function(init);
         self
     }
 
-    pub fn build(self) -> Modules {
+    pub fn build(self) -> (ModuleResolver, ModuleLoader, GlobalAttachment) {
         (
             self.module_resolver,
             self.module_loader,
-            self.module_names,
             self.global_attachment,
         )
     }

--- a/llrt_modules/src/module_builder.rs
+++ b/llrt_modules/src/module_builder.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::collections::HashSet;
+use std::{cell::RefCell, collections::HashSet};
 
 use llrt_utils::module::ModuleInfo;
 use rquickjs::{
@@ -8,6 +8,8 @@ use rquickjs::{
     module::ModuleDef,
     Ctx, Error, Result,
 };
+
+use super::ModuleNames;
 
 #[derive(Debug, Default)]
 pub struct GlobalAttachment {
@@ -28,8 +30,7 @@ impl GlobalAttachment {
 
     pub fn attach(self, ctx: &Ctx<'_>) -> Result<()> {
         if !self.names.is_empty() {
-            let object = ctx.globals();
-            object.set("__module_names", self.names)?;
+            let _ = ctx.store_userdata(RefCell::new(ModuleNames::new(self.names)));
         }
         for init in self.functions {
             init(ctx)?;


### PR DESCRIPTION
### Description of changes

We've refactored `require` and `module` to be more independent.

- Previously, the module list output by `ModuleBuilder` was passed directly to `Module::init()`, but now it is passed via global (although I'm not sure if this is a good way to do it).
- This allowed `Module::init()` to have the same specifications as other `init()`, so the attachment method could also be made consistent.
- The `module` contained the implementation of `require`, but we were able to separate the implementation part.

This makes it more likely that we can move `module` to the module directory and `require` to the libs directory. However, in order to make it an independent crate, there are some things to consider about the implementation of `require` (what to do with LLRT and Lambda-specific logic), so we will not implement it in this PR.

NOTE:
We already have an idea for this issue. It's to split `CustomResolver/Loader` into `NpmJsResolver/Loader` and `EmbeddedResolver/Loader`. `NpmJsResolver/Loader` will be exposed, but `EmbeddedResolver/Loader` will continue to be under the management of core.

However, some integration will be required in `require`. But it seems that we can deal with it by accepting one user-defined function in `require_resolver()` and making ByteCodeCache judgment.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
