### PR TITLE
feat: add `--executable` flag to `llrt compile`

### DIFF
--- a/llrt_core/src/modules/require/loader.rs
+++ b/llrt_core/src/modules/require/loader.rs
@@ -1,14 +1,150 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::{fs::File, io::Read};
+use std::{
+    fs::File,
+    io::{self, Read},
+    result::Result as StdResult,
+};
 
 use rquickjs::{loader::Loader, Ctx, Function, Module, Object, Result, Value};
 use tracing::trace;
+use zstd::bulk::Decompressor;
 
 use super::{CJS_IMPORT_PREFIX, CJS_LOADER_PREFIX};
+use crate::bytecode::{BYTECODE_COMPRESSED, BYTECODE_VERSION, SIGNATURE_LENGTH};
+use crate::modules::embedded::COMPRESSION_DICT;
+
+// These are used for backward compatibility
+const LEGACY_BYTECODE_VERSION: &str = "v1";
+const LEGACY_BYTECODE_COMPRESSED: u8 = 1;
+const LEGACY_SIGNATURE_LENGTH: usize = 3;
 
 #[derive(Debug, Default)]
 pub struct NpmJsLoader;
+
+#[derive(Debug, Default)]
+pub struct CustomLoader;
+
+impl CustomLoader {
+    pub fn load_bytecode_module<'js>(ctx: Ctx<'js>, buf: &[u8]) -> Result<Module<'js>> {
+        let bytes = Self::get_module_bytecode(buf)?;
+        unsafe { Module::load(ctx, &bytes) }
+    }
+
+    #[inline]
+    pub fn uncompressed_size(input: &[u8]) -> StdResult<(usize, &[u8]), io::Error> {
+        let size = input.get(..4).ok_or(io::ErrorKind::InvalidInput)?;
+        let size: &[u8; 4] = size.try_into().map_err(|_| io::ErrorKind::InvalidInput)?;
+        let uncompressed_size = u32::from_le_bytes(*size) as usize;
+        let rest = &input[4..];
+        Ok((uncompressed_size, rest))
+    }
+
+    pub fn get_module_bytecode(input: &[u8]) -> Result<Vec<u8>> {
+        // Check for LLRT_EXE marker at the end (self-contained executable)
+        let marker = b"LLRT_EXE";
+        if input.len() > marker.len() + 8 {
+            let marker_pos = input.len() - marker.len();
+            if &input[marker_pos..] == marker {
+                trace!("Found LLRT_EXE marker at position {}", marker_pos);
+
+                let size_bytes = &input[marker_pos - 8..marker_pos];
+                let bytecode_size = u64::from_le_bytes([
+                    size_bytes[0],
+                    size_bytes[1],
+                    size_bytes[2],
+                    size_bytes[3],
+                    size_bytes[4],
+                    size_bytes[5],
+                    size_bytes[6],
+                    size_bytes[7],
+                ]) as usize;
+
+                trace!("Bytecode size from footer: {} bytes", bytecode_size);
+
+                if bytecode_size > 0 && bytecode_size < input.len() {
+                    let bytecode_start = marker_pos - 8 - bytecode_size;
+                    trace!("Bytecode starts at offset {}", bytecode_start);
+
+                    let bytecode = &input[bytecode_start..bytecode_start + bytecode_size];
+                    trace!("Checking bytecode signature and format");
+
+                    // Return the raw bytecode for further processing
+                    return Self::extract_bytecode(bytecode);
+                } else {
+                    trace!("Invalid bytecode size: {}", bytecode_size);
+                }
+            }
+        }
+
+        // Regular bytecode processing
+        Self::extract_bytecode(input)
+    }
+
+    fn extract_bytecode(input: &[u8]) -> Result<Vec<u8>> {
+        trace!("Extracting bytecode, input size: {} bytes", input.len());
+
+        // Try the current bytecode format
+        if input.len() >= SIGNATURE_LENGTH
+            && &input[..BYTECODE_VERSION.len()] == BYTECODE_VERSION.as_bytes()
+        {
+            trace!(
+                "Recognized current bytecode format signature: {}",
+                BYTECODE_VERSION
+            );
+            let compressed = input[BYTECODE_VERSION.len()] == BYTECODE_COMPRESSED;
+            trace!("Bytecode is compressed: {}", compressed);
+            let rest = &input[SIGNATURE_LENGTH..];
+
+            if compressed {
+                let (size, data) = Self::uncompressed_size(rest)?;
+                trace!("Uncompressed size will be: {} bytes", size);
+                let mut buf = Vec::with_capacity(size);
+                let mut decompressor = Decompressor::with_dictionary(COMPRESSION_DICT)?;
+                decompressor.decompress_to_buffer(data, &mut buf)?;
+                trace!("Successfully decompressed bytecode");
+                return Ok(buf);
+            } else {
+                trace!("Using uncompressed bytecode");
+                return Ok(rest.to_vec());
+            }
+        }
+
+        // Try the legacy bytecode format
+        if input.len() >= LEGACY_SIGNATURE_LENGTH
+            && &input[..LEGACY_BYTECODE_VERSION.len()] == LEGACY_BYTECODE_VERSION.as_bytes()
+        {
+            trace!(
+                "Recognized legacy bytecode format signature: {}",
+                LEGACY_BYTECODE_VERSION
+            );
+            let compressed = input[LEGACY_BYTECODE_VERSION.len()] == LEGACY_BYTECODE_COMPRESSED;
+            trace!("Legacy bytecode is compressed: {}", compressed);
+            let rest = &input[LEGACY_SIGNATURE_LENGTH..];
+
+            if compressed {
+                let (size, data) = Self::uncompressed_size(rest)?;
+                trace!("Uncompressed size will be: {} bytes", size);
+                let mut buf = Vec::with_capacity(size);
+                let mut decompressor = Decompressor::with_dictionary(COMPRESSION_DICT)?;
+                decompressor.decompress_to_buffer(data, &mut buf)?;
+                trace!("Successfully decompressed legacy bytecode");
+                return Ok(buf);
+            } else {
+                trace!("Using uncompressed legacy bytecode");
+                return Ok(rest.to_vec());
+            }
+        }
+
+        // If both formats fail, return an error
+        trace!("Failed to recognize bytecode format");
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Invalid bytecode signature".to_string(),
+        )
+        .into())
+    }
+}
 
 impl NpmJsLoader {
     fn load_cjs_module<'js>(name: &str, ctx: Ctx<'js>) -> Result<Module<'js>> {
