### PR TITLE
Increased Web Platform compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,9 +380,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -3724,9 +3724,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.10"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/modules/llrt_crypto/src/subtle/crypto_key.rs
+++ b/modules/llrt_crypto/src/subtle/crypto_key.rs
@@ -4,8 +4,9 @@ use std::rc::Rc;
 
 use llrt_utils::str_enum;
 use rquickjs::{
+    atom::PredefinedAtom,
     class::{Trace, Tracer},
-    Ctx, Result, Value,
+    Ctx, Exception, Result, Value,
 };
 
 use super::key_algorithm::KeyAlgorithm;
@@ -60,6 +61,11 @@ impl<'js> Trace<'js> for CryptoKey {
 
 #[rquickjs::methods]
 impl CryptoKey {
+    #[qjs(constructor)]
+    fn constructor(ctx: Ctx<'_>) -> Result<Self> {
+        Err(Exception::throw_type(&ctx, "Illegal constructor"))
+    }
+
     #[qjs(get, rename = "type")]
     pub fn get_type(&self) -> &str {
         self.kind.as_str()
@@ -68,6 +74,11 @@ impl CryptoKey {
     #[qjs(get)]
     pub fn extractable(&self) -> bool {
         self.extractable
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(CryptoKey)
     }
 
     #[qjs(get)]

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -53,6 +53,18 @@ use rsa::RsaPrivateKey;
 
 use crate::sha_hash::ShaAlgorithm;
 
+#[rquickjs::class]
+#[derive(rquickjs::JsLifetime, rquickjs::class::Trace)]
+pub struct SubtleCrypto {}
+
+#[rquickjs::methods]
+impl SubtleCrypto {
+    #[qjs(constructor)]
+    pub fn new(ctx: Ctx<'_>) -> Result<Self> {
+        Err(Exception::throw_type(&ctx, "Illegal constructor"))
+    }
+}
+
 pub enum AesCbcEncVariant {
     Aes128(cbc::Encryptor<aes::Aes128>),
     Aes192(cbc::Encryptor<aes::Aes192>),

--- a/modules/llrt_exceptions/src/lib.rs
+++ b/modules/llrt_exceptions/src/lib.rs
@@ -168,7 +168,7 @@ impl DOMException {
 
     #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
     pub fn to_string_tag(&self) -> &str {
-        "DOMException"
+        stringify!(DOMException)
     }
 }
 

--- a/modules/llrt_http/src/request.rs
+++ b/modules/llrt_http/src/request.rs
@@ -5,8 +5,8 @@ use llrt_json::parse::json_parse;
 use llrt_url::url_class::URL;
 use llrt_utils::{bytes::ObjectBytes, class::get_class, object::ObjectExt, result::ResultExt};
 use rquickjs::{
-    class::Trace, function::Opt, ArrayBuffer, Class, Ctx, Exception, FromJs, IntoJs, Null, Object,
-    Result, TypedArray, Value,
+    atom::PredefinedAtom, class::Trace, function::Opt, ArrayBuffer, Class, Ctx, Exception, FromJs,
+    IntoJs, Null, Object, Result, TypedArray, Value,
 };
 
 use super::{blob::Blob, headers::Headers};
@@ -97,6 +97,11 @@ impl<'js> Request<'js> {
         self.headers.clone()
     }
 
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(Request)
+    }
+
     //TODO should implement readable stream
     #[qjs(get)]
     fn body(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
@@ -122,13 +127,13 @@ impl<'js> Request<'js> {
     }
 
     #[qjs(get)]
-    fn mode(&self) -> String {
-        "navigate".to_string()
+    fn mode(&self) -> &'static str {
+        "navigate"
     }
 
     #[qjs(get)]
-    fn cache(&self) -> String {
-        "no-store".to_string()
+    fn cache(&self) -> &'static str {
+        "no-store"
     }
 
     pub async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {

--- a/modules/llrt_http/src/response.rs
+++ b/modules/llrt_http/src/response.rs
@@ -21,6 +21,7 @@ use llrt_utils::bytes::ObjectBytes;
 use llrt_utils::{mc_oneshot, result::ResultExt};
 use once_cell::sync::Lazy;
 use rquickjs::{
+    atom::PredefinedAtom,
     class::{Trace, Tracer},
     function::Opt,
     ArrayBuffer, Class, Coerced, Ctx, Exception, JsLifetime, Null, Object, Result, TypedArray,
@@ -329,6 +330,11 @@ impl<'js> Response<'js> {
             0 => "error",
             _ => "basic",
         }
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(Response)
     }
 
     #[qjs(get)]


### PR DESCRIPTION
### Issue # (if available)

Partially fixes
https://github.com/awslabs/llrt/issues/967

Fixes:
https://github.com/awslabs/llrt/issues/970

### Description of changes

Exposes the Crypto, SubtleCrypto and CryptoKey constructors to `globalThis`.
Additionally this PR adds some `toStringTag` symbol getters for Web APIs

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
