### PR TITLE
refactor(require): further separation of npm-require and bytecode-require

### DIFF
--- a/llrt_core/src/compiler.rs
+++ b/llrt_core/src/compiler.rs
@@ -9,7 +9,7 @@ use zstd::bulk::Compressor;
 use crate::bytecode::add_bytecode_header;
 use crate::compiler_common::{human_file_size, DummyLoader, DummyResolver};
 use crate::libs::{logging::print_error_and_exit, utils::result::ResultExt};
-use crate::modules::require::COMPRESSION_DICT;
+use crate::modules::embedded::COMPRESSION_DICT;
 
 fn compress_module(bytes: &[u8]) -> io::Result<Vec<u8>> {
     let mut compressor = Compressor::with_dictionary(22, COMPRESSION_DICT)?;

--- a/llrt_core/src/modules/embedded/loader.rs
+++ b/llrt_core/src/modules/embedded/loader.rs
@@ -1,0 +1,199 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::{io, result::Result as StdResult};
+
+use once_cell::sync::Lazy;
+use rquickjs::{loader::Loader, Ctx, Error, Module, Object, Result};
+use tracing::trace;
+use zstd::{bulk::Decompressor, dict::DecoderDictionary};
+
+use crate::bytecode::{
+    BYTECODE_COMPRESSED, BYTECODE_FILE_EXT, BYTECODE_UNCOMPRESSED, BYTECODE_VERSION,
+    SIGNATURE_LENGTH,
+};
+
+use super::{BYTECODE_CACHE, CJS_IMPORT_PREFIX, CJS_LOADER_PREFIX, COMPRESSION_DICT};
+
+static DECOMPRESSOR_DICT: Lazy<DecoderDictionary> =
+    Lazy::new(|| DecoderDictionary::copy(COMPRESSION_DICT));
+
+#[cfg(feature = "lambda")]
+include!(concat!(env!("OUT_DIR"), "/sdk_client_endpoints.rs"));
+
+#[derive(Debug, Default)]
+pub struct EmbeddedLoader;
+
+impl EmbeddedLoader {
+    pub fn load_bytecode_module<'js>(ctx: Ctx<'js>, buf: &[u8]) -> Result<Module<'js>> {
+        let bytes = Self::get_module_bytecode(buf)?;
+        unsafe { Module::load(ctx, &bytes) }
+    }
+
+    #[inline]
+    pub fn uncompressed_size(input: &[u8]) -> StdResult<(usize, &[u8]), io::Error> {
+        let size = input.get(..4).ok_or(io::ErrorKind::InvalidInput)?;
+        let size: &[u8; 4] = size.try_into().map_err(|_| io::ErrorKind::InvalidInput)?;
+        let uncompressed_size = u32::from_le_bytes(*size) as usize;
+        let rest = &input[4..];
+        Ok((uncompressed_size, rest))
+    }
+
+    fn get_module_bytecode(input: &[u8]) -> Result<Vec<u8>> {
+        let (_, compressed, input) = Self::get_bytecode_signature(input)?;
+
+        if compressed {
+            let (size, input) = Self::uncompressed_size(input)?;
+            let mut buf = Vec::with_capacity(size);
+            let mut decompressor = Decompressor::with_prepared_dictionary(&DECOMPRESSOR_DICT)?;
+            decompressor.decompress_to_buffer(input, &mut buf)?;
+            return Ok(buf);
+        }
+
+        Ok(input.to_vec())
+    }
+
+    fn get_bytecode_signature(input: &[u8]) -> StdResult<(&[u8], bool, &[u8]), io::Error> {
+        let raw_signature = input
+            .get(..SIGNATURE_LENGTH)
+            .ok_or(io::Error::new::<String>(
+                io::ErrorKind::InvalidInput,
+                "Invalid bytecode signature length".into(),
+            ))?;
+
+        let (last, signature) = raw_signature.split_last().unwrap();
+
+        if signature != BYTECODE_VERSION.as_bytes() {
+            return Err(io::Error::new::<String>(
+                io::ErrorKind::InvalidInput,
+                "Invalid bytecode version".into(),
+            ));
+        }
+
+        let mut compressed = None;
+        if *last == BYTECODE_COMPRESSED {
+            compressed = Some(true)
+        } else if *last == BYTECODE_UNCOMPRESSED {
+            compressed = Some(false)
+        }
+
+        let rest = &input[SIGNATURE_LENGTH..];
+        Ok((
+            signature,
+            compressed.ok_or(io::Error::new::<String>(
+                io::ErrorKind::InvalidInput,
+                "Invalid bytecode signature".into(),
+            ))?,
+            rest,
+        ))
+    }
+
+    fn normalize_name(name: &str) -> (bool, bool, &str, &str) {
+        if !name.starts_with("__") {
+            // If name doesn’t start with "__", return defaults
+            return (false, false, name, name);
+        }
+
+        if let Some(cjs_path) = name.strip_prefix(CJS_IMPORT_PREFIX) {
+            // If it starts with CJS_IMPORT_PREFIX, mark as from_cjs_import
+            return (true, false, name, cjs_path);
+        }
+
+        if let Some(cjs_path) = name.strip_prefix(CJS_LOADER_PREFIX) {
+            // If it starts with CJS_LOADER_PREFIX, mark as is_cjs
+            return (false, true, cjs_path, cjs_path);
+        }
+
+        // Default return if no prefixes match
+        (false, false, name, name)
+    }
+
+    fn load_module<'js>(name: &str, ctx: &Ctx<'js>) -> Result<(Module<'js>, Option<String>)> {
+        let ctx = ctx.clone();
+
+        let (_, _, normalized_name, path) = Self::normalize_name(name);
+
+        if let Some(bytes) = BYTECODE_CACHE.get(path) {
+            #[cfg(feature = "lambda")]
+            init_client_connection(&ctx, path)?;
+
+            trace!("Loading embedded module: {}\n", path);
+
+            return Ok((Self::load_bytecode_module(ctx, bytes)?, Some(path.into())));
+        }
+
+        let bytes = std::fs::read(path)?;
+        let bytes: &[u8] = &bytes;
+
+        if normalized_name.ends_with(BYTECODE_FILE_EXT) {
+            trace!("Loading binary module: {}\n", path);
+            return Ok((Self::load_bytecode_module(ctx, bytes)?, Some(path.into())));
+        }
+
+        Err(Error::new_loading_message(path, "unable to load"))
+    }
+}
+
+impl Loader for EmbeddedLoader {
+    fn load<'js>(&mut self, ctx: &Ctx<'js>, name: &str) -> Result<Module<'js>> {
+        let (module, url) = Self::load_module(name, ctx)?;
+        if let Some(url) = url {
+            let meta: Object = module.meta()?;
+            meta.prop("url", url)?;
+        }
+
+        Ok(module)
+    }
+}
+
+#[cfg(feature = "lambda")]
+fn init_client_connection(ctx: &Ctx<'_>, specifier: &str) -> Result<()> {
+    use std::{env, time::Instant};
+
+    use http_body_util::BodyExt;
+    use rquickjs::qjs;
+
+    use crate::libs::utils::result::ResultExt;
+    use crate::modules::http::HTTP_CLIENT;
+    use crate::runtime_client::{check_client_inited, mark_client_inited};
+
+    if let Some(sdk_import) = specifier.strip_prefix("@aws-sdk/") {
+        let client_name = sdk_import.trim_start_matches("client-");
+        if let Some(endpoint) = SDK_CLIENT_ENDPOINTS.get(client_name) {
+            let endpoint = if endpoint.is_empty() {
+                client_name
+            } else {
+                endpoint
+            };
+
+            let rt = unsafe { qjs::JS_GetRuntime(ctx.as_raw().as_ptr()) };
+            let rt_ptr = rt as usize; //hack to move, is safe since runtime is still alive in spawn
+
+            if !check_client_inited(rt, endpoint) {
+                let client = HTTP_CLIENT.as_ref().or_throw(ctx)?;
+
+                trace!("Started client init {}", client_name);
+                let region = env::var("AWS_REGION").unwrap();
+
+                let url = ["https://", endpoint, ".", &region, ".amazonaws.com/sping"].concat();
+
+                tokio::task::spawn(async move {
+                    let start = Instant::now();
+
+                    if let Ok(url) = url.parse() {
+                        if let Ok(mut res) = client.get(url).await {
+                            if let Ok(res) = res.body_mut().collect().await {
+                                let _ = res;
+
+                                mark_client_inited(rt_ptr as _);
+
+                                trace!("Client connection initialized in {:?}", start.elapsed());
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/llrt_core/src/modules/embedded/mod.rs
+++ b/llrt_core/src/modules/embedded/mod.rs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::env;
+
+use rquickjs::{Ctx, Function, Result};
+
+use self::resolver::embedded_resolve;
+
+pub mod loader;
+pub mod resolver;
+
+// added when .cjs files are imported
+const CJS_IMPORT_PREFIX: &str = "__cjs:";
+// added to force CJS imports in loader
+const CJS_LOADER_PREFIX: &str = "__cjsm:";
+
+pub static COMPRESSION_DICT: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/compression.dict"));
+
+include!(concat!(env!("OUT_DIR"), "/bytecode_cache.rs"));
+
+pub fn init(ctx: &Ctx) -> Result<()> {
+    let globals = ctx.globals();
+
+    let embedded_hook = Function::new(ctx.clone(), move |x: String, y: String| {
+        embedded_resolve(&x, &y).map(|res| res.into_owned())
+    })?;
+
+    globals.set("__embedded_hook", embedded_hook)?;
+
+    Ok(())
+}

--- a/llrt_core/src/modules/embedded/resolver.rs
+++ b/llrt_core/src/modules/embedded/resolver.rs
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::borrow::Cow;
+
+use rquickjs::{loader::Resolver, Ctx, Error, Result};
+use tracing::trace;
+
+use crate::modules::path;
+
+use super::{BYTECODE_CACHE, CJS_IMPORT_PREFIX};
+
+#[derive(Debug, Default)]
+pub struct EmbeddedResolver;
+
+#[allow(clippy::manual_strip)]
+impl Resolver for EmbeddedResolver {
+    fn resolve(&mut self, _ctx: &Ctx, base: &str, name: &str) -> Result<String> {
+        let name = name.trim_start_matches(CJS_IMPORT_PREFIX);
+        let base = base.trim_start_matches(CJS_IMPORT_PREFIX);
+
+        trace!("Try resolve '{}' from '{}'", name, base);
+
+        embedded_resolve(name, base).map(|name| name.into_owned())
+    }
+}
+
+pub fn embedded_resolve<'a>(x: &'a str, y: &str) -> Result<Cow<'a, str>> {
+    trace!("embedded_resolve(x, y):({}, {})", x, y);
+
+    // If X is a bytecode cache,
+    if BYTECODE_CACHE.contains_key(x) {
+        trace!("+- Resolved by `BYTECODE_CACHE`: {}", x);
+        return Ok(x.into());
+    }
+
+    let x_normalized = path::normalize(x);
+    if BYTECODE_CACHE.contains_key(&x_normalized) {
+        trace!("+- Resolved by `BYTECODE_CACHE`: {}", x_normalized);
+        return Ok(x_normalized.into());
+    }
+
+    Err(Error::new_resolving(y.to_string(), x.to_string()))
+}

--- a/llrt_core/src/modules/mod.rs
+++ b/llrt_core/src/modules/mod.rs
@@ -3,13 +3,14 @@
 #[cfg(not(feature = "lambda"))]
 pub use llrt_modules::console;
 pub use llrt_modules::{
-    abort, assert, buffer, child_process, crypto, dns, events, exceptions, fs, http,
-    module_builder, navigator, net, os, path, perf_hooks, process, stream_web, string_decoder,
-    timers, tty, url, util, zlib, ModuleNames,
+    abort, assert, buffer, child_process, crypto, dns, events, exceptions, fs, http, navigator,
+    net, os, path, perf_hooks, process, stream_web, string_decoder, timers, tty, url, util, zlib,
 };
+pub use llrt_modules::{module_builder, ModuleNames};
 
 #[cfg(feature = "lambda")]
 pub mod console;
+pub mod embedded;
 pub mod llrt;
 pub mod module;
 pub mod require;

--- a/llrt_core/src/modules/require/loader.rs
+++ b/llrt_core/src/modules/require/loader.rs
@@ -1,95 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::{
-    fs::File,
-    io::{self, Read},
-    result::Result as StdResult,
-};
+use std::{fs::File, io::Read};
 
-use once_cell::sync::Lazy;
 use rquickjs::{loader::Loader, Ctx, Function, Module, Object, Result, Value};
 use tracing::trace;
-use zstd::{bulk::Decompressor, dict::DecoderDictionary};
 
-use crate::bytecode::{
-    BYTECODE_COMPRESSED, BYTECODE_FILE_EXT, BYTECODE_UNCOMPRESSED, BYTECODE_VERSION,
-    SIGNATURE_LENGTH,
-};
-
-use super::{BYTECODE_CACHE, CJS_IMPORT_PREFIX, CJS_LOADER_PREFIX, COMPRESSION_DICT};
-
-static DECOMPRESSOR_DICT: Lazy<DecoderDictionary> =
-    Lazy::new(|| DecoderDictionary::copy(COMPRESSION_DICT));
-
-#[cfg(feature = "lambda")]
-include!(concat!(env!("OUT_DIR"), "/sdk_client_endpoints.rs"));
+use super::{CJS_IMPORT_PREFIX, CJS_LOADER_PREFIX};
 
 #[derive(Debug, Default)]
-pub struct CustomLoader;
-impl CustomLoader {
-    pub fn load_bytecode_module<'js>(ctx: Ctx<'js>, buf: &[u8]) -> Result<Module<'js>> {
-        let bytes = Self::get_module_bytecode(buf)?;
-        unsafe { Module::load(ctx, &bytes) }
-    }
+pub struct NpmJsLoader;
 
-    #[inline]
-    pub fn uncompressed_size(input: &[u8]) -> StdResult<(usize, &[u8]), io::Error> {
-        let size = input.get(..4).ok_or(io::ErrorKind::InvalidInput)?;
-        let size: &[u8; 4] = size.try_into().map_err(|_| io::ErrorKind::InvalidInput)?;
-        let uncompressed_size = u32::from_le_bytes(*size) as usize;
-        let rest = &input[4..];
-        Ok((uncompressed_size, rest))
-    }
-
-    fn get_module_bytecode(input: &[u8]) -> Result<Vec<u8>> {
-        let (_, compressed, input) = Self::get_bytecode_signature(input)?;
-
-        if compressed {
-            let (size, input) = Self::uncompressed_size(input)?;
-            let mut buf = Vec::with_capacity(size);
-            let mut decompressor = Decompressor::with_prepared_dictionary(&DECOMPRESSOR_DICT)?;
-            decompressor.decompress_to_buffer(input, &mut buf)?;
-            return Ok(buf);
-        }
-
-        Ok(input.to_vec())
-    }
-
-    fn get_bytecode_signature(input: &[u8]) -> StdResult<(&[u8], bool, &[u8]), io::Error> {
-        let raw_signature = input
-            .get(..SIGNATURE_LENGTH)
-            .ok_or(io::Error::new::<String>(
-                io::ErrorKind::InvalidInput,
-                "Invalid bytecode signature length".into(),
-            ))?;
-
-        let (last, signature) = raw_signature.split_last().unwrap();
-
-        if signature != BYTECODE_VERSION.as_bytes() {
-            return Err(io::Error::new::<String>(
-                io::ErrorKind::InvalidInput,
-                "Invalid bytecode version".into(),
-            ));
-        }
-
-        let mut compressed = None;
-        if *last == BYTECODE_COMPRESSED {
-            compressed = Some(true)
-        } else if *last == BYTECODE_UNCOMPRESSED {
-            compressed = Some(false)
-        }
-
-        let rest = &input[SIGNATURE_LENGTH..];
-        Ok((
-            signature,
-            compressed.ok_or(io::Error::new::<String>(
-                io::ErrorKind::InvalidInput,
-                "Invalid bytecode signature".into(),
-            ))?,
-            rest,
-        ))
-    }
-
+impl NpmJsLoader {
     fn load_cjs_module<'js>(name: &str, ctx: Ctx<'js>) -> Result<Module<'js>> {
         let cjs_specifier = [CJS_IMPORT_PREFIX, name].concat();
         let require: Function = ctx.globals().get("require")?;
@@ -155,7 +76,7 @@ impl CustomLoader {
 
         let (from_cjs_import, is_cjs, normalized_name, path) = Self::normalize_name(name);
 
-        trace!("Loading module: {}", normalized_name);
+        trace!("Loading npm module: {}\n", normalized_name);
 
         //json files can never be from CJS imports as they are handled by require
         if !from_cjs_import {
@@ -176,22 +97,9 @@ impl CustomLoader {
             }
         }
 
-        if let Some(bytes) = BYTECODE_CACHE.get(path) {
-            #[cfg(feature = "lambda")]
-            init_client_connection(&ctx, path)?;
-
-            trace!("Loading embedded module: {}", path);
-
-            return Ok((Self::load_bytecode_module(ctx, bytes)?, Some(path.into())));
-        }
-
         let bytes = std::fs::read(path)?;
         let mut bytes: &[u8] = &bytes;
 
-        if normalized_name.ends_with(BYTECODE_FILE_EXT) {
-            trace!("Loading binary module: {}", path);
-            return Ok((Self::load_bytecode_module(ctx, bytes)?, Some(path.into())));
-        }
         if !from_cjs_import && bytes.starts_with(b"#!") {
             bytes = bytes.splitn(2, |&c| c == b'\n').nth(1).unwrap_or(bytes);
         }
@@ -201,7 +109,7 @@ impl CustomLoader {
     }
 }
 
-impl Loader for CustomLoader {
+impl Loader for NpmJsLoader {
     fn load<'js>(&mut self, ctx: &Ctx<'js>, name: &str) -> Result<Module<'js>> {
         let (module, url) = Self::load_module(name, ctx)?;
         if let Some(url) = url {
@@ -211,56 +119,4 @@ impl Loader for CustomLoader {
 
         Ok(module)
     }
-}
-#[cfg(feature = "lambda")]
-fn init_client_connection(ctx: &Ctx<'_>, specifier: &str) -> Result<()> {
-    use std::{env, time::Instant};
-
-    use http_body_util::BodyExt;
-    use rquickjs::qjs;
-
-    use crate::libs::utils::result::ResultExt;
-    use crate::modules::http::HTTP_CLIENT;
-    use crate::runtime_client::{check_client_inited, mark_client_inited};
-
-    if let Some(sdk_import) = specifier.strip_prefix("@aws-sdk/") {
-        let client_name = sdk_import.trim_start_matches("client-");
-        if let Some(endpoint) = SDK_CLIENT_ENDPOINTS.get(client_name) {
-            let endpoint = if endpoint.is_empty() {
-                client_name
-            } else {
-                endpoint
-            };
-
-            let rt = unsafe { qjs::JS_GetRuntime(ctx.as_raw().as_ptr()) };
-            let rt_ptr = rt as usize; //hack to move, is safe since runtime is still alive in spawn
-
-            if !check_client_inited(rt, endpoint) {
-                let client = HTTP_CLIENT.as_ref().or_throw(ctx)?;
-
-                trace!("Started client init {}", client_name);
-                let region = env::var("AWS_REGION").unwrap();
-
-                let url = ["https://", endpoint, ".", &region, ".amazonaws.com/sping"].concat();
-
-                tokio::task::spawn(async move {
-                    let start = Instant::now();
-
-                    if let Ok(url) = url.parse() {
-                        if let Ok(mut res) = client.get(url).await {
-                            if let Ok(res) = res.body_mut().collect().await {
-                                let _ = res;
-
-                                mark_client_inited(rt_ptr as _);
-
-                                trace!("Client connection initialized in {:?}", start.elapsed());
-                            }
-                        }
-                    }
-                });
-            }
-        }
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
### Issue # (if available)

Related #936 

### Description of changes

> NOTE: We already have an idea for this issue. It's to split `CustomResolver/Loader` into `NpmJsResolver/Loader` and `EmbeddedResolver/Loader`. `NpmJsResolver/Loader` will be exposed, but `EmbeddedResolver/Loader` will continue to be under the management of core.
> 
> However, some integration will be required in `require`. But it seems that we can deal with it by accepting one user-defined function in `require_resolver()` and making ByteCodeCache judgment.

As mentioned in #936, we have extracted the LLRT-specific bytecode from the previous require. In the future, we plan to expose the require directory as llrt_require, and leave the embedded directory under the management of llrt_core.

However, there are still some tangled parts (src/bytecode.rs, src/modules/utils/*) and we cannot expose require as it is. I need some more time to sort this out, so I will hold off on this for now.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
