### PR TITLE
fix(number): fix Number.toString(radix)

### DIFF
--- a/libs/llrt_numbers/src/lib.rs
+++ b/libs/llrt_numbers/src/lib.rs
@@ -4,7 +4,7 @@ use rquickjs::{
     atom::PredefinedAtom,
     function::{Opt, This},
     prelude::Func,
-    Ctx, Exception, Function, Object, Result, Value,
+    Ctx, Exception, FromJs, Function, Object, Result, Value,
 };
 use std::result::Result as StdResult;
 
@@ -256,11 +256,11 @@ fn check_radix(ctx: &Ctx, radix: u8) -> Result<()> {
     Ok(())
 }
 
-fn number_to_string(ctx: Ctx, this: This<Value>, radix: Opt<u8>) -> Result<String> {
-    if let Some(int) = this.as_int() {
+fn number_to_string<'js>(ctx: Ctx<'js>, this: This<Value<'js>>, radix: Opt<u8>) -> Result<String> {
+    if let Ok(int) = i64::from_js(&ctx, this.0.clone()) {
         if let Some(radix) = radix.0 {
             check_radix(&ctx, radix)?;
-            return Ok(i64_to_base_n(int as i64, radix));
+            return Ok(i64_to_base_n(int, radix));
         }
         let mut buffer = itoa::Buffer::new();
         return Ok(buffer.format(int).into());

--- a/tests/unit/numbers.test.ts
+++ b/tests/unit/numbers.test.ts
@@ -1,0 +1,67 @@
+describe("Number to base conversion within 32-bit range", () => {
+  const testCases = [
+    { num: 0, radix: 2, expected: "0" },
+    { num: 1, radix: 2, expected: "1" },
+    { num: -1, radix: 2, expected: "-1" },
+
+    { num: 255, radix: 16, expected: "ff" },
+    { num: -255, radix: 16, expected: "-ff" },
+
+    { num: 1023, radix: 8, expected: "1777" },
+    { num: -1023, radix: 8, expected: "-1777" },
+
+    { num: 123456789, radix: 10, expected: "123456789" },
+    { num: -123456789, radix: 10, expected: "-123456789" },
+
+    { num: 2147483647, radix: 16, expected: "7fffffff" }, // max 32bit signed
+    { num: -2147483648, radix: 16, expected: "-80000000" }, // min 32bit signed
+
+    { num: 100, radix: 36, expected: "2s" },
+    { num: -100, radix: 36, expected: "-2s" },
+  ];
+
+  testCases.forEach(({ num, radix, expected }) => {
+    it(`num=${num} radix=${radix} => ${expected}`, () => {
+      const actual = num.toString(radix);
+      expect(actual).toBe(expected);
+    });
+  });
+});
+
+describe("Number to base conversion over 32-bit range", () => {
+  const num = 1749475325433;
+
+  it("should convert number to binary (base-2)", () => {
+    expect(num.toString(2)).toEqual(
+      "11001011101010100110110101111010111111001"
+    );
+  });
+
+  it("should convert number to octal (base-8)", () => {
+    expect(num.toString(8)).toEqual("31352466572771");
+  });
+
+  it("should convert number to decimal (base-10)", () => {
+    expect(num.toString(10)).toEqual("1749475325433");
+  });
+
+  it("should convert number to hexadecimal (base-16)", () => {
+    expect(num.toString(16)).toEqual("19754daf5f9");
+  });
+
+  it("should convert number to base-20", () => {
+    expect(num.toString(20)).toEqual("386fb0fdbd");
+  });
+
+  it("should convert number to base-26", () => {
+    expect(num.toString(26)).toEqual("89l74gagh");
+  });
+
+  it("should convert number to base-32", () => {
+    expect(num.toString(32)).toEqual("1itadltfp");
+  });
+
+  it("should convert number to base-36", () => {
+    expect(num.toString(36)).toEqual("mbp4fshl");
+  });
+});


### PR DESCRIPTION
### Issue # (if available)

Fixed: #1011 

### Description of changes

Fixed an issue where numbers larger than 32-bits could not be converted in `Number.toString(radix)`.

```javascript
// reproduction.js
const d = Date.now().toString(16);
console.log(d)
console.log(d.length)
console.log(d[11] == String.fromCharCode(0))
console.log(d[11] == undefined)
console.log(Buffer.from(d));
```

llrt: 
```
% llrt reproduction.js 
19759a74897
11
false
true
Buffer [ 49, 57, 55, 53, 57, 97, 55, 52, 56, 57, 55 ]
```

node.js:
```
% node reproduction.js 
19759a7571b
11
false
true
<Buffer 31 39 37 35 39 61 37 35 37 31 62>
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
