### PR TITLE
fix(core): fix incompatibilities caused by the latest cargo fix

### DIFF
--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -253,10 +253,7 @@ fn compress_bytecode(dictionary_path: String, source_files: Vec<String>) -> io::
             .output()?;
 
         if !output.status.success() {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Failed to compress file",
-            ));
+            return Err(io::Error::other("Failed to compress file"));
         }
 
         let bytes = fs::read(&filename)?;
@@ -313,8 +310,7 @@ fn generate_compression_dictionary(
     let mut cmd = cmd.current_dir(out_dir).args(short_source_files).spawn()?;
     let exit_status = cmd.wait()?;
     if !exit_status.success() {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
+        return Err(io::Error::other(
             "Failed to generate compression dictionary",
         ));
     };


### PR DESCRIPTION
### Description of changes

After applying the latest rust toolchain, we found new incompatibilities and have fixed them.

```
% rustup update
info: syncing channel updates for 'stable-aarch64-apple-darwin'
info: syncing channel updates for 'nightly-aarch64-apple-darwin'
info: checking for self-update

   stable-aarch64-apple-darwin unchanged - rustc 1.87.0 (17067e9ac 2025-05-09)
  nightly-aarch64-apple-darwin unchanged - rustc 1.89.0-nightly (d97326eab 2025-05-15)
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
