### PR TITLE
feat: process.exitCode

### DIFF
--- a/llrt_core/src/modules/js/@llrt/test/index.ts
+++ b/llrt_core/src/modules/js/@llrt/test/index.ts
@@ -653,8 +653,7 @@ class TestServer {
           }
         }
       }
-      console.log(output);
-      process.exit(1);
+      process.exitCode = 1;
     }
     console.log(output);
   }

--- a/tests/unit/child_process.test.ts
+++ b/tests/unit/child_process.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import { platform } from "os";
+import process from "process";
 const IS_WINDOWS = platform() === "win32";
 
 describe("child_process.spawn", () => {
@@ -140,5 +141,28 @@ describe("child_process.spawn", () => {
         done(error);
       }
     });
+  });
+
+  it("should have a process exitCode", async () => {
+    const testExitCode = async (
+      exitCodeValue: number,
+      expectedCode: number
+    ) => {
+      const proc = spawn(process.argv0, [
+        "-e",
+        `process.exitCode = ${exitCodeValue}`,
+      ]);
+      await new Promise<void>((resolve) => {
+        proc.on("exit", (code) => {
+          expect(code).toEqual(expectedCode);
+          resolve();
+        });
+      });
+    };
+
+    await testExitCode(241212341, 255);
+    await testExitCode(-1, 255);
+    await testExitCode(1, 1);
+    await testExitCode(-1231231231, 1);
   });
 });

--- a/tests/unit/child_process.test.ts
+++ b/tests/unit/child_process.test.ts
@@ -145,7 +145,7 @@ describe("child_process.spawn", () => {
 
   it("should have a process exitCode", async () => {
     const testExitCode = async (
-      exitCodeValue: number,
+      exitCodeValue: number | string,
       expectedCode: number
     ) => {
       const proc = spawn(process.argv0, [
@@ -160,9 +160,11 @@ describe("child_process.spawn", () => {
       });
     };
 
-    await testExitCode(241212341, 255);
+    await testExitCode(241212341, 181);
     await testExitCode(-1, 255);
     await testExitCode(1, 1);
     await testExitCode(-1231231231, 1);
+    await testExitCode(266, 10);
+    await testExitCode("266", 10);
   });
 });

--- a/types/process.d.ts
+++ b/types/process.d.ts
@@ -185,6 +185,22 @@ declare module "process" {
     exit(code?: number | string | null | undefined): never;
 
     /**
+     * The `process.exitCode` property indicates the exit code that will be used
+     * when the llrt process eventually exits. If it is not specified, the default
+     * exit code is `undefined` and will be 0 on exit.
+     *
+     * ```js
+     * import { exitCode, exit } from 'process';
+     *
+     * exitCode = 42;
+     * exit();
+     * ```
+     *
+     * This will cause the llrt process to exit with the exit code `42`.
+     */
+    exitCode: number | null;
+
+    /**
      * The `process.getgid()` method returns the numerical group identity of the
      * process. (See [`getgid(2)`](http://man7.org/linux/man-pages/man2/getgid.2.html).)
      *
@@ -200,7 +216,7 @@ declare module "process" {
      * Android).
      * @since v0.1.31
      */
-    getgid?: () => number
+    getgid?: () => number;
     /**
      * The `process.setgid()` method sets the group identity of the process. (See [`setgid(2)`](http://man7.org/linux/man-pages/man2/setgid.2.html).) The `id` can be passed as either a
      * numeric ID or a group name
@@ -227,7 +243,7 @@ declare module "process" {
      * @since v0.1.31
      * @param id The group name or ID
      */
-    setgid?: (id: number) => void
+    setgid?: (id: number) => void;
     /**
      * The `process.getuid()` method returns the numeric user identity of the process.
      * (See [`getuid(2)`](http://man7.org/linux/man-pages/man2/getuid.2.html).)
@@ -244,7 +260,7 @@ declare module "process" {
      * Android).
      * @since v0.1.28
      */
-    getuid?: () => number
+    getuid?: () => number;
     /**
      * The `process.setuid(id)` method sets the user identity of the process. (See [`setuid(2)`](http://man7.org/linux/man-pages/man2/setuid.2.html).) The `id` can be passed as either a
      * numeric ID or a username string.
@@ -270,7 +286,7 @@ declare module "process" {
      * This feature is not available in `Worker` threads.
      * @since v0.1.28
      */
-    setuid?: (id: number) => void
+    setuid?: (id: number) => void;
     /**
      * The `process.geteuid()` method returns the numerical effective user identity of
      * the process. (See [`geteuid(2)`](http://man7.org/linux/man-pages/man2/geteuid.2.html).)
@@ -287,7 +303,7 @@ declare module "process" {
      * Android).
      * @since v2.0.0
      */
-    geteuid?: () => number
+    geteuid?: () => number;
     /**
      * The `process.seteuid()` method sets the effective user identity of the process.
      * (See [`seteuid(2)`](http://man7.org/linux/man-pages/man2/seteuid.2.html).) The `id` can be passed as either a numeric ID or a username
@@ -314,7 +330,7 @@ declare module "process" {
      * @since v2.0.0
      * @param id A user name or ID
      */
-    seteuid?: (id: number) => void
+    seteuid?: (id: number) => void;
     /**
      * The `process.getegid()` method returns the numerical effective group identity
      * of the Node.js process. (See [`getegid(2)`](http://man7.org/linux/man-pages/man2/getegid.2.html).)
@@ -331,7 +347,7 @@ declare module "process" {
      * Android).
      * @since v2.0.0
      */
-    getegid?: () => number
+    getegid?: () => number;
     /**
      * The `process.setegid()` method sets the effective group identity of the process.
      * (See [`setegid(2)`](http://man7.org/linux/man-pages/man2/setegid.2.html).) The `id` can be passed as either a numeric ID or a group
@@ -358,6 +374,6 @@ declare module "process" {
      * @since v2.0.0
      * @param id A group name or ID
      */
-    setegid?: (id: number) => void
+    setegid?: (id: number) => void;
   }
 }


### PR DESCRIPTION
### Description of changes

Allows users to set exit code for process.

`process.exitCode = 42`. Also make sure `process.exit()` can be called without args.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
