### PR TITLE
fix(require): crash when accessing RequireState

### DIFF
--- a/llrt_core/src/modules/module.rs
+++ b/llrt_core/src/modules/module.rs
@@ -226,6 +226,7 @@ pub fn init(ctx: &Ctx, module_names: HashSet<&'static str>) -> Result<()> {
 
             if let Some(exports_obj) = exports_obj {
                 if exports_obj.type_of() == rquickjs::Type::Object {
+                    drop(state);
                     let exports = unsafe { exports_obj.as_object().unwrap_unchecked() };
 
                     for prop in
@@ -239,7 +240,12 @@ pub fn init(ctx: &Ctx, module_names: HashSet<&'static str>) -> Result<()> {
                     state.cache.insert(import_name, exports_obj.clone());
                     return Ok(exports_obj);
                 }
+            } else {
+                drop(state);
             }
+
+            let binding = ctx.userdata::<RefCell<RequireState>>().unwrap();
+            let mut state = binding.borrow_mut();
 
             let props = imported_object.props::<String, Value>();
 


### PR DESCRIPTION
### Issue # (if available)

fixed #886 

### Description of changes

By immediately dropping the `state` obtained with `borrow_mut()` when it is no longer needed, we can avoid crashes caused by multiple `borrow_mut()` calls.

At least it won't crash and the search for the module will continue, like so:

```
% cat reproduction.js 
const a = require('pg');
console.log(a);

% llrt reproduction.js
ReferenceError: Error resolving module 'module_root/build/addon.node' from '/Users/shinya/Workspaces/llrt-test/node_modules/bindings/bindings.js'
  at bindings (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/bindings/./bindings.js:112:60)
      at <anonymous> (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/libpq/index.js:1:27)
      at <anonymous> (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/pg-native/index.js:1:12)
      at <anonymous> (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/pg/lib/native/client.js:7:12)
      at <anonymous> (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/pg/lib/native/index.js:2:18)
      at get (__cjs:/Users/shinya/Workspaces/llrt-test/node_modules/pg/./lib/index.js:43:25)
      at <anonymous> (/Users/shinya/Workspaces/llrt-test/reproduction.js:1:10)
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
