### PR TITLE
chore: crate organization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,6 @@ name = "llrt_test"
 version = "0.5.1-beta"
 dependencies = [
  "nanoid",
- "rand 0.8.5",
  "rquickjs",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,7 +1757,6 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "pkcs8",
  "rand 0.8.5",
  "ring",
  "rquickjs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes",
  "cipher",
  "ctr",
  "ghash",
@@ -62,19 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,15 +74,6 @@ name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
 
 [[package]]
 name = "allocator-api2"
@@ -281,7 +258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
- "alloc-stdlib",
  "brotli-decompressor",
 ]
 
@@ -292,7 +268,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -505,15 +480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,8 +526,6 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -643,7 +607,6 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "derive_more",
  "document-features",
  "mio",
  "parking_lot",
@@ -687,7 +650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -752,7 +714,6 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "der_derive",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -762,27 +723,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
- "proc-macro2 1.0.94",
- "quote 1.0.40",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "convert_case 0.7.1",
  "proc-macro2 1.0.94",
  "quote 1.0.40",
  "syn 2.0.100",
@@ -854,7 +794,6 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
 ]
 
 [[package]]
@@ -876,7 +815,6 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1682,7 +1620,6 @@ dependencies = [
  "llrt_test",
  "llrt_utils",
  "rquickjs",
- "tokio",
 ]
 
 [[package]]
