### PR TITLE
fix(timers): not completing all microtasks before completing a macrotask

### DIFF
--- a/modules/llrt_timers/src/lib.rs
+++ b/modules/llrt_timers/src/lib.rs
@@ -315,6 +315,9 @@ pub fn poll_timers(
     for item in call_vec.iter_mut() {
         if let Some(ExecutingTimer(ctx, timeout)) = item.take() {
             let ctx2 = unsafe { Ctx::from_raw(ctx) };
+
+            while ctx2.execute_pending_job() {}
+
             if let Ok(timeout) = timeout.restore(&ctx2) {
                 timeout.call::<_, ()>(())?;
             }

--- a/tests/unit/asynchronous-processing-discipline.test.ts
+++ b/tests/unit/asynchronous-processing-discipline.test.ts
@@ -1,3 +1,5 @@
+const CWD = process.cwd();
+
 async function waitAndExpectSequentialNumbers(tracked, delayMs) {
   await new Promise((resolve) => {
     setTimeout(() => {
@@ -135,5 +137,96 @@ describe("Asynchronous Microtask Function", () => {
     tracked.push(1);
 
     await waitAndExpectSequentialNumbers(tracked, 10);
+  });
+});
+
+describe("Asynchronous Require/Import", () => {
+  it("When a require is executed synchronously within the main thread, the following statements are executed immediately after the module is loaded.", async () => {
+    const tracked = [];
+
+    tracked.push(1);
+    require(`${CWD}/fixtures/empty.js`);
+    tracked.push(2);
+
+    await waitAndExpectSequentialNumbers(tracked, 10);
+  });
+
+  it("When require is placed inside a queueMicrotask, it executes after the current synchronous execution context finishes and before any scheduled macrotasks.", async () => {
+    const tracked = [];
+
+    queueMicrotask(() => {
+      tracked.push(2);
+      require(`${CWD}/fixtures/empty.js`);
+      tracked.push(3);
+    });
+    queueMicrotask(() => tracked.push(4));
+
+    tracked.push(1);
+
+    await waitAndExpectSequentialNumbers(tracked, 10);
+  });
+
+  it("When require is placed inside a setTimeout, it executes after all synchronous code and all microtasks have been completed, following the macrotask scheduling.", async () => {
+    const tracked = [];
+
+    setTimeout(() => {
+      tracked.push(3);
+      require(`${CWD}/fixtures/empty.js`);
+      tracked.push(4);
+    }, 0);
+    queueMicrotask(() => tracked.push(2));
+
+    tracked.push(1);
+
+    await waitAndExpectSequentialNumbers(tracked, 10);
+  });
+
+  it("When require is placed inside a Promise.then, it executes after the current synchronous execution context finishes but before any macrotasks, following the microtask scheduling rules.", async () => {
+    const tracked = [];
+
+    Promise.resolve().then(() => {
+      tracked.push(2);
+      require(`${CWD}/fixtures/empty.js`);
+      tracked.push(3);
+    });
+    queueMicrotask(() => tracked.push(4));
+
+    tracked.push(1);
+
+    await waitAndExpectSequentialNumbers(tracked, 10);
+  });
+
+  it("When multiple queueMicrotask calls contain require, they execute in the order they were scheduled, immediately after all synchronous code, according to FIFO (first-in, first-out) microtask queue behavior.", async () => {
+    const tracked = [];
+
+    queueMicrotask(() => {
+      tracked.push(2);
+      require(`${CWD}/fixtures/empty.js`);
+      tracked.push(3);
+    });
+    queueMicrotask(() => {
+      tracked.push(4);
+      require(`${CWD}/fixtures/empty.js`);
+      tracked.push(5);
+    });
+
+    tracked.push(1);
+
+    await waitAndExpectSequentialNumbers(tracked, 10);
+  });
+
+  it("When using await import(), the code following the await resumes only after all earlier queued microtasks have been executed, as await yields execution back to the event loop.", async () => {
+    const tracked = [];
+
+    (async () => {
+      tracked.push(1);
+      await import(`${CWD}/fixtures/empty.js`);
+      tracked.push(4);
+    })();
+
+    queueMicrotask(() => tracked.push(3));
+    tracked.push(2);
+
+    await waitAndExpectSequentialNumbers(tracked, 20);
   });
 });

--- a/tests/unit/asynchronous-processing-discipline.test.ts
+++ b/tests/unit/asynchronous-processing-discipline.test.ts
@@ -1,19 +1,22 @@
-describe("Asynchronous Processing Discipline", () => {
-  function expectSequentialNumbers(tracked) {
-    expect(tracked).toEqual(
-      Array.from({ length: tracked.length }, (_, i) => i + 1)
-    );
-  }
+async function waitAndExpectSequentialNumbers(tracked, delayMs) {
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      expect(tracked).toEqual(
+        Array.from({ length: tracked.length }, (_, i) => i + 1)
+      );
+      resolve();
+    }, delayMs);
+  });
+}
 
+describe("Execution order of synchronous and asynchronous processes", () => {
   it("Synchronous operations have priority over microtasks.", async () => {
     const tracked = [];
 
     queueMicrotask(() => tracked.push(2));
     tracked.push(1);
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
 
   it("Synchronous operations have priority over macrotasks.", async () => {
@@ -22,9 +25,7 @@ describe("Asynchronous Processing Discipline", () => {
     setTimeout(() => tracked.push(2));
     tracked.push(1);
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
 
   it("Microtasks are executed in the order they are registered.", async () => {
@@ -33,9 +34,7 @@ describe("Asynchronous Processing Discipline", () => {
     Promise.resolve().then(() => tracked.push(1));
     queueMicrotask(() => tracked.push(2));
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
 
   it("When a microtask occurs within a microtask, it is placed at the end of the accumulated microtasks.", async () => {
@@ -43,13 +42,11 @@ describe("Asynchronous Processing Discipline", () => {
 
     Promise.resolve().then(() => {
       tracked.push(1);
-      queueMicrotask(() => (tracked.push(3)));
+      queueMicrotask(() => tracked.push(3));
     });
     queueMicrotask(() => tracked.push(2));
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
 
   it("If a macrotask and a microtask are registered at the same time, the microtask will take priority.", async () => {
@@ -59,21 +56,17 @@ describe("Asynchronous Processing Discipline", () => {
     Promise.resolve().then(() => tracked.push(1));
     queueMicrotask(() => tracked.push(2));
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
 
   it("Macro tasks with different scheduled firing times are executed in the order of their scheduled firing times.", async () => {
     const tracked = [];
 
-    setTimeout(() => tracked.push(3), 10);
+    setTimeout(() => tracked.push(3), 20);
+    setTimeout(() => tracked.push(2), 10);
     setTimeout(() => tracked.push(1));
-    setTimeout(() => tracked.push(2));
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 20);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 30);
   });
 
   it("If a microtask occurs within a macrotask, all microtasks are executed before the next macrotask is executed.", async () => {
@@ -86,9 +79,7 @@ describe("Asynchronous Processing Discipline", () => {
     });
     setTimeout(() => tracked.push(4));
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
 
   it("When a new macrotask occurs among the macrotasks, it is placed at the end of the accumulated macrotasks.", async () => {
@@ -100,11 +91,11 @@ describe("Asynchronous Processing Discipline", () => {
     });
     setTimeout(() => tracked.push(2));
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
+});
 
+describe("Asynchronous Microtask Function", () => {
   it("If an asynchronous microtask function does not contain an await, it is executed entirely at the time of function registration.", async () => {
     const tracked = [];
 
@@ -115,41 +106,34 @@ describe("Asynchronous Processing Discipline", () => {
     microTaskFunction();
     tracked.push(2);
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
-  });
-
-  it("If an asynchronous microtask function contains an asynchronous operation with await, the subsequent operation will be executed after the asynchronous operation has finished.", async () => {
-    const tracked = [];
-
-    async function microTaskFunction() {
-      await Promise.resolve();
-      tracked.push(2);
-    }
-
-    microTaskFunction();
-    tracked.push(1);
-
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
 
   it("If an asynchronous microtask function contains an asynchronous operation without await, the subsequent operation will execute immediately because the asynchronous operation will not wait for completion.", async () => {
     const tracked = [];
 
     async function microTaskFunction() {
-      Promise.resolve();
+      Promise.resolve().then(() => tracked.push(3));
       tracked.push(1);
     }
 
     microTaskFunction();
     tracked.push(2);
 
-    await new Promise((resolve) => {
-      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
-    });
+    await waitAndExpectSequentialNumbers(tracked, 10);
   });
 
+  it("If an asynchronous microtask function contains an asynchronous operation with await, the subsequent operation will be executed after the asynchronous operation has finished.", async () => {
+    const tracked = [];
+
+    async function microTaskFunction() {
+      await Promise.resolve().then(() => tracked.push(2));
+      tracked.push(3);
+    }
+
+    microTaskFunction();
+    tracked.push(1);
+
+    await waitAndExpectSequentialNumbers(tracked, 10);
+  });
 });

--- a/tests/unit/asynchronous-processing-discipline.test.ts
+++ b/tests/unit/asynchronous-processing-discipline.test.ts
@@ -1,0 +1,155 @@
+describe("Asynchronous Processing Discipline", () => {
+  function expectSequentialNumbers(tracked) {
+    expect(tracked).toEqual(
+      Array.from({ length: tracked.length }, (_, i) => i + 1)
+    );
+  }
+
+  it("Synchronous operations have priority over microtasks.", async () => {
+    const tracked = [];
+
+    queueMicrotask(() => tracked.push(2));
+    tracked.push(1);
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("Synchronous operations have priority over macrotasks.", async () => {
+    const tracked = [];
+
+    setTimeout(() => tracked.push(2));
+    tracked.push(1);
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("Microtasks are executed in the order they are registered.", async () => {
+    const tracked = [];
+
+    Promise.resolve().then(() => tracked.push(1));
+    queueMicrotask(() => tracked.push(2));
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("When a microtask occurs within a microtask, it is placed at the end of the accumulated microtasks.", async () => {
+    const tracked = [];
+
+    Promise.resolve().then(() => {
+      tracked.push(1);
+      queueMicrotask(() => (tracked.push(3)));
+    });
+    queueMicrotask(() => tracked.push(2));
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("If a macrotask and a microtask are registered at the same time, the microtask will take priority.", async () => {
+    const tracked = [];
+
+    setTimeout(() => tracked.push(3));
+    Promise.resolve().then(() => tracked.push(1));
+    queueMicrotask(() => tracked.push(2));
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("Macro tasks with different scheduled firing times are executed in the order of their scheduled firing times.", async () => {
+    const tracked = [];
+
+    setTimeout(() => tracked.push(3), 10);
+    setTimeout(() => tracked.push(1));
+    setTimeout(() => tracked.push(2));
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 20);
+    });
+  });
+
+  it("If a microtask occurs within a macrotask, all microtasks are executed before the next macrotask is executed.", async () => {
+    const tracked = [];
+
+    setTimeout(() => {
+      tracked.push(1);
+      queueMicrotask(() => tracked.push(2));
+      queueMicrotask(() => tracked.push(3));
+    });
+    setTimeout(() => tracked.push(4));
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("When a new macrotask occurs among the macrotasks, it is placed at the end of the accumulated macrotasks.", async () => {
+    const tracked = [];
+
+    setTimeout(() => {
+      tracked.push(1);
+      setTimeout(() => tracked.push(3));
+    });
+    setTimeout(() => tracked.push(2));
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("If an asynchronous microtask function does not contain an await, it is executed entirely at the time of function registration.", async () => {
+    const tracked = [];
+
+    async function microTaskFunction() {
+      tracked.push(1);
+    }
+
+    microTaskFunction();
+    tracked.push(2);
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("If an asynchronous microtask function contains an asynchronous operation with await, the subsequent operation will be executed after the asynchronous operation has finished.", async () => {
+    const tracked = [];
+
+    async function microTaskFunction() {
+      await Promise.resolve();
+      tracked.push(2);
+    }
+
+    microTaskFunction();
+    tracked.push(1);
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+  it("If an asynchronous microtask function contains an asynchronous operation without await, the subsequent operation will execute immediately because the asynchronous operation will not wait for completion.", async () => {
+    const tracked = [];
+
+    async function microTaskFunction() {
+      Promise.resolve();
+      tracked.push(1);
+    }
+
+    microTaskFunction();
+    tracked.push(2);
+
+    await new Promise((resolve) => {
+      setTimeout(() => { expectSequentialNumbers(tracked); resolve(); }, 10);
+    });
+  });
+
+});


### PR DESCRIPTION
### Description of changes

This code verifies that all microtasks have been processed before processing a macrotask. If it works correctly, the output will start in alphabetical order.

<details>
  <summary> realitySettimeout-nested.js</summary>

```javascript
// realitySettimeout-nested.js
console.log("[A] 🦖 MAINLINE: Start");

setTimeout(() => {
  console.log("[D] ⏰ TIMERS: setTimeout[0ms]");

  Promise.resolve("1st Promise")
    .then((value) => console.log("[E] 👦 MICRO: Resolved value:", value))
    .then(() => console.log("[F] 👦 MICRO: Next chain"));

  setTimeout(() => {
    console.log("[J] ⏰ TIMERS: setTimeout[0ms]");

    Promise.resolve("2nd Promise")
      .then((value) => console.log("[K] 👦 MICRO: Resolved value:", value))
      .then(() => console.log("[L] 👦 MICRO: Next chain"));
    });
  });

setTimeout(() => {
  console.log("[G] ⏰ TIMERS: setTimeout[0ms]");

  Promise.resolve("3rd Promise")
    .then((value) => console.log("[H] 👦 MICRO: Resolved value:", value))
    .then(() => console.log("[I] 👦 MICRO: Next chain"));
  });

Promise.resolve().then(() => console.log("[C] 👦 MICRO: then"));

console.log("[B] 🦖 MAINLINE: End");
```

</details>

Node.js (The results for Deno and Bun are similar):
```
% node realitySettimeout-nested.cjs
[A] 🦖 MAINLINE: Start
[B] 🦖 MAINLINE: End
[C] 👦 MICRO: then
[D] ⏰ TIMERS: setTimeout[0ms]
[E] 👦 MICRO: Resolved value: 1st Promise
[F] 👦 MICRO: Next chain
[G] ⏰ TIMERS: setTimeout[0ms]
[H] 👦 MICRO: Resolved value: 3rd Promise
[I] 👦 MICRO: Next chain
[J] ⏰ TIMERS: setTimeout[0ms]
[K] 👦 MICRO: Resolved value: 2nd Promise
[L] 👦 MICRO: Next chain
```

LLRT:
```
 % llrt realitySettimeout-nested.cjs
[A] 🦖 MAINLINE: Start
[B] 🦖 MAINLINE: End
[D] ⏰ TIMERS: setTimeout[0ms]
[G] ⏰ TIMERS: setTimeout[0ms]
[C] 👦 MICRO: then
[E] 👦 MICRO: Resolved value: 1st Promise
[H] 👦 MICRO: Resolved value: 3rd Promise
[F] 👦 MICRO: Next chain
[I] 👦 MICRO: Next chain
[J] ⏰ TIMERS: setTimeout[0ms]
[K] 👦 MICRO: Resolved value: 2nd Promise
[L] 👦 MICRO: Next chain
```

This PR checks that all microtasks have been processed before executing a macrotask (a timer task in LLRT).

LLRT(After correction):
```
% llrt realitySettimeout-nested.cjs
[A] 🦖 MAINLINE: Start
[B] 🦖 MAINLINE: End
[C] 👦 MICRO: then
[D] ⏰ TIMERS: setTimeout[0ms]
[E] 👦 MICRO: Resolved value: 1st Promise
[F] 👦 MICRO: Next chain
[G] ⏰ TIMERS: setTimeout[0ms]
[H] 👦 MICRO: Resolved value: 3rd Promise
[I] 👦 MICRO: Next chain
[J] ⏰ TIMERS: setTimeout[0ms]
[K] 👦 MICRO: Resolved value: 2nd Promise
[L] 👦 MICRO: Next chain
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
