### PR TITLE
fix: WARNING: lifetime flowing from input to output with different syntax can be confusing

### DIFF
--- a/llrt_core/src/modules/llrt/uuid.rs
+++ b/llrt_core/src/modules/llrt/uuid.rs
@@ -123,7 +123,7 @@ fn uuidv6_to_v1<'js>(ctx: Ctx<'js>, v6_value: Value<'js>) -> Result<String> {
     Ok(Uuid::from_bytes(v1_bytes).format_hyphenated().to_string())
 }
 
-fn parse(ctx: Ctx<'_>, value: String) -> Result<TypedArray<u8>> {
+fn parse(ctx: Ctx<'_>, value: String) -> Result<TypedArray<'_, u8>> {
     let uuid = Uuid::try_parse(&value).or_throw_msg(&ctx, ERROR_MESSAGE)?;
     let bytes = uuid.as_bytes();
     TypedArray::<u8>::new(ctx, *bytes)

--- a/modules/llrt_os/src/network.rs
+++ b/modules/llrt_os/src/network.rs
@@ -14,7 +14,7 @@ use sysinfo::Networks;
 static NETWORKS: Lazy<Arc<Mutex<Networks>>> =
     Lazy::new(|| Arc::new(Mutex::new(Networks::new_with_refreshed_list())));
 
-pub fn get_network_interfaces(ctx: Ctx<'_>) -> Result<HashMap<String, Vec<Object>>> {
+pub fn get_network_interfaces(ctx: Ctx<'_>) -> Result<HashMap<String, Vec<Object<'_>>>> {
     let mut map: HashMap<String, Vec<Object>> = HashMap::new();
     let networks = NETWORKS.lock().unwrap();
 

--- a/modules/llrt_os/src/statistics.rs
+++ b/modules/llrt_os/src/statistics.rs
@@ -14,7 +14,7 @@ static SYSTEM: Lazy<Arc<Mutex<System>>> = Lazy::new(|| {
     )))
 });
 
-pub fn get_cpus(ctx: Ctx<'_>) -> Result<Vec<Object>> {
+pub fn get_cpus(ctx: Ctx<'_>) -> Result<Vec<Object<'_>>> {
     let mut vec: Vec<Object> = Vec::new();
     let system = SYSTEM.lock().unwrap();
 

--- a/modules/llrt_process/src/lib.rs
+++ b/modules/llrt_process/src/lib.rs
@@ -29,7 +29,7 @@ fn cwd(ctx: Ctx<'_>) -> Result<String> {
         .map(|path| path.to_string_lossy().to_string())
 }
 
-fn hr_time_big_int(ctx: Ctx<'_>) -> Result<BigInt> {
+fn hr_time_big_int(ctx: Ctx<'_>) -> Result<BigInt<'_>> {
     let now = time::now_nanos();
     let started = time::origin_nanos();
 


### PR DESCRIPTION
### Description of changes

Fixes warnings that occur when updating the Rust toolchain.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