@@ -53,7 +189,7 @@ impl NpmJsLoader {
 
     fn normalize_name(name: &str) -> (bool, bool, &str, &str) {
         if !name.starts_with("__") {
-            // If name doesn’t start with "__", return defaults
+            // If name doesn't start with "__", return defaults
             return (false, false, name, name);
         }
 

--- a/llrt_core/src/modules/require/mod.rs
+++ b/llrt_core/src/modules/require/mod.rs
@@ -51,6 +51,36 @@ unsafe impl<'js> JsLifetime<'js> for RequireState<'js> {
     type Changed<'to> = RequireState<'to>;
 }
 
+// Include bytecode cache for loading embedded modules
+include!(concat!(env!("OUT_DIR"), "/bytecode_cache.rs"));
+
+/// Load bytecode as a module
+pub fn load_bytecode_as_module<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    module_name: &str,
+    bytecode: &[u8],
+) -> rquickjs::Result<rquickjs::Module<'js>> {
+    use tracing::trace;
+
+    trace!("Loading bytecode as module: {}", module_name);
+
+    // Attempt to load the bytecode as a module
+    let bytes = loader::CustomLoader::get_module_bytecode(bytecode).map_err(|e| {
+        rquickjs::Error::new_loading(format!("Failed to decompress bytecode: {}", e))
+    })?;
+
+    // Try to load as a module
+    let result = unsafe { rquickjs::Module::load(ctx.clone(), &bytes) };
+
+    // Return the module if successful
+    if result.is_ok() {
+        return result;
+    }
+
+    // If loading as a module fails, return the error
+    result
+}
+
 pub fn require(ctx: Ctx<'_>, specifier: String) -> Result<Value<'_>> {
     let globals = ctx.globals();
     let embedded_fn: Option<Function> = globals.get("__embedded_hook").ok();

--- a/tests/fixtures/executable/test.ts
+++ b/tests/fixtures/executable/test.ts
@@ -1,0 +1,45 @@
+// Simple test script for the executable functionality
+console.log("Hello from LLRT executable test!");
+console.log(
+  "This file is used to test the --executable flag for 'llrt compile'"
+);
+
+// Print command line arguments
+console.log("Command line arguments:", process.argv);
+
+// Test some basic JavaScript features to ensure they work in the executable
+interface RuntimeInfo {
+  name: string;
+  version: string;
+  features: string[];
+}
+
+const runtimeInfo: RuntimeInfo = {
+  name: "LLRT",
+  version: process.env.LLRT_VERSION || "test",
+  features: [
+    "Self-contained executables",
+    "Bytecode compilation",
+    "Fast JavaScript runtime",
+  ],
+};
+
+console.log("Runtime info:", runtimeInfo);
+console.log("Features:", runtimeInfo.features.join(", "));
+
+// Test async functions
+async function testAsync(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      console.log("Async operation completed");
+      resolve();
+    }, 100);
+  });
+}
+
+// Run async test and exit with custom code
+(async (): Promise<never> => {
+  await testAsync();
+  // Exit with custom code to test proper process exit handling
+  process.exit(42);
+})(); 

