### PR TITLE
chore(url): update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,6 @@ dependencies = [
  "terminal_size",
  "tokio",
  "tracing",
- "url",
  "uuid",
  "uuid-simd",
  "wiremock",
@@ -3394,9 +3393,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -57,7 +57,6 @@ tokio = { version = "1", features = [
 tracing = { version = "0.1", features = [
   "log"
 ], default-features = false }
-url = { version = "=2.5.1", default-features = false }
 uuid = { version = "1", features = [
   "fast-rng",
   "v1",

--- a/modules/llrt_url/Cargo.toml
+++ b/modules/llrt_url/Cargo.toml
@@ -16,7 +16,9 @@ llrt_utils = { version = "0.5.1-beta", path = "../../libs/llrt_utils", default-f
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "macro",
 ], default-features = false }
-url = { version =  "=2.5.1", default-features = false }
+url = { version =  "2", features = [
+  "std",
+], default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -333,11 +333,8 @@ Error: [Parsing: <file:///w|/m> without base] assert_equals: href expected "file
 url > should pass url-origin.any.js tests
 Error: [Origin parsing: <blob:blob:https://example.org/> without base] assert_equals: origin expected "null" but got "https://example.org"
 
-url > should pass url-setters-stripping.any.js tests
-Error: [Setting port with leading U+0000 (https:)] assert_equals: property expected "8000" but got ""
-
 url > should pass url-setters.any.js tests
-Error: [URL: Setting <http://example.net:8080>.host = 'example.com:invalid' Anything other than ASCII digit stops the port parser in a setter but is not an error] assert_equals: expected "http://example.com:8080/" but got "http://example.com/"
+Error: [URL: Setting <non-spec:/.//p>.hostname = 'h' Drop /. from path] assert_equals: expected "non-spec://h//p" but got "non-spec://h/.//p"
 
 url > should pass urlencoded-parser.any.js tests
 Error: [request.formData() with input: test] not a function


### PR DESCRIPTION
### Issue # (if available)

Related: #487
Related: https://github.com/servo/rust-url/issues/952

### Description of changes

- The reported issues have been resolved in url 2.5.3, so we will be moving forward with the dependency. We compared the binary size and there was no change in KB.

No change in results before and after:
```sh
% du -k ./target/aarch64-apple-darwin/release/llrt
10588   ./target/aarch64-apple-darwin/release/llrt
```
- This update also improves WPT compatibility.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
