### PR TITLE
fix(fetch): improve compliance with Fetch Standard

### DIFF
--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -122,9 +122,14 @@ impl Headers {
         }
     }
 
-    pub fn delete(&mut self, key: String) {
-        let key = key.to_lowercase().into();
+    pub fn delete<'js>(&mut self, ctx: Ctx<'js>, key: String) -> Result<()> {
+        let key: ImmutableString = key.to_lowercase().into();
+        if !is_http_header_name(&key) {
+            return Err(Exception::throw_type(&ctx, "Invalid key"));
+        }
+
         self.headers.retain(|(k, _)| k != &key);
+        Ok(())
     }
 
     pub fn keys(&self) -> Vec<&str> {

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -197,6 +197,10 @@ impl Headers {
         let mut vec = Vec::new();
         for entry in array.into_iter().flatten() {
             if let Some(array_entry) = entry.as_array() {
+                if array_entry.clone().into_iter().flatten().count() % 2 != 0 {
+                    return Err(Exception::throw_type(ctx, "Header arrays are not paired"));
+                }
+
                 let key = array_entry.get::<String>(0)?.to_lowercase();
                 let raw_value = array_entry.get::<Value>(1)?;
                 let value: ImmutableString = coerce_to_string(ctx, raw_value)?.into();

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -72,7 +72,7 @@ impl Headers {
             new_value.push_str(&value);
             *existing_value = new_value.into();
         } else {
-            self.headers.push((key, value.into()));
+            self.headers.push((key, value));
         }
         Ok(())
     }

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -66,6 +66,10 @@ impl Headers {
 
     pub fn get<'js>(&self, ctx: Ctx<'js>, key: String) -> Result<Value<'js>> {
         let key: ImmutableString = key.to_lowercase().into();
+        if !is_http_header_name(&key) {
+            return Err(Exception::throw_type(&ctx, "Invalid key"));
+        }
+
         if key.as_ref() == HEADERS_KEY_SET_COOKIE {
             let result: Vec<&str> = self
                 .headers

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -337,11 +337,25 @@ mod tests {
             crate::init(&ctx).unwrap();
             Box::pin(async move {
                 let mut headers = Headers::new(ctx.clone(), Opt(None)).unwrap();
-                headers.set("Content-Type".into(), "application/json".into());
-                headers.append("set-cookie".into(), "cookie1=value1".into());
-                headers.append("set-cookie".into(), "cookie2=value2".into());
-                headers.append("Accept-Encoding".into(), "deflate".into());
-                headers.append("Accept-Encoding".into(), "gzip".into());
+                headers
+                    .set(
+                        ctx.clone(),
+                        "Content-Type".into(),
+                        "application/json".into(),
+                    )
+                    .unwrap();
+                headers
+                    .append(ctx.clone(), "set-cookie".into(), "cookie1=value1".into())
+                    .unwrap();
+                headers
+                    .append(ctx.clone(), "set-cookie".into(), "cookie2=value2".into())
+                    .unwrap();
+                headers
+                    .append(ctx.clone(), "Accept-Encoding".into(), "deflate".into())
+                    .unwrap();
+                headers
+                    .append(ctx.clone(), "Accept-Encoding".into(), "gzip".into())
+                    .unwrap();
 
                 assert_eq!(
                     headers

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -228,7 +228,7 @@ impl Headers {
         ctx: &Ctx<'js>,
         array: Array<'js>,
     ) -> Result<Vec<(ImmutableString, ImmutableString)>> {
-        let mut vec = Vec::new();
+        let mut vec: Vec<(ImmutableString, ImmutableString)> = Vec::new();
 
         for entry in array.into_iter().flatten() {
             if let Some(array_entry) = entry.as_array() {
@@ -268,6 +268,9 @@ impl Headers {
                 }
             }
         }
+
+        vec.sort_by(|a, b| a.0.cmp(&b.0));
+
         Ok(vec)
     }
 }

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -8,8 +8,8 @@ use llrt_utils::{
     object::map_to_entries,
 };
 use rquickjs::{
-    atom::PredefinedAtom, methods, prelude::Opt, Array, Coerced, Ctx, FromJs, Function, IntoJs,
-    Null, Object, Result, Value,
+    atom::PredefinedAtom, methods, prelude::Opt, Array, Coerced, Ctx, Exception, FromJs, Function,
+    IntoJs, Null, Object, Result, Value,
 };
 
 const HEADERS_KEY_COOKIE: &str = "cookie";
@@ -33,6 +33,8 @@ impl Headers {
                 let array = unsafe { init.into_array().unwrap_unchecked() };
                 let headers = Self::array_to_headers(array)?;
                 return Ok(Self { headers });
+            } else if init.is_null() {
+                return Err(Exception::throw_type(&ctx, "Invalid argument"));
             } else if init.is_object() {
                 return Self::from_value(&ctx, init);
             }

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -33,7 +33,7 @@ impl Headers {
                 let array = unsafe { init.into_array().unwrap_unchecked() };
                 let headers = Self::array_to_headers(array)?;
                 return Ok(Self { headers });
-            } else if init.is_null() {
+            } else if init.is_null() || init.is_number() {
                 return Err(Exception::throw_type(&ctx, "Invalid argument"));
             } else if init.is_object() {
                 return Self::from_value(&ctx, init);

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -102,9 +102,13 @@ impl Headers {
             .collect()
     }
 
-    pub fn has(&self, key: String) -> bool {
-        let key = key.to_lowercase().into();
-        self.headers.iter().any(|(k, _)| k == &key)
+    pub fn has<'js>(&self, ctx: Ctx<'js>, key: String) -> Result<bool> {
+        let key: ImmutableString = key.to_lowercase().into();
+        if !is_http_header_name(&key) {
+            return Err(Exception::throw_type(&ctx, "Invalid key"));
+        }
+
+        Ok(self.headers.iter().any(|(k, _)| k == &key))
     }
 
     pub fn set(&mut self, key: String, value: String) {

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -191,7 +191,7 @@ fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
 fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Create headers giving bad header value as init argument] assert_throws_js: function "function() { new Headers([["name", "invalidValueĀ"]]); }" did not throw
+Error: [Check headers get with an invalid name invalidĀ] assert_throws_js: function "function() { headers.get(name); }" did not throw
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -191,7 +191,7 @@ fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
 fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Check headers set with an invalid name invalidĀ] assert_throws_js: function "function() { headers.set(name, "Value1"); }" did not throw
+Error: [Check headers append with an invalid name invalidĀ] assert_throws_js: function "function() { headers.append("invalidĀ", "Value1"); }" did not throw
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -191,7 +191,7 @@ fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
 fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Create headers giving an array having one string as init argument] assert_throws_js: function "function() { new Headers([["name"]]); }" did not throw
+Error: [Create headers giving bad header name as init argument] assert_throws_js: function "function() { new Headers([["invalidĀ", "Value1"]]); }" did not throw
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -191,7 +191,7 @@ fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
 fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Check headers delete with an invalid name invalidĀ] assert_throws_js: function "function() { headers.delete(name); }" did not throw
+Error: [Check headers has with an invalid name invalidĀ] assert_throws_js: function "function() { headers.has(name); }" did not throw
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -182,13 +182,10 @@ Error: [Request: overriding explicit Content-Type] assert_equals: expected "test
 
 🧪/wpt/fetch.api.headers.test.js 
 fetch/api/headers > should pass header-setcookie.any.js tests
-Error: [Headers iterator preserves per header ordering, but sorts keys alphabetically] assert_array_equals: expected property 0 to be "a-cool-header" but got "xylophone-header" (expected array ["a-cool-header", "4, 6"] got ["xylophone-header", "1"])
+Error: [Headers iterator is correctly updated with set-cookie changes] assert_array_equals: expected property 0 to be "set-cookie" but got "x-header" (expected array ["set-cookie", "a=b"] got ["x-header", "test"])
 
 fetch/api/headers > should pass headers-basic.any.js tests
 Error: [Create headers with existing headers with custom iterator] assert_equals: expected (string) "test" but got (object) null
-
-fetch/api/headers > should pass headers-combine.any.js tests
-Error: [Iterate combined values in sorted order] assert_array_equals: expected property 0 to be "1" but got "2" (expected array ["1", "b"] got ["2", "a, b"])
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -191,7 +191,7 @@ fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
 fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Create headers giving bad header name as init argument] assert_throws_js: function "function() { new Headers([["invalidĀ", "Value1"]]); }" did not throw
+Error: [Create headers giving bad header value as init argument] assert_throws_js: function "function() { new Headers([["name", "invalidValueĀ"]]); }" did not throw
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -185,7 +185,7 @@ fetch/api/headers > should pass header-setcookie.any.js tests
 Error: [Headers iterator does not special case set-cookie2 headers] assert_equals: Array length is not equal expected 1 but got 2
 
 fetch/api/headers > should pass headers-basic.any.js tests
-Error: [Create headers with null should throw] assert_throws_js: function "function() { new Headers(parameter) }" did not throw
+Error: [Create headers with 1 should throw] assert_throws_js: function "function() { new Headers(parameter) }" did not throw
 
 fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
@@ -200,9 +200,7 @@ fetch/api/headers > should pass headers-normalize.any.js tests
 Error: [Create headers with not normalized values] assert_equals: name: name1 has normalized value: space expected "space" but got " space "
 
 fetch/api/headers > should pass headers-record.any.js tests
-Error: [Passing null to Headers constructor] assert_throws_js: function "function() {
-    var h = new Headers(null);
-  }" did not throw
+Error: [Basic operation with one property] assert_equals: expected 4 but got 3
 
 
 🧪/wpt/fetch.api.request.test.js 

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -185,7 +185,7 @@ fetch/api/headers > should pass header-setcookie.any.js tests
 Error: [Headers iterator does not special case set-cookie2 headers] assert_equals: Array length is not equal expected 1 but got 2
 
 fetch/api/headers > should pass headers-basic.any.js tests
-Error: [Create headers with 1 should throw] assert_throws_js: function "function() { new Headers(parameter) }" did not throw
+Error: [Create headers with sequence] Error converting from js 'null' into type 'string'
 
 fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -185,13 +185,13 @@ fetch/api/headers > should pass header-setcookie.any.js tests
 Error: [Headers iterator does not special case set-cookie2 headers] assert_equals: Array length is not equal expected 1 but got 2
 
 fetch/api/headers > should pass headers-basic.any.js tests
-Error: [Create headers with sequence] Error converting from js 'null' into type 'string'
+Error: [Create headers with existing headers with custom iterator] assert_equals: expected (string) "test" but got (object) null
 
 fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
 fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Create headers giving an array having three strings as init argument] assert_throws_js: function "function() { new Headers([["invalid", "invalidValue1", "invalidValue2"]]); }" did not throw
+Error: [Create headers giving an array having one string as init argument] assert_throws_js: function "function() { new Headers([["name"]]); }" did not throw
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -191,7 +191,7 @@ fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
 fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Check headers has with an invalid name invalidĀ] assert_throws_js: function "function() { headers.has(name); }" did not throw
+Error: [Check headers set with an invalid name invalidĀ] assert_throws_js: function "function() { headers.set(name, "Value1"); }" did not throw
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -182,13 +182,13 @@ Error: [Request: overriding explicit Content-Type] assert_equals: expected "test
 
 🧪/wpt/fetch.api.headers.test.js 
 fetch/api/headers > should pass header-setcookie.any.js tests
-Error: [Headers iterator does not special case set-cookie2 headers] assert_equals: Array length is not equal expected 1 but got 2
+Error: [Headers iterator preserves per header ordering, but sorts keys alphabetically] assert_array_equals: expected property 0 to be "a-cool-header" but got "xylophone-header" (expected array ["a-cool-header", "4, 6"] got ["xylophone-header", "1"])
 
 fetch/api/headers > should pass headers-basic.any.js tests
 Error: [Create headers with existing headers with custom iterator] assert_equals: expected (string) "test" but got (object) null
 
 fetch/api/headers > should pass headers-combine.any.js tests
-Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
+Error: [Iterate combined values in sorted order] assert_array_equals: expected property 0 to be "1" but got "2" (expected array ["1", "b"] got ["2", "a, b"])
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -191,7 +191,7 @@ fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
 fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Check headers get with an invalid name invalidĀ] assert_throws_js: function "function() { headers.get(name); }" did not throw
+Error: [Check headers delete with an invalid name invalidĀ] assert_throws_js: function "function() { headers.delete(name); }" did not throw
 
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -190,9 +190,6 @@ Error: [Create headers with existing headers with custom iterator] assert_equals
 fetch/api/headers > should pass headers-combine.any.js tests
 Error: [Create headers using same name for different values] assert_equals: expected "doubleValue1, doubleValue2" but got "doubleValue1"
 
-fetch/api/headers > should pass headers-errors.any.js tests
-Error: [Check headers append with an invalid name invalidĀ] assert_throws_js: function "function() { headers.append("invalidĀ", "Value1"); }" did not throw
-
 fetch/api/headers > should pass headers-no-cors.any.js tests
 Error: ["no-cors" Headers object cannot have accept set to sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, , sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss] assert_equals: 1 expected "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss" but got "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss, "
 


### PR DESCRIPTION
### Description of changes

The following tests have been modified to pass:

 - fetch/api/headers > should pass headers-combine.any.js tests
 - fetch/api/headers > should pass headers-errors.any.js tests

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