@@ -1759,8 +1696,6 @@ dependencies = [
  "home",
  "http-body-util",
  "hyper",
- "hyper-rustls",
- "hyper-util",
  "itoa",
  "jwalk",
  "libc",
@@ -1828,7 +1763,6 @@ dependencies = [
  "rquickjs",
  "rsa",
  "spki",
- "tokio",
  "uuid",
  "uuid-simd",
  "x25519-dalek",
@@ -1848,8 +1782,6 @@ dependencies = [
 name = "llrt_dns_cache"
 version = "0.5.1-beta"
 dependencies = [
- "hyper",
- "hyper-rustls",
  "hyper-util",
  "llrt_context",
  "llrt_utils",
@@ -2073,7 +2005,6 @@ dependencies = [
  "llrt_test",
  "llrt_utils",
  "rquickjs",
- "tokio",
 ]
 
 [[package]]
@@ -2198,7 +2129,6 @@ dependencies = [
  "llrt_test",
  "llrt_utils",
  "rquickjs",
- "tokio",
 ]
 
 [[package]]
@@ -2441,7 +2371,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "rand_core 0.6.4",
  "sha2",
 ]
 
@@ -2472,15 +2401,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -2581,34 +2501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,7 +2518,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2690,10 +2582,8 @@ version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
 dependencies = [
- "ahash",
  "equivalent",
  "hashbrown",
- "parking_lot",
 ]
 
 [[package]]
@@ -2739,7 +2629,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2919,7 +2809,7 @@ name = "rquickjs-macro"
 version = "0.9.0"
 source = "git+https://github.com/DelSkayn/rquickjs.git#3394aa3128dc2d8e73c6fc8bb064a9d48c0680ff"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "fnv",
  "ident_case",
  "indexmap",
@@ -3153,9 +3043,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3374,7 +3264,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3447,19 +3336,7 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
-dependencies = [
- "proc-macro2 1.0.94",
- "quote 1.0.40",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -3469,7 +3346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
- "valuable",
 ]
 
 [[package]]
@@ -3573,12 +3449,6 @@ dependencies = [
  "uuid",
  "vsimd",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-trait"
@@ -3700,16 +3570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4048,7 +3908,6 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
- "serde",
  "zeroize",
 ]
 
@@ -4078,31 +3937,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.24",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2 1.0.94",
- "quote 1.0.40",
- "syn 2.0.100",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -252,4 +252,12 @@ deploy:
 check:
 	cargo clippy --all-targets --all-features -- -D warnings
 
-.PHONY: libs check libs-arm64 libs-x64 toolchain clean-js release-linux release-darwin release-windows lambda stdlib stdlib-x64 stdlib-arm64 test test-ci run js run-release build release clean flame deploy
+check-crates:
+	cargo metadata --no-deps --format-version 1 --quiet | \
+	jq -r '.packages[] | select(.manifest_path | contains("modules/")) | .name' | \
+	while read crate; do \
+	  echo "Checking crate: $$crate"; \
+	  cargo check -p "$$crate"; \
+	done
+
+.PHONY: libs check check-crates libs-arm64 libs-x64 toolchain clean-js release-linux release-darwin release-windows lambda stdlib stdlib-x64 stdlib-arm64 test test-ci run js run-release build release clean flame deploy

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,6 @@ fix:
 	cargo fmt
 
 bloat: js
-	cargo build --profile=flame --target $(CURRENT_TARGET)
 	cargo bloat --profile=flame --crates
 
 run: export AWS_LAMBDA_FUNCTION_NAME = n/a

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ fix:
 	cargo fmt
 
 bloat: js
+	cargo build --profile=flame --target $(CURRENT_TARGET)
 	cargo bloat --profile=flame --crates
 
 run: export AWS_LAMBDA_FUNCTION_NAME = n/a

--- a/libs/llrt_build/Cargo.toml
+++ b/libs/llrt_build/Cargo.toml
@@ -11,4 +11,4 @@ name = "llrt_build"
 path = "src/lib.rs"
 
 [dependencies]
-rustc_version = "0.4"
+rustc_version = { version = "0.4", default-features = false }

--- a/libs/llrt_compression/Cargo.toml
+++ b/libs/llrt_compression/Cargo.toml
@@ -26,7 +26,7 @@ zstd-c = ["zstd"]
 zstd-rust = ["zstd"] # No pure rust implementation exists
 
 [dependencies]
-brotlic = { version = "0.8", optional = true }
-brotli = { version = "8", optional = true }
+brotlic = { version = "0.8", default-features = false, optional = true }
+brotli = { version = "8", default-features = false, optional = true }
 flate2 = { version = "1", default-features = false, optional = true }
 zstd = { version = "0.13", default-features = false, optional = true }

--- a/libs/llrt_context/Cargo.toml
+++ b/libs/llrt_context/Cargo.toml
@@ -12,11 +12,10 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
 ], default-features = false }
 llrt_utils = { version = "0.5.1-beta", path = "../llrt_utils", default-features = false }
 tokio = { version = "1", features = ["sync"], default-features = false }
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 llrt_test = { version = "0.5.1-beta", path = "../llrt_test" }
-tokio = { version = "1", features = ["full"] }
 
 [build-dependencies]
 llrt_build = { version = "0.5.1-beta", path = "../llrt_build" }

--- a/libs/llrt_dns_cache/Cargo.toml
+++ b/libs/llrt_dns_cache/Cargo.toml
@@ -12,12 +12,17 @@ name = "llrt_dns_cache"
 path = "src/lib.rs"
 
 [dependencies]
-hyper-util = { version = "0.1", default-features = false }
+hyper-util = { version = "0.1", features = [
+  "client",
+  "client-legacy",
+], default-features = false }
 llrt_context = { version = "0.5.1-beta", path = "../llrt_context" }
 llrt_utils = { version = "0.5.1-beta", path = "../llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
-tokio = {version = "1", default-features = false }
+tokio = {version = "1", features = [
+  "net",
+], default-features = false }
 tower-service = { version = "0.3", default-features = false }
 quick_cache = { version = "0.6", default-features = false }

--- a/libs/llrt_dns_cache/Cargo.toml
+++ b/libs/llrt_dns_cache/Cargo.toml
@@ -12,18 +12,12 @@ name = "llrt_dns_cache"
 path = "src/lib.rs"
 
 [dependencies]
-hyper = { version = "1", features = ["client"] }
-hyper-rustls = { version = "0.27", default-features = false, features = [
-  "webpki-roots",
-  "webpki-tokio",
-  "ring",
-] }
-hyper-util = "0.1"
+hyper-util = { version = "0.1", default-features = false }
 llrt_context = { version = "0.5.1-beta", path = "../llrt_context" }
 llrt_utils = { version = "0.5.1-beta", path = "../llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
-tokio = "1"
-tower-service = "0.3.3"
-quick_cache = "0.6.12"
+tokio = {version = "1", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+quick_cache = { version = "0.6", default-features = false }

--- a/libs/llrt_encoding/Cargo.toml
+++ b/libs/llrt_encoding/Cargo.toml
@@ -7,10 +7,16 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/llrt"
 
 [dependencies]
-base64-simd = "0.8"
-hex-simd = "0.8"
-phf = { version = "0.11", features = ["macros"] }
-memchr = "2"
+base64-simd = { version = "0.8", features = [
+  "alloc",
+], default-features = false }
+hex-simd = { version = "0.8", features = [
+  "alloc",
+], default-features = false }
+phf = { version = "0.11", features = [
+  "macros",
+], default-features = false }
+memchr = { version = "2", default-features = false }
 
 [build-dependencies]
 llrt_build = { version = "0.5.1-beta", path = "../llrt_build" }

--- a/libs/llrt_json/Cargo.toml
+++ b/libs/llrt_json/Cargo.toml
@@ -11,18 +11,18 @@ name = "llrt_json"
 path = "src/lib.rs"
 
 [dependencies]
-itoa = "1"
+itoa = { version = "1", default-features = false }
 llrt_utils = { version = "0.5.1-beta", path = "../llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-ryu = "1"
-simd-json = { version = "0.15", default-features = false, features = [
+ryu = { version = "1", default-features = false }
+simd-json = { version = "0.15", features = [
   "big-int-as-float",
-] }
+], default-features = false }
 
 [dev-dependencies]
-criterion = "0.6"
+criterion = { version = "0.6", default-features = false }
 llrt_test = { version = "0.5.1-beta", path = "../llrt_test" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["test-util"], default-features = false }
 
 [build-dependencies]
 llrt_build = { version = "0.5.1-beta", path = "../llrt_build" }

--- a/libs/llrt_logging/Cargo.toml
+++ b/libs/llrt_logging/Cargo.toml
@@ -11,7 +11,7 @@ name = "llrt_logging"
 path = "src/lib.rs"
 
 [dependencies]
-itoa = "1"
+itoa = { version = "1", default-features = false }
 llrt_context = { version = "0.5.1-beta", path = "../llrt_context" }
 llrt_encoding = { version = "0.5.1-beta", path = "../llrt_encoding" }
 llrt_json = { version = "0.5.1-beta", path = "../llrt_json" }
@@ -20,4 +20,4 @@ llrt_utils = { version = "0.5.1-beta", path = "../llrt_utils", default-features 
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
-ryu = "1"
+ryu = { version = "1", default-features = false }

--- a/libs/llrt_numbers/Cargo.toml
+++ b/libs/llrt_numbers/Cargo.toml
@@ -14,12 +14,15 @@ path = "src/lib.rs"
 itoa = { version = "1", default-features = false }
 llrt_utils = { version = "0.5.1-beta", path = "../llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-rand = { version = "0.8", default-features = false }
 ryu = { version = "1", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.6", default-features = false }
 llrt_test = { version = "0.5.1-beta", path = "../llrt_test" }
+rand = { version = "0.8", features = [
+  "alloc",
+  "getrandom",
+], default-features = false }
 
 [[bench]]
 name = "numbers"

--- a/libs/llrt_numbers/Cargo.toml
+++ b/libs/llrt_numbers/Cargo.toml
@@ -11,14 +11,14 @@ name = "llrt_numbers"
 path = "src/lib.rs"
 
 [dependencies]
-itoa = "1"
+itoa = { version = "1", default-features = false }
 llrt_utils = { version = "0.5.1-beta", path = "../llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-rand = "0.8"
-ryu = "1"
+rand = { version = "0.8", default-features = false }
+ryu = { version = "1", default-features = false }
 
 [dev-dependencies]
-criterion = "0.6"
+criterion = { version = "0.6", default-features = false }
 llrt_test = { version = "0.5.1-beta", path = "../llrt_test" }
 
 [[bench]]

--- a/libs/llrt_test/Cargo.toml
+++ b/libs/llrt_test/Cargo.toml
@@ -17,7 +17,6 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
   "loader",
   "parallel",
 ], default-features = false }
-rand = { version = "0.8", default-features = false }
 tokio = { version = "1", features = [
   "fs"
 ], default-features = false }

--- a/libs/llrt_test/Cargo.toml
+++ b/libs/llrt_test/Cargo.toml
@@ -11,11 +11,13 @@ name = "llrt_test"
 path = "src/lib.rs"
 
 [dependencies]
-nanoid = "0.4.0"
+nanoid = { version = "0.4", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "futures",
-  "parallel",
   "loader",
+  "parallel",
 ], default-features = false }
-rand = "0.8.5"
-tokio = { version = "1", features = ["full"] }
+rand = { version = "0.8", default-features = false }
+tokio = { version = "1", features = [
+  "fs"
+], default-features = false }

--- a/libs/llrt_utils/Cargo.toml
+++ b/libs/llrt_utils/Cargo.toml
@@ -18,12 +18,13 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
   "array-buffer",
   "macro",
 ], default-features = false }
-tokio = { version = "1", features = ["sync"] }
-tracing = "0.1"
+tokio = { version = "1", features = [
+  "sync",
+], default-features = false }
+tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 llrt_test = { version = "0.5.1-beta", path = "../llrt_test" }
-tokio = { version = "1", features = ["full"] }
 
 [build-dependencies]
 llrt_build = { version = "0.5.1-beta", path = "../llrt_build" }

--- a/llrt/Cargo.toml
+++ b/llrt/Cargo.toml
@@ -13,16 +13,29 @@ uncompressed = ["llrt_core/uncompressed"]
 bindgen = ["llrt_core/bindgen"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-constcat = "0.6"
-crossterm = { version = "0.29" }
+chrono = { version = "0.4", features = [
+  "std"
+], default-features = false }
+constcat = { version = "0.6", default-features = false }
+crossterm = { version = "0.29", features = [
+  "events",
+  "windows",
+], default-features = false }
 llrt_core = { path = "../llrt_core" }
-tokio = { version = "1", features = ["full"] }
-tracing = { version = "0.1", features = ["log"] }
-tracing-core = "0.1"
+tokio = { version = "1", features = [
+  "macros",
+  "rt-multi-thread",
+], default-features = false }
+tracing = { version = "0.1", features = [
+  "log"
+], default-features = false }
+tracing-core = { version = "0.1", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-snmalloc-rs = { version = "0.3", features = ["lto"] }
+snmalloc-rs = { version = "0.3", features = [
+  "default",
+  "lto",
+], default-features = false }
 
 [dev-dependencies]
 llrt_test = { version = "0.5.1-beta", path = "../libs/llrt_test" }

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -13,21 +13,15 @@ macro = ["rquickjs/macro"]
 bindgen = ["rquickjs/bindgen"]
 
 [dependencies]
-bytes = "1"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-home = "0.5"
-http-body-util = "0.1"
-hyper = { version = "1", features = ["client", "http1", "http2"] }
-hyper-rustls = { version = "0.27", default-features = false, features = [
-  "http2",
-  "http1",
-  "webpki-roots",
-  "webpki-tokio",
-  "ring",
-] }
-hyper-util = "0.1"
-itoa = "1"
-libc = "0.2"
+bytes = { version = "1", default-features = false }
+chrono = { version = "0.4", features = [
+  "std"
+], default-features = false }
+home = { version = "0.5", default-features = false }
+http-body-util = { version = "0.1", default-features = false }
+hyper = { version = "1", default-features = false }
+itoa = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false }
 llrt_context = { path = "../libs/llrt_context" }
 llrt_encoding = { path = "../libs/llrt_encoding" }
 llrt_json = { path = "../libs/llrt_json" }
@@ -35,55 +29,64 @@ llrt_logging = { path = "../libs/llrt_logging" }
 llrt_modules = { path = "../llrt_modules" }
 llrt_numbers = { path = "../libs/llrt_numbers" }
 llrt_utils = { path = "../libs/llrt_utils", features = ["all"] }
-once_cell = "1"
-phf = "0.11"
-quick-xml = "0.37"
-ring = "0.17"
+once_cell = { version = "1", default-features = false }
+phf = {version = "0.11", default-features = false }
+quick-xml = { version = "0.37", default-features = false }
+ring = { version = "0.17", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "full-async",
   "parallel",
   "rust-alloc",
 ], default-features = false }
-rustls = { version = "0.23", default-features = false, features = [
-  "tls12",
+rustls = { version = "0.23", features = [
   "ring",
-] }
-rustls-pemfile = "2"
-ryu = "1"
-simd-json = { version = "0.15", default-features = false, features = [
-  "big-int-as-float",
-] }
-terminal_size = "0.4"
-tokio = { version = "1", features = ["full"] }
-tracing = { version = "0.1", features = ["log"] }
-url = "=2.5.1"
-uuid = { version = "1", default-features = false, features = [
+  "tls12",
+], default-features = false }
+rustls-pemfile = { version = "2", features = [
+  "std",
+], default-features = false }
+ryu = { version = "1", default-features = false }
+simd-json = { version = "0.15", default-features = false }
+terminal_size = { version = "0.4", default-features = false }
+tokio = { version = "1", features = [
+  "sync",
+  "time",
+], default-features = false }
+tracing = { version = "0.1", features = [
+  "log"
+], default-features = false }
+url = { version = "=2.5.1", default-features = false }
+uuid = { version = "1", features = [
+  "fast-rng",
   "v1",
   "v3",
   "v4",
   "v5",
   "v6",
   "v7",
-  "fast-rng",
-] }
-uuid-simd = "0.8"
-zstd = { version = "0.13", default-features = false, features = [] }
+], default-features = false }
+uuid-simd = { version = "0.8", features = [
+  "uuid",
+], default-features = false }
+zstd = { version = "0.13", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-md-5 = { version = "0.10" }
+md-5 = { version = "0.10", default-features = false }
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-md-5 = { version = "0.10", features = ["asm"] }
+md-5 = { version = "0.10", features = [
+  "asm",
+], default-features = false }
 
 [build-dependencies]
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "full-async",
   "rust-alloc",
 ], default-features = false }
-phf_codegen = "0.11"
-jwalk = "0.8"
-nanoid = "0.4"
+phf_codegen = { version = "0.11", default-features = false }
+jwalk = { version = "0.8", default-features = false }
+nanoid = { version = "0.4", default-features = false }
 llrt_build = { path = "../libs/llrt_build" }
 
 [dev-dependencies]
-wiremock = "0.6"
+wiremock = { version = "0.6", default-features = false }
 llrt_test = { path = "../libs/llrt_test" }

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -29,7 +29,9 @@ llrt_logging = { path = "../libs/llrt_logging" }
 llrt_modules = { path = "../llrt_modules" }
 llrt_numbers = { path = "../libs/llrt_numbers" }
 llrt_utils = { path = "../libs/llrt_utils", features = ["all"] }
-once_cell = { version = "1", default-features = false }
+once_cell = { version = "1", features = [
+  "std",
+], default-features = false }
 phf = {version = "0.11", default-features = false }
 quick-xml = { version = "0.37", default-features = false }
 ring = { version = "0.17", default-features = false }

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -77,7 +77,7 @@ llrt_fetch = { version = "0.5.1-beta", path = "../modules/llrt_fetch", optional 
 llrt_fs = { version = "0.5.1-beta", path = "../modules/llrt_fs", optional = true }
 llrt_navigator = { version = "0.5.1-beta", path = "../modules/llrt_navigator", optional = true }
 llrt_net = { version = "0.5.1-beta", path = "../modules/llrt_net", optional = true }
-llrt_os = { version = "0.5.1-beta", path = "../modules/llrt_os", optional = true }
+llrt_os = { version = "0.5.1-beta", path = "../modules/llrt_os", default-features = false, optional = true }
 llrt_path = { version = "0.5.1-beta", path = "../modules/llrt_path", optional = true }
 llrt_process = { version = "0.5.1-beta", path = "../modules/llrt_process", optional = true }
 llrt_perf_hooks = { version = "0.5.1-beta", path = "../modules/llrt_perf_hooks", optional = true }

--- a/modules/llrt_abort/Cargo.toml
+++ b/modules/llrt_abort/Cargo.toml
@@ -24,8 +24,12 @@ llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-f
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
-tokio = { version = "1", features = ["time"], optional = true }
+tokio = { version = "1", features = [
+  "time",
+], default-features = false, optional = true }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = [
+  "test-util"
+], default-features = false }

--- a/modules/llrt_assert/Cargo.toml
+++ b/modules/llrt_assert/Cargo.toml
@@ -16,4 +16,3 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }

--- a/modules/llrt_buffer/Cargo.toml
+++ b/modules/llrt_buffer/Cargo.toml
@@ -20,4 +20,6 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = [
+  "test-util"
+], default-features = false }

--- a/modules/llrt_child_process/Cargo.toml
+++ b/modules/llrt_child_process/Cargo.toml
@@ -11,18 +11,19 @@ name = "llrt_child_process"
 path = "src/lib.rs"
 
 [dependencies]
-itoa = "1"
+itoa = { version = "1", default-features = false }
 llrt_buffer = { version = "0.5.1-beta", path = "../llrt_buffer" }
 llrt_context = { version = "0.5.1-beta", path = "../../libs/llrt_context" }
 llrt_events = { version = "0.5.1-beta", path = "../llrt_events" }
 llrt_stream = { version = "0.5.1-beta", path = "../llrt_stream" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-tokio = { version = "1", features = ["process"] }
+tokio = { version = "1", features = [
+  "process",
+], default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -45,7 +45,10 @@ llrt_json = { version = "0.5.1-beta", path = "../../libs/llrt_json", optional = 
 once_cell = { version = "1", features = [
   "std",
 ], default-features = false }
-rand = { version = "0.8", default-features = false}
+rand = { version = "0.8", features = [
+  "alloc",
+  "getrandom",
+], default-features = false }
 ring = { version = "0.17", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -42,7 +42,9 @@ llrt_context = { version = "0.5.1-beta", path = "../../libs/llrt_context" }
 llrt_encoding = { version = "0.5.1-beta", path = "../../libs/llrt_encoding" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
 llrt_json = { version = "0.5.1-beta", path = "../../libs/llrt_json", optional = true }
-once_cell = { version = "1", default-features = false }
+once_cell = { version = "1", features = [
+  "std",
+], default-features = false }
 rand = { version = "0.8", default-features = false}
 ring = { version = "0.17", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
@@ -94,10 +96,10 @@ x25519-dalek = { version = "2", features = [
 ], default-features = false, optional = true }
 ecdsa = { version = "0.16", default-features = false, optional = true }
 spki = { version = "0.7", features = [
-  "std",
+  "alloc",
 ], default-features = false, optional = true }
 pkcs8 = { version = "0.10", features = [
-  "std",
+  "alloc",
 ], default-features = false, optional = true }
 der = { version = "0.7", features = [
   "derive",

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -29,7 +29,6 @@ subtle-rs = [
   "x25519-dalek",
   "ecdsa",
   "spki",
-  "pkcs8",
   "der",
   "const-oid",
 ]
@@ -41,7 +40,6 @@ llrt_buffer = { version = "0.5.1-beta", path = "../llrt_buffer" }
 llrt_context = { version = "0.5.1-beta", path = "../../libs/llrt_context" }
 llrt_encoding = { version = "0.5.1-beta", path = "../../libs/llrt_encoding" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
-llrt_json = { version = "0.5.1-beta", path = "../../libs/llrt_json", optional = true }
 once_cell = { version = "1", features = [
   "std",
 ], default-features = false }
@@ -49,7 +47,6 @@ rand = { version = "0.8", features = [
   "std",
   "std_rng",
 ], default-features = false }
-ring = { version = "0.17", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
@@ -60,6 +57,10 @@ uuid = { version = "1", features = [
 uuid-simd = { version = "0.8", features = [
   "uuid",
 ], default-features = false }
+
+# optional
+llrt_json = { version = "0.5.1-beta", path = "../../libs/llrt_json", optional = true }
+ring = { version = "0.17", default-features = false }
 aes = { version = "0.8", optional = true }
 aes-gcm = { version = "0.10", features = [
   "alloc",
@@ -99,9 +100,6 @@ x25519-dalek = { version = "2", features = [
 ], default-features = false, optional = true }
 ecdsa = { version = "0.16", default-features = false, optional = true }
 spki = { version = "0.7", features = [
-  "alloc",
-], default-features = false, optional = true }
-pkcs8 = { version = "0.10", features = [
   "alloc",
 ], default-features = false, optional = true }
 der = { version = "0.7", features = [

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -46,8 +46,8 @@ once_cell = { version = "1", features = [
   "std",
 ], default-features = false }
 rand = { version = "0.8", features = [
-  "alloc",
-  "getrandom",
+  "std",
+  "std_rng",
 ], default-features = false }
 ring = { version = "0.17", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -47,6 +47,7 @@ rand = { version = "0.8", features = [
   "std",
   "std_rng",
 ], default-features = false }
+ring = { version = "0.17", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
@@ -60,7 +61,6 @@ uuid-simd = { version = "0.8", features = [
 
 # optional
 llrt_json = { version = "0.5.1-beta", path = "../../libs/llrt_json", optional = true }
-ring = { version = "0.17", default-features = false }
 aes = { version = "0.8", optional = true }
 aes-gcm = { version = "0.10", features = [
   "alloc",

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -68,7 +68,9 @@ aes-gcm = { version = "0.10", features = [
 aes-kw = { version = "0.2", features = [
   "alloc",
 ], default-features = false, optional = true }
-cbc = { version = "0.1", features = ["std"], optional = true }
+cbc = { version = "0.1", features = [
+  "std"
+], optional = true }
 ctr = { version = "0.9", default-features = false, optional = true }
 rsa = { version = "0.9", features = [
   "std",
@@ -91,7 +93,6 @@ p521 = { version = "0.13", features = [
 ], default-features = false, optional = true }
 elliptic-curve = { version = "0.13", features = [
   "alloc",
-  "arithmetic",
 ], default-features = false, optional = true }
 x25519-dalek = { version = "2", features = [
   "getrandom",

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -35,54 +35,86 @@ subtle-rs = [
 ]
 
 [dependencies]
-crc32c = "0.6"
-crc32fast = "1"
+crc32c = { version = "0.6", default-features = false }
+crc32fast = { version = "1", default-features = false }
 llrt_buffer = { version = "0.5.1-beta", path = "../llrt_buffer" }
 llrt_context = { version = "0.5.1-beta", path = "../../libs/llrt_context" }
 llrt_encoding = { version = "0.5.1-beta", path = "../../libs/llrt_encoding" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
 llrt_json = { version = "0.5.1-beta", path = "../../libs/llrt_json", optional = true }
-once_cell = "1"
-rand = "0.8"
-ring = { version = "0.17", features = ["std"] }
+once_cell = { version = "1", default-features = false }
+rand = { version = "0.8", default-features = false}
+ring = { version = "0.17", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
-uuid = { version = "1", default-features = false, features = [
-  "v4",
+uuid = { version = "1", features = [
   "fast-rng",
-] }
-uuid-simd = "0.8"
+  "v4",
+], default-features = false }
+uuid-simd = { version = "0.8", features = [
+  "uuid",
+], default-features = false }
 aes = { version = "0.8", optional = true }
-aes-gcm = { version = "0.10", optional = true }
-aes-kw = { version = "0.2", features = ["alloc"], optional = true }
+aes-gcm = { version = "0.10", features = [
+  "alloc",
+], default-features = false, optional = true }
+aes-kw = { version = "0.2", features = [
+  "alloc",
+], default-features = false, optional = true }
 cbc = { version = "0.1", features = ["std"], optional = true }
-ctr = { version = "0.9", optional = true }
+ctr = { version = "0.9", default-features = false, optional = true }
 rsa = { version = "0.9", features = [
   "std",
   "sha2",
 ], default-features = false, optional = true }
-p256 = { version = "0.13", optional = true }
-p384 = { version = "0.13", optional = true }
-p521 = { version = "0.13", optional = true }
-elliptic-curve = { version = "0.13", optional = true }
+p256 = { version = "0.13", features = [
+  "ecdh",
+  "ecdsa",
+  "pkcs8",
+], default-features = false, optional = true }
+p384 = { version = "0.13", features = [
+  "ecdh",
+  "ecdsa",
+  "pkcs8",
+], default-features = false, optional = true }
+p521 = { version = "0.13", features = [
+  "ecdh",
+  "ecdsa",
+  "pkcs8",
+], default-features = false, optional = true }
+elliptic-curve = { version = "0.13", features = [
+  "alloc",
+  "arithmetic",
+], default-features = false, optional = true }
 x25519-dalek = { version = "2", features = [
+  "getrandom",
   "static_secrets",
   "zeroize",
-  "getrandom",
-], optional = true }
-ecdsa = { version = "0.16", optional = true }
-spki = { version = "0.7", features = ["std"], optional = true }
-pkcs8 = { version = "0.10", features = ["std"], optional = true }
-der = { version = "0.7", features = ["derive"], optional = true }
-const-oid = { version = "0.9", features = ["db"], optional = true }
+], default-features = false, optional = true }
+ecdsa = { version = "0.16", default-features = false, optional = true }
+spki = { version = "0.7", features = [
+  "std",
+], default-features = false, optional = true }
+pkcs8 = { version = "0.10", features = [
+  "std",
+], default-features = false, optional = true }
+der = { version = "0.7", features = [
+  "derive",
+], default-features = false, optional = true }
+const-oid = { version = "0.9", features = [
+  "db",
+], default-features = false, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-memchr = "2"
-md-5 = "0.10"
+memchr = { version = "2", default-features = false }
+md-5 = { version = "0.10", default-features = false }
+
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-md-5 = { version = "0.10", features = ["asm"] }
+md-5 = { version = "0.10", features = [
+  "asm",
+], default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
+

--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -19,8 +19,7 @@ use llrt_utils::{
     result::ResultExt,
 };
 use once_cell::sync::Lazy;
-use rand::prelude::ThreadRng;
-use rand::Rng;
+use rand::{prelude::ThreadRng, Rng};
 use ring::rand::{SecureRandom, SystemRandom};
 #[cfg(feature = "subtle-rs")]
 use rquickjs::prelude::Async;

--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -30,12 +30,11 @@ use rquickjs::{
     prelude::{Func, Rest},
     Class, Ctx, Error, Exception, Function, IntoJs, Null, Object, Result, Value,
 };
-use subtle::SubtleCrypto;
 #[cfg(feature = "subtle-rs")]
 use subtle::{
     subtle_decrypt, subtle_derive_bits, subtle_derive_key, subtle_digest, subtle_encrypt,
     subtle_export_key, subtle_generate_key, subtle_import_key, subtle_sign, subtle_unwrap_key,
-    subtle_verify, subtle_wrap_key, CryptoKey,
+    subtle_verify, subtle_wrap_key, CryptoKey, SubtleCrypto,
 };
 use uuid::Uuid;
 use uuid_simd::UuidExt;

--- a/modules/llrt_crypto/src/md5_hash.rs
+++ b/modules/llrt_crypto/src/md5_hash.rs
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use md5::{Digest as Md5Digest, Md5 as MdHasher};
-
 use llrt_utils::bytes::{bytes_to_typed_array, ObjectBytes};
+use md5::{Digest as Md5Digest, Md5 as MdHasher};
 use rquickjs::{function::Opt, prelude::This, Class, Ctx, Result, Value};
 
 use super::encoded_bytes;

--- a/modules/llrt_crypto/src/subtle/derive.rs
+++ b/modules/llrt_crypto/src/subtle/derive.rs
@@ -3,9 +3,14 @@
 use std::num::NonZeroU32;
 
 use llrt_utils::result::ResultExt;
-use p256::pkcs8::DecodePrivateKey;
 use ring::{hkdf, pbkdf2};
 use rquickjs::{Array, ArrayBuffer, Class, Ctx, Exception, Result, Value};
+use rsa::pkcs8::DecodePrivateKey;
+
+use crate::{
+    sha_hash::ShaAlgorithm,
+    subtle::{CryptoKey, EllipticCurve},
+};
 
 use super::{
     algorithm_mismatch_error, algorithm_not_supported_error,
@@ -14,11 +19,6 @@ use super::{
     key_algorithm::{
         EcAlgorithm, KeyAlgorithm, KeyAlgorithmMode, KeyAlgorithmWithUsages, KeyDerivation,
     },
-};
-
-use crate::{
-    sha_hash::ShaAlgorithm,
-    subtle::{CryptoKey, EllipticCurve},
 };
 
 struct HkdfOutput(usize);

--- a/modules/llrt_crypto/src/subtle/derive_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/derive_algorithm.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 use std::rc::Rc;
 
 use llrt_utils::object::ObjectExt;

--- a/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt};
 use rquickjs::{Ctx, Exception, FromJs, Result, Value};
 

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 use der::{
     asn1::{self, BitString},
     Decode, Encode, SecretDocument,
@@ -11,11 +10,12 @@ use elliptic_curve::{
 };
 use llrt_encoding::bytes_to_b64_url_safe_string;
 use llrt_utils::result::ResultExt;
-use pkcs8::{AssociatedOid, DecodePrivateKey, PrivateKeyInfo};
-
-use pkcs8::EncodePrivateKey;
 use rquickjs::{ArrayBuffer, Class, Ctx, Exception, Object, Result};
-use rsa::{pkcs1::DecodeRsaPrivateKey, RsaPrivateKey};
+use rsa::{
+    pkcs1::DecodeRsaPrivateKey,
+    pkcs8::{AssociatedOid, DecodePrivateKey, EncodePrivateKey, PrivateKeyInfo},
+    RsaPrivateKey,
+};
 use spki::{AlgorithmIdentifier, AlgorithmIdentifierOwned, SubjectPublicKeyInfo};
 
 use crate::subtle::CryptoKey;

--- a/modules/llrt_crypto/src/subtle/generate_key.rs
+++ b/modules/llrt_crypto/src/subtle/generate_key.rs
@@ -1,17 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 use llrt_utils::result::ResultExt;
-use p256::pkcs8::DecodePrivateKey;
-use pkcs8::EncodePrivateKey;
 use ring::{
     rand::SecureRandom,
     signature::{EcdsaKeyPair, Ed25519KeyPair, KeyPair},
 };
-use rquickjs::Class;
-use rquickjs::{object::Property, Array, Ctx, Exception, Object, Result, Value};
+use rquickjs::{object::Property, Array, Class, Ctx, Exception, Object, Result, Value};
 use rsa::{
     pkcs1::{EncodeRsaPrivateKey, EncodeRsaPublicKey},
+    pkcs8::{DecodePrivateKey, EncodePrivateKey},
     rand_core::OsRng,
     BigUint, RsaPrivateKey,
 };

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -1,22 +1,21 @@
-use der::asn1::UintRef;
-use der::Decode;
-use der::Encode;
-use llrt_encoding::bytes_from_b64_url_safe;
-use llrt_utils::str_enum;
-use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
-use pkcs8::EncodePrivateKey;
-use pkcs8::PrivateKeyInfo;
-use rquickjs::FromJs;
-use rquickjs::{atom::PredefinedAtom, Array, Ctx, Exception, Object, Result, TypedArray, Value};
-use spki::{AlgorithmIdentifier, ObjectIdentifier};
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 use std::rc::Rc;
+
+use der::{asn1::UintRef, Decode, Encode};
+use llrt_encoding::bytes_from_b64_url_safe;
+use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt, str_enum};
+use rquickjs::{
+    atom::PredefinedAtom, Array, Ctx, Exception, FromJs, Object, Result, TypedArray, Value,
+};
+use rsa::pkcs8::{EncodePrivateKey, PrivateKeyInfo};
+use spki::{AlgorithmIdentifier, ObjectIdentifier};
 
 use crate::sha_hash::ShaAlgorithm;
 
-use super::algorithm_mismatch_error;
 use super::{
-    algorithm_not_supported_error, crypto_key::KeyKind, to_name_and_maybe_object, EllipticCurve,
+    algorithm_mismatch_error, algorithm_not_supported_error, crypto_key::KeyKind,
+    to_name_and_maybe_object, EllipticCurve,
 };
 
 #[derive(Clone, Copy, PartialEq)]

--- a/modules/llrt_crypto/src/subtle/sign_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/sign_algorithm.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 use llrt_utils::{object::ObjectExt, result::ResultExt};
 use rquickjs::{Ctx, FromJs, Result, Value};
 

--- a/modules/llrt_events/Cargo.toml
+++ b/modules/llrt_events/Cargo.toml
@@ -15,4 +15,4 @@ llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-f
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
-tracing = "0.1"
+tracing = { version = "0.1", default-features = false }

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -44,7 +44,9 @@ llrt_json = { version = "0.5.1-beta", path = "../../libs/llrt_json" }
 llrt_url = { version = "0.5.1-beta", path = "../llrt_url" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
-once_cell = { version = "1", default-features = false }
+once_cell = { version = "1", features = [
+  "std",
+], default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
 rustls = { version = "0.23", features = [
   "ring",

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -21,17 +21,19 @@ compression-c = ["llrt_compression/all-c"]
 compression-rust = ["llrt_compression/all-rust"]
 
 [dependencies]
-bytes = "1"
-either = "1"
-http-body-util = "0.1"
-hyper = { version = "1", features = ["client"] }
-hyper-rustls = { version = "0.27", default-features = false, features = [
+bytes = { version = "1", default-features = false }
+either = { version = "1", default-features = false }
+http-body-util = { version = "0.1", default-features = false }
+hyper = { version = "1", features = [
+  "client",
+], default-features = false }
+hyper-rustls = { version = "0.27", features = [
+  "ring",
   "webpki-roots",
   "webpki-tokio",
-  "ring",
-] }
-hyper-util = "0.1"
-itoa = "1"
+], default-features = false }
+hyper-util = { version = "0.1", default-features = false }
+itoa = { version = "1", default-features = false }
 llrt_abort = { version = "0.5.1-beta", path = "../llrt_abort" }
 llrt_buffer = { version = "0.5.1-beta", path = "../llrt_buffer" }
 llrt_compression = { version = "0.5.1-beta", path = "../../libs/llrt_compression", default-features = false }
@@ -41,24 +43,24 @@ llrt_encoding = { version = "0.5.1-beta", path = "../../libs/llrt_encoding" }
 llrt_json = { version = "0.5.1-beta", path = "../../libs/llrt_json" }
 llrt_url = { version = "0.5.1-beta", path = "../llrt_url" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
-pin-project-lite = "0.2"
-once_cell = "1"
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
-  "either",
-], default-features = false }
-rustls = { version = "0.23", default-features = false, features = [
-  "tls12",
+pin-project-lite = { version = "0.2", default-features = false }
+once_cell = { version = "1", default-features = false }
+rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
+rustls = { version = "0.23", features = [
   "ring",
-] }
-ryu = "1"
-tokio = "1"
-tracing = "0.1"
-webpki-roots = "1.0"
-tower-service = "0.3"
-quick_cache = "0.6"
+  "tls12",
+], default-features = false }
+ryu = { version = "1", default-features = false }
+tokio = { version = "1", features = [
+  "macros",
+  "sync",
+], default-features = false }
+tracing = { version = "0.1", default-features = false }
+webpki-roots = { version = "1", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+quick_cache = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 llrt_compression = { version = "0.5.1-beta", path = "../../libs/llrt_compression" }
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
-wiremock = "0.6"
+wiremock = { version = "0.6", default-features = false }

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -47,7 +47,9 @@ pin-project-lite = { version = "0.2", default-features = false }
 once_cell = { version = "1", features = [
   "std",
 ], default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
+rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", features = [
+  "either",
+], version = "0.9.0", default-features = false }
 rustls = { version = "0.23", features = [
   "ring",
   "tls12",

--- a/modules/llrt_fs/Cargo.toml
+++ b/modules/llrt_fs/Cargo.toml
@@ -12,21 +12,24 @@ name = "llrt_fs"
 path = "src/lib.rs"
 
 [dependencies]
-either = "1"
+either = { version = "1", default-features = false }
 llrt_buffer = { version = "0.5.1-beta", path = "../llrt_buffer" }
 llrt_encoding = { version = "0.5.1-beta", path = "../../libs/llrt_encoding" }
 llrt_path = { version = "0.5.1-beta", path = "../llrt_path" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", features = [
   "fs",
 ], default-features = false }
-ring = "0.17"
+ring = { version = "0.17", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "either",
-  "macro",
   "futures",
+  "macro",
 ], default-features = false }
-tokio = { version = "1", features = ["rt", "fs", "io-util"] }
+tokio = { version = "1", features = [
+  "fs",
+  "io-util",
+  "rt",
+], default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }

--- a/modules/llrt_net/Cargo.toml
+++ b/modules/llrt_net/Cargo.toml
@@ -26,4 +26,7 @@ tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.8", features = [
+  "alloc",
+  "getrandom",
+], default-features = false }

--- a/modules/llrt_net/Cargo.toml
+++ b/modules/llrt_net/Cargo.toml
@@ -12,17 +12,18 @@ name = "llrt_net"
 path = "src/lib.rs"
 
 [dependencies]
-itoa = "1"
+itoa = { version = "1", default-features = false }
 llrt_buffer = { version = "0.5.1-beta", path = "../llrt_buffer" }
 llrt_context = { version = "0.5.1-beta", path = "../../libs/llrt_context" }
 llrt_events = { version = "0.5.1-beta", path = "../llrt_events" }
 llrt_stream = { version = "0.5.1-beta", path = "../llrt_stream" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-tokio = { version = "1", features = ["net"] }
-tracing = "0.1"
+tokio = { version = "1", features = [
+  "net",
+], default-features = false }
+tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-rand = "0.8"
-tokio = { version = "1", features = ["full"] }
+rand = { version = "0.8", default-features = false }

--- a/modules/llrt_os/Cargo.toml
+++ b/modules/llrt_os/Cargo.toml
@@ -8,29 +8,34 @@ repository = "https://github.com/awslabs/llrt"
 readme = "README.md"
 
 [features]
-default = ["network", "statistics"]
+default = ["network", "statistics", "system"]
 
-network = ["sysinfo/network"]
-statistics = []
+network = ["sysinfo/network", "system"]
+statistics = ["system"]
+system = ["sysinfo/system"]
 
 [dependencies]
-home = "0.5"
+home = { version = "0.5", default-features = false }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
-num_cpus = "1"
-once_cell = "1"
+num_cpus = { version = "1", default-features = false }
+once_cell = { version = "1", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-sysinfo = { version = "0.35", features = ["system"], default-features = false }
+sysinfo = { version = "0.35", default-features = false, optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
-users = { version = "0.11", features = ["cache"], default-features = false }
+libc = { version = "0.2", default-features = false }
+users = { version = "0.11", features = [
+  "cache",
+], default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 whoami = { version = "1", default-features = false }
-windows-registry = "0.5"
-windows-result = "0.3"
-windows-version = "0.1"
+windows-registry = { version = "0.5", default-features = false }
+windows-result = { version = "0.3", default-features = false }
+windows-version = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = [
+  "test-util"
+], default-features = false }

--- a/modules/llrt_os/Cargo.toml
+++ b/modules/llrt_os/Cargo.toml
@@ -32,8 +32,12 @@ users = { version = "0.11", features = [
 
 [target.'cfg(windows)'.dependencies]
 whoami = { version = "1", default-features = false }
-windows-registry = { version = "0.5", default-features = false }
-windows-result = { version = "0.3", default-features = false }
+windows-registry = { version = "0.5", features = [
+  "std",
+], default-features = false }
+windows-result = { version = "0.3", features = [
+  "std",
+], default-features = false }
 windows-version = { version = "0.1", default-features = false }
 
 [dev-dependencies]

--- a/modules/llrt_os/Cargo.toml
+++ b/modules/llrt_os/Cargo.toml
@@ -18,7 +18,9 @@ system = ["sysinfo/system"]
 home = { version = "0.5", default-features = false }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
 num_cpus = { version = "1", default-features = false }
-once_cell = { version = "1", default-features = false }
+once_cell = { version = "1", features = [
+  "std",
+], default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
 sysinfo = { version = "0.35", default-features = false, optional = true }
 

--- a/modules/llrt_path/Cargo.toml
+++ b/modules/llrt_path/Cargo.toml
@@ -19,7 +19,9 @@ memchr = { version = "2", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.6", default-features = false }
-once_cell = { version = "1", default-features = false }
+once_cell = { version = "1", features = [
+  "std",
+], default-features = false }
 rand = { version = "0.8", default-features = false }
 
 [[bench]]

--- a/modules/llrt_path/Cargo.toml
+++ b/modules/llrt_path/Cargo.toml
@@ -15,12 +15,12 @@ llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-f
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
-memchr = "2"
+memchr = { version = "2", default-features = false }
 
 [dev-dependencies]
-criterion = "0.6"
-once_cell = "1"
-rand = "0.8"
+criterion = { version = "0.6", default-features = false }
+once_cell = { version = "1", default-features = false }
+rand = { version = "0.8", default-features = false }
 
 [[bench]]
 name = "slash_replacement"

--- a/modules/llrt_path/Cargo.toml
+++ b/modules/llrt_path/Cargo.toml
@@ -22,7 +22,10 @@ criterion = { version = "0.6", default-features = false }
 once_cell = { version = "1", features = [
   "std",
 ], default-features = false }
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.8", features = [
+  "alloc",
+  "getrandom",
+], default-features = false }
 
 [[bench]]
 name = "slash_replacement"

--- a/modules/llrt_perf_hooks/Cargo.toml
+++ b/modules/llrt_perf_hooks/Cargo.toml
@@ -17,4 +17,3 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }

--- a/modules/llrt_process/Cargo.toml
+++ b/modules/llrt_process/Cargo.toml
@@ -14,9 +14,11 @@ path = "src/lib.rs"
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
 
+[target.'cfg(unix)'.dependencies]
+libc = { version = "0.2", default-features = false }
+
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
-
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
+tokio = { version = "1", features = [
+  "test-util"
+], default-features = false }

--- a/modules/llrt_stream/Cargo.toml
+++ b/modules/llrt_stream/Cargo.toml
@@ -18,4 +18,7 @@ llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", features 
   "bytearray-buffer",
 ], default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-tokio = { version = "1", features = ["macros", "io-util"] }
+tokio = { version = "1", features = [
+  "macros",
+  "io-util",
+], default-features = false }

--- a/modules/llrt_stream_web/Cargo.toml
+++ b/modules/llrt_stream_web/Cargo.toml
@@ -17,4 +17,6 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = [
+  "test-util"
+], default-features = false }

--- a/modules/llrt_string_decoder/Cargo.toml
+++ b/modules/llrt_string_decoder/Cargo.toml
@@ -19,4 +19,6 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = [
+  "test-util"
+], default-features = false }

--- a/modules/llrt_timers/Cargo.toml
+++ b/modules/llrt_timers/Cargo.toml
@@ -13,7 +13,9 @@ path = "src/lib.rs"
 [dependencies]
 llrt_context = { version = "0.5.1-beta", path = "../../libs/llrt_context" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
-once_cell = { version = "1", default-features = false }
+once_cell = { version = "1", features = [
+  "std",
+], default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
 tokio = { version = "1", features = [
   "macros",

--- a/modules/llrt_timers/Cargo.toml
+++ b/modules/llrt_timers/Cargo.toml
@@ -13,10 +13,13 @@ path = "src/lib.rs"
 [dependencies]
 llrt_context = { version = "0.5.1-beta", path = "../../libs/llrt_context" }
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
-once_cell = "1"
+once_cell = { version = "1", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-tokio = { version = "1", features = ["sync", "time", "macros"] }
+tokio = { version = "1", features = [
+  "macros",
+  "sync",
+  "time",
+], default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }

--- a/modules/llrt_tty/Cargo.toml
+++ b/modules/llrt_tty/Cargo.toml
@@ -14,8 +14,10 @@ path = "src/lib.rs"
 [dependencies]
 llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", default-features = false }
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = [
+  "test-util"
+], default-features = false }

--- a/modules/llrt_url/Cargo.toml
+++ b/modules/llrt_url/Cargo.toml
@@ -16,8 +16,10 @@ llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-f
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
-url = "2.5"
+url = { version =  "=2.5.1", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = [
+  "test-util"
+], default-features = false }

--- a/modules/llrt_zlib/Cargo.toml
+++ b/modules/llrt_zlib/Cargo.toml
@@ -29,4 +29,3 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
### Description of changes

As the size of our assets has grown, in this PR we will be organizing our crates.
- Removed crates that were never referenced in the code.
- We set `default-features=false` for all external crates, whether they have feature flags or not, to prevent unintentional introduction of unwanted features, and honestly. We didn't have time to evaluate them one by one. :)
- llrt_crypto: Fixed some missing feature flag settings.
- llrt_os: Introduced the systems feature flag. Turning off all of the included feature flags will prevent the inclusion of the sysinfo crate. 

Looking at the diff of Cargo.lock, we have made progress in removing dependencies on several crates, resulting in a 48KB reduction in size. Below is the execution result using full-sdk.

before:
```sh
% du -k ./target/aarch64-apple-darwin/release/llrt
10604   ./target/aarch64-apple-darwin/release/llrt
```

after:
```sh
% du -k ./target/aarch64-apple-darwin/release/llrt
10556   ./target/aarch64-apple-darwin/release/llrt
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