--- a/tests/unit/compile.test.ts
+++ b/tests/unit/compile.test.ts
@@ -28,11 +28,16 @@ const spawnCapture = async (cmd: string, args: string[]) => {
   return { stdout, stderr, status, signal };
 };
 
-const compile = async (filename: string, outputFilename: string) =>
-  await spawnCapture(process.argv0, ["compile", filename, outputFilename]);
+const compile = async (filename: string, outputFilename: string, executable = false) => {
+  const args = ["compile", filename, outputFilename];
+  if (executable) {
+    args.push("--executable");
+  }
+  return await spawnCapture(process.argv0, args);
+};
 
-const run = async (filename: string) =>
-  await spawnCapture(process.argv0, [filename]);
+const run = async (filename: string, args: string[] = []) =>
+  await spawnCapture(filename, args);
 
 if (false) {
   describe("llrt compile", async () => {
@@ -81,6 +86,24 @@ if (false) {
       expect(runResult.stdout).toEqual("");
       expect(runResult.stderr).toEqual("42\n");
       expect(runResult.status).toEqual(1);
+    });
+
+    // Test the --executable flag
+    it("can create a self-contained executable", async () => {
+      const tmpExe = `${tmpDir}/hello_exe`;
+
+      // Create a self-contained executable
+      const compileResult = await compile("fixtures/hello.js", tmpExe, true);
+
+      expect(compileResult.stderr).toEqual("");
+      expect(compileResult.signal).toEqual(undefined);
+      
+      // Check that the file exists and is executable
+      const stat = await fs.stat(tmpExe);
+      expect(stat.isFile()).toBe(true);
+      
+      // 0o111 is the executable bits (uga+x)
+      expect(!!(stat.mode & 0o111)).toBe(true);
     });
 
     afterAll(async () => {

--- a/tests/unit/executable.test.ts
+++ b/tests/unit/executable.test.ts
@@ -1,0 +1,127 @@
+// Tests for the executable compilation feature
+// This verifies that we can create a self-contained executable that bundles
+// LLRT with compiled JavaScript bytecode
+
+import { spawn, ChildProcessWithoutNullStreams } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { test, expect, describe, it } from "vitest";
+import { platform } from "os";
+
+const IS_WINDOWS = platform() === "win32";
+
+describe("executable compilation", () => {
+  it("should compile JavaScript to a self-contained executable", async () => {
+    // Create a temporary test script
+    const testScript = `
+      console.log("LLRT executable test");
+      console.log("Args:", process.argv);
+      process.exit(42);
+    `;
+
+    const tmpDir: string = path.join(process.cwd(), "tmp");
+    try {
+      fs.mkdirSync(tmpDir, { recursive: true });
+    } catch (e) {
+      // Directory might already exist
+    }
+
+    const scriptPath: string = path.join(tmpDir, "exe_test.js");
+    const exePath: string = path.join(tmpDir, "exe_test");
+
+    try {
+      // Clean up existing files if they exist
+      if (fs.existsSync(exePath)) {
+        fs.unlinkSync(exePath);
+      }
+      
+      fs.writeFileSync(scriptPath, testScript);
+
+      // Use cargo run to compile the script (more reliable in test environment)
+      const compileCommand = IS_WINDOWS 
+        ? `cargo run -- compile "${scriptPath}" "${exePath}" --executable`
+        : `cargo run -- compile ${scriptPath} ${exePath} --executable`;
+      
+      console.log(`Running compile command: ${compileCommand}`);
+      
+      // Execute the compilation
+      const compileResult = await new Promise<number>((resolve, reject) => {
+        const compile = spawn("sh", ["-c", compileCommand]);
+        
+        let stdout = "";
+        let stderr = "";
+        
+        compile.stdout.on("data", (data: Buffer) => {
+          stdout += data.toString();
+        });
+        
+        compile.stderr.on("data", (data: Buffer) => {
+          stderr += data.toString();
+        });
+        
+        compile.on("error", (err: Error) => {
+          console.error("Compile error:", err.message);
+          reject(err);
+        });
+        
+        compile.on("close", (code: number | null) => {
+          console.log("Compile stdout:", stdout);
+          console.log("Compile stderr:", stderr);
+          console.log("Compile exit code:", code);
+          resolve(code || 0);
+        });
+      });
+      
+      expect(compileResult).toBe(0);
+      expect(fs.existsSync(exePath)).toBe(true);
+      
+      // Check executable permissions on non-Windows platforms
+      if (!IS_WINDOWS) {
+        const stats = fs.statSync(exePath);
+        // Just verify it's a file and is not empty
+        expect(stats.isFile()).toBe(true);
+        expect(stats.size).toBeGreaterThan(0);
+      }
+      
+      // Run the executable
+      const execResult = await new Promise<{code: number | null, stdout: string}>((resolve, reject) => {
+        const exe = spawn(exePath);
+        let stdout = "";
+        let stderr = "";
+        
+        exe.stdout.on("data", (data: Buffer) => {
+          stdout += data.toString();
+        });
+        
+        exe.stderr.on("data", (data: Buffer) => {
+          stderr += data.toString();
+        });
+        
+        exe.on("error", (err: Error) => {
+          console.error("Execute error:", err.message);
+          reject(err);
+        });
+        
+        exe.on("close", (code: number | null) => {
+          console.log("Execute stdout:", stdout);
+          console.log("Execute stderr:", stderr);
+          console.log("Execute exit code:", code);
+          resolve({code, stdout});
+        });
+      });
+      
+      // Verify exit code and output
+      expect(execResult.code).toBe(42);
+      expect(execResult.stdout).toContain("LLRT executable test");
+    } finally {
+      // Clean up
+      try {
+        if (fs.existsSync(scriptPath)) fs.unlinkSync(scriptPath);
+        if (fs.existsSync(exePath)) fs.unlinkSync(exePath);
+        fs.rmdirSync(tmpDir, { recursive: true });
+      } catch (e) {
+        console.warn("Cleanup failed:", e);
+      }
+    }
+  }, { timeout: 60000 }); // Increase timeout to 60 seconds
+}); 


### PR DESCRIPTION
<!--  **Please post the link to the resolved issue** -->

Fixes: #787

### Description of changes

This introduces support for generating self-contained executables by passing the `--executable` option to `llrt compile`, enabling embedding of bytecode along with the runtime for easier distribution (ex. CLI tools). 

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._