### PR TITLE
fix(fetch/headers): Improve Headers class conformance to Fetch standards

### DIFF
--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -165,13 +165,13 @@ impl Headers {
         Ok(self.headers.iter().any(|(k, _)| k == &key))
     }
 
-    pub fn set<'js>(&mut self, ctx: Ctx<'js>, key: String, value: String) -> Result<()> {
+    pub fn set<'js>(&mut self, ctx: Ctx<'js>, key: String, value: Value<'js>) -> Result<()> {
         let key: ImmutableString = key.to_lowercase().into();
         if !is_http_header_name(&key) {
             return Err(Exception::throw_type(&ctx, "Invalid key"));
         }
 
-        let mut value: String = value;
+        let mut value = coerce_to_string(&ctx, value)?;
         normalize_header_value_inplace(&ctx, &mut value)?;
         if self.guard == HeadersGuard::RequestNoCors {
             let val = value.split(',').next().unwrap_or("").trim();
@@ -528,7 +528,7 @@ mod tests {
                     .set(
                         ctx.clone(),
                         "Content-Type".into(),
-                        "application/json".into(),
+                        "application/json".into_js(&ctx).unwrap(),
                     )
                     .unwrap();
 

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -544,36 +544,23 @@ mod tests {
                         .unwrap();
                 }
 
-                assert_eq!(
-                    headers
-                        .get(ctx.clone(), "Content-Type".into())
-                        .unwrap()
-                        .as_string()
-                        .unwrap()
-                        .to_string()
-                        .unwrap(),
-                    "application/json"
-                );
-                assert_eq!(
-                    headers
-                        .get(ctx.clone(), "set-cookie".into())
-                        .unwrap()
-                        .as_string()
-                        .unwrap()
-                        .to_string()
-                        .unwrap(),
-                    "cookie1=value1, cookie2=value2"
-                );
-                assert_eq!(
-                    headers
-                        .get(ctx.clone(), "Accept-Encoding".into())
-                        .unwrap()
-                        .as_string()
-                        .unwrap()
-                        .to_string()
-                        .unwrap(),
-                    "deflate, gzip"
-                );
+                let get_headers = [
+                    ("Content-Type", "application/json"),
+                    ("set-cookie", "cookie1=value1, cookie2=value2"),
+                    ("Accept-Encoding", "deflate, gzip"),
+                ];
+                for (key, expected) in get_headers {
+                    assert_eq!(
+                        headers
+                            .get(ctx.clone(), key.into())
+                            .unwrap()
+                            .as_string()
+                            .unwrap()
+                            .to_string()
+                            .unwrap(),
+                        expected
+                    );
+                }
             })
         })
         .await;

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -185,7 +185,7 @@ fetch/api/headers > should pass header-setcookie.any.js tests
 Error: [Headers iterator is correctly updated with set-cookie changes] assert_array_equals: expected property 0 to be "set-cookie" but got "x-header" (expected array ["set-cookie", "a=b"] got ["x-header", "test"])
 
 fetch/api/headers > should pass headers-basic.any.js tests
-Error: [Check set method] Error converting from js 'null' into type 'string'
+Error: [Check keys method] assert_equals: expected object "[object Iterator]" but got object "[object Object]"
 
 fetch/api/headers > should pass headers-record.any.js tests
 Error: [Basic operation with one property] assert_array_equals: lengths differ, expected array ["get", object "[object Object]", symbol "Symbol(Symbol.iterator)", object "[object Object]"] length 4, got ["has", object "[object Object]", symbol "Symbol(Symbol.iterator)"] length 3

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -185,7 +185,7 @@ fetch/api/headers > should pass header-setcookie.any.js tests
 Error: [Headers iterator is correctly updated with set-cookie changes] assert_array_equals: expected property 0 to be "set-cookie" but got "x-header" (expected array ["set-cookie", "a=b"] got ["x-header", "test"])
 
 fetch/api/headers > should pass headers-basic.any.js tests
-Error: [Check append method] Error converting from js 'null' into type 'string'
+Error: [Check set method] Error converting from js 'null' into type 'string'
 
 fetch/api/headers > should pass headers-record.any.js tests
 Error: [Basic operation with one property] assert_array_equals: lengths differ, expected array ["get", object "[object Object]", symbol "Symbol(Symbol.iterator)", object "[object Object]"] length 4, got ["has", object "[object Object]", symbol "Symbol(Symbol.iterator)"] length 3

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -185,10 +185,10 @@ fetch/api/headers > should pass header-setcookie.any.js tests
 Error: [Headers iterator is correctly updated with set-cookie changes] assert_array_equals: expected property 0 to be "set-cookie" but got "x-header" (expected array ["set-cookie", "a=b"] got ["x-header", "test"])
 
 fetch/api/headers > should pass headers-basic.any.js tests
-Error: [Create headers with existing headers with custom iterator] assert_equals: expected (string) "test" but got (object) null
+Error: [Check append method] Error converting from js 'null' into type 'string'
 
 fetch/api/headers > should pass headers-record.any.js tests
-Error: [Basic operation with one property] assert_equals: expected 4 but got 3
+Error: [Basic operation with one property] assert_array_equals: lengths differ, expected array ["get", object "[object Object]", symbol "Symbol(Symbol.iterator)", object "[object Object]"] length 4, got ["has", object "[object Object]", symbol "Symbol(Symbol.iterator)"] length 3
 
 
 🧪/wpt/fetch.api.request.test.js 


### PR DESCRIPTION
### Description of changes

Although it's still far from perfect, we've improved our compliance with the Fetch standard.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
