### PR TITLE
fix: Timer execution order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 resolver = "2"
-# Patch doesn't play well with *, so we have to list individual members
-# See https://github.com/rust-lang/cargo/issues/14717
+
 members = [
   "libs/llrt_build",
   "libs/llrt_compression",

--- a/modules/llrt_timers/src/lib.rs
+++ b/modules/llrt_timers/src/lib.rs
@@ -252,7 +252,11 @@ fn create_spawn_loop(
     Ok(())
 }
 
-pub struct ExecutingTimer(NonNull<qjs::JSContext>, Persistent<Function<'static>>);
+pub struct ExecutingTimer(
+    Instant,
+    NonNull<qjs::JSContext>,
+    Persistent<Function<'static>>,
+);
 
 unsafe impl Send for ExecutingTimer {}
 
@@ -277,14 +281,14 @@ pub fn poll_timers(
             let ctx = timeout.raw_ctx;
             if let Some(cb) = timeout.callback.take() {
                 if !timeout.repeating {
-                    call_vec.push(Some(ExecutingTimer(ctx, cb)));
+                    call_vec.push(Some(ExecutingTimer(timeout.deadline, ctx, cb)));
                     return false;
                 }
                 timeout.deadline = now + Duration::from_millis(timeout.interval);
                 if timeout.deadline < lowest {
                     lowest = timeout.deadline;
                 }
-                call_vec.push(Some(ExecutingTimer(ctx, cb.clone())));
+                call_vec.push(Some(ExecutingTimer(timeout.deadline, ctx, cb.clone())));
                 timeout.callback.replace(cb);
             } else {
                 return false;
@@ -312,8 +316,10 @@ pub fn poll_timers(
 
     drop(rt_timers);
 
+    call_vec.sort_unstable_by_key(|v| v.as_ref().map(|v| v.0));
+
     for item in call_vec.iter_mut() {
-        if let Some(ExecutingTimer(ctx, timeout)) = item.take() {
+        if let Some(ExecutingTimer(_, ctx, timeout)) = item.take() {
             let ctx2 = unsafe { Ctx::from_raw(ctx) };
             if let Ok(timeout) = timeout.restore(&ctx2) {
                 timeout.call::<_, ()>(())?;


### PR DESCRIPTION
### Issue # (if available)

Fixes: https://github.com/awslabs/llrt/issues/965

### Description of changes

Timers are batched for performance reasons. A timer batch was not sorted. This PR sorts timers according to their deadline.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
