### PR TITLE
feat(fetch/os/zlib): make features that use some crates optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,9 +1745,7 @@ dependencies = [
  "home",
  "http-body-util",
  "hyper",
- "itoa",
  "jwalk",
- "libc",
  "llrt_build",
  "llrt_context",
  "llrt_encoding",
@@ -1767,7 +1765,6 @@ dependencies = [
  "rquickjs",
  "rustls",
  "rustls-pemfile",
- "ryu",
  "simd-json",
  "terminal_size",
  "tokio",
@@ -3475,7 +3472,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/README.md
+++ b/README.md
@@ -530,6 +530,9 @@ Set a memory threshold in MB for garbage collection. Default threshold is 20MB
 
 Extends the HTTP request version. By default, only HTTP/1.1 is enabled. Specifying '2' will enable HTTP/1.1 and HTTP/2.
 
+> [!NOTE]
+> Although it is supported by the llrt_fetch crate, the http/2 feature is disabled at build time to reduce binary size. Regardless of the setting of this environment variable, llrt only works with http/1.1.
+
 ### `LLRT_LOG=[target][=][level][,...]`
 
 Filter the log output by target module, level, or both (using `=`). Log levels are case-insensitive and will also enable any higher priority logs.

--- a/libs/llrt_compression/Cargo.toml
+++ b/libs/llrt_compression/Cargo.toml
@@ -11,10 +11,9 @@ name = "llrt_compression"
 path = "src/lib.rs"
 
 [features]
-default = ["all-c"]
-
-all-c = ["brotli-c", "flate2-c", "zstd-c"]
-all-rust = ["brotli-rust", "flate2-rust", "zstd-rust"]
+default = ["flate2-c", "zstd-c"]
+#default = ["std"]
+std = ["brotli-c", "flate2-c", "zstd-c"]
 
 brotli-c = ["brotlic"]
 brotli-rust = ["brotli"]

--- a/llrt/Cargo.toml
+++ b/llrt/Cargo.toml
@@ -26,9 +26,7 @@ tokio = { version = "1", features = [
   "macros",
   "rt-multi-thread",
 ], default-features = false }
-tracing = { version = "0.1", features = [
-  "log"
-], default-features = false }
+tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -20,8 +20,6 @@ chrono = { version = "0.4", features = [
 home = { version = "0.5", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper = { version = "1", default-features = false }
-itoa = { version = "1", default-features = false }
-libc = { version = "0.2", default-features = false }
 llrt_context = { path = "../libs/llrt_context" }
 llrt_encoding = { path = "../libs/llrt_encoding" }
 llrt_json = { path = "../libs/llrt_json" }
@@ -47,16 +45,13 @@ rustls = { version = "0.23", features = [
 rustls-pemfile = { version = "2", features = [
   "std",
 ], default-features = false }
-ryu = { version = "1", default-features = false }
 simd-json = { version = "0.15", default-features = false }
 terminal_size = { version = "0.4", default-features = false }
 tokio = { version = "1", features = [
   "sync",
   "time",
 ], default-features = false }
-tracing = { version = "0.1", features = [
-  "log"
-], default-features = false }
+tracing = { version = "0.1", default-features = false }
 uuid = { version = "1", features = [
   "fast-rng",
   "v1",
@@ -73,6 +68,7 @@ zstd = { version = "0.13", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 md-5 = { version = "0.10", default-features = false }
+
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 md-5 = { version = "0.10", features = [
   "asm",

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/awslabs/llrt"
 readme = "README.md"
 
 [features]
-default = ["base", "console"]
-lambda = ["base"]
+default = ["std", "console"]
+lambda = ["std"]
 
-base = [
+std = [
   "abort",
   "assert",
   "buffer",
@@ -63,6 +63,16 @@ url = ["llrt_url"]
 util = ["llrt_util"]
 zlib = ["llrt_zlib"]
 
+# Options
+fetch-brotli = ["llrt_fetch/brotli"]
+fetch-http2 = ["llrt_fetch/http2"]
+
+os-network = ["llrt_os/network"]
+os-statistics = ["llrt_os/statistics"]
+os-system = ["llrt_os/system"]
+
+zlib-brotli = ["llrt_zlib/brotli"]
+
 [dependencies]
 llrt_abort = { version = "0.5.1-beta", path = "../modules/llrt_abort", optional = true }
 llrt_assert = { version = "0.5.1-beta", path = "../modules/llrt_assert", optional = true }
@@ -77,7 +87,7 @@ llrt_fetch = { version = "0.5.1-beta", path = "../modules/llrt_fetch", optional 
 llrt_fs = { version = "0.5.1-beta", path = "../modules/llrt_fs", optional = true }
 llrt_navigator = { version = "0.5.1-beta", path = "../modules/llrt_navigator", optional = true }
 llrt_net = { version = "0.5.1-beta", path = "../modules/llrt_net", optional = true }
-llrt_os = { version = "0.5.1-beta", path = "../modules/llrt_os", default-features = false, optional = true }
+llrt_os = { version = "0.5.1-beta", path = "../modules/llrt_os", optional = true }
 llrt_path = { version = "0.5.1-beta", path = "../modules/llrt_path", optional = true }
 llrt_process = { version = "0.5.1-beta", path = "../modules/llrt_process", optional = true }
 llrt_perf_hooks = { version = "0.5.1-beta", path = "../modules/llrt_perf_hooks", optional = true }

--- a/llrt_modules/README.md
+++ b/llrt_modules/README.md
@@ -117,34 +117,34 @@ async fn main() -> Result<(), Error> {
 > [!NOTE]
 > Only a fraction of the Node.js APIs are supported. Below is a high level overview of partially supported APIs and modules.
 
-|                | Node.js | LLRT Modules | Feature          | Crate                 |
-| -------------- | ------- | ------------ | ---------------- | --------------------- |
-| abort          | ✔︎     | ✔︎️         | `abort`          | `llrt_abort`          |
-| assert         | ✔︎     | ⚠️           | `assert`         | `llrt_assert`         |
-| buffer         | ✔︎     | ✔︎️         | `buffer`         | `llrt_buffer`         |
-| child process  | ✔︎     | ⚠️           | `child-process`  | `llrt_child_process`  |
-| console        | ✔︎     | ⚠️           | `console`        | `llrt_console`        |
-| crypto         | ✔︎     | ⚠️           | `crypto`         | `llrt_crypto`         |
-| dns            | ✔︎     | ⚠️           | `dns`            | `llrt_dns`            |
-| events         | ✔︎     | ⚠️           | `events`         | `llrt_events`         |
-| exceptions     | ✔︎     | ⚠️           | `exceptions`     | `llrt_exceptions`     |
-| fetch          | ✔︎     | ⚠️           | `fetch`          | `llrt_fetch`          |
-| fs/promises    | ✔︎     | ⚠️           | `fs`             | `llrt_fs`             |
-| fs             | ✔︎     | ⚠️           | `fs`             | `llrt_fs`             |
-| navigator      | ✔︎     | ⚠️           | `navigator`      | `llrt_navigator`      |
-| net            | ✔︎     | ⚠️           | `net`            | `llrt_net`            |
-| os             | ✔︎     | ⚠️           | `os`             | `llrt_os`             |
-| path           | ✔︎     | ✔︎          | `path`           | `llrt_path`           |
-| perf hooks     | ✔︎     | ⚠️           | `perf-hooks`     | `llrt_perf_hooks`     |
-| stream         | ✔︎     | ⚠️           | N/A              | `llrt_stream`         |
-| string_decoder | ✔︎     | ✔︎          | `string_decoder` | `llrt_string_decoder` |
-| timers         | ✔︎     | ✔︎          | `timers`         | `llrt_timers`         |
-| process        | ✔︎     | ✔︎          | `process`        | `llrt_process`        |
-| tty            | ✔︎     | ⚠️           | `tty`            | `llrt_tty`            |
-| url            | ✔︎     | ⚠️           | `url`            | `llrt_url`            |
-| util           | ✔︎     | ⚠️           | `util`           | `llrt_util`           |
-| zlib           | ✔︎     | ⚠️           | `zlib`           | `llrt_zlib`           |
-| Other modules  | ✔︎     | ✘            | N/A              | N/A                   |
+|                | Node.js | LLRT Modules | Feature          | Crate                 | Options                                  |
+| -------------- | ------- | ------------ | ---------------- | --------------------- | ---------------------------------------- |
+| abort          | ✔︎     | ✔︎️         | `abort`          | `llrt_abort`          |                                          |
+| assert         | ✔︎     | ⚠️           | `assert`         | `llrt_assert`         |                                          |
+| buffer         | ✔︎     | ✔︎️         | `buffer`         | `llrt_buffer`         |                                          |
+| child process  | ✔︎     | ⚠️           | `child-process`  | `llrt_child_process`  |                                          |
+| console        | ✔︎     | ⚠️           | `console`        | `llrt_console`        |                                          |
+| crypto         | ✔︎     | ⚠️           | `crypto`         | `llrt_crypto`         |                                          |
+| dns            | ✔︎     | ⚠️           | `dns`            | `llrt_dns`            |                                          |
+| events         | ✔︎     | ⚠️           | `events`         | `llrt_events`         |                                          |
+| exceptions     | ✔︎     | ⚠️           | `exceptions`     | `llrt_exceptions`     |                                          |
+| fetch          | ✔︎     | ⚠️           | `fetch`          | `llrt_fetch`          | `fetch-brotli` `fetch-http2`             |
+| fs/promises    | ✔︎     | ⚠️           | `fs`             | `llrt_fs`             |                                          |
+| fs             | ✔︎     | ⚠️           | `fs`             | `llrt_fs`             |                                          |
+| navigator      | ✔︎     | ⚠️           | `navigator`      | `llrt_navigator`      |                                          |
+| net            | ✔︎     | ⚠️           | `net`            | `llrt_net`            |                                          |
+| os             | ✔︎     | ⚠️           | `os`             | `llrt_os`             | `os-network` `os-statistics` `os-system` |
+| path           | ✔︎     | ✔︎          | `path`           | `llrt_path`           |                                          |
+| perf hooks     | ✔︎     | ⚠️           | `perf-hooks`     | `llrt_perf_hooks`     |                                          |
+| stream         | ✔︎     | ⚠️           | N/A              | `llrt_stream`         |                                          |
+| string_decoder | ✔︎     | ✔︎          | `string_decoder` | `llrt_string_decoder` |                                          |
+| timers         | ✔︎     | ✔︎          | `timers`         | `llrt_timers`         |                                          |
+| process        | ✔︎     | ✔︎          | `process`        | `llrt_process`        |                                          |
+| tty            | ✔︎     | ⚠️           | `tty`            | `llrt_tty`            |                                          |
+| url            | ✔︎     | ⚠️           | `url`            | `llrt_url`            |                                          |
+| util           | ✔︎     | ⚠️           | `util`           | `llrt_util`           |                                          |
+| zlib           | ✔︎     | ⚠️           | `zlib`           | `llrt_zlib`           | `zlib-brotli`                            |
+| Other modules  | ✔︎     | ✘            | N/A              | N/A                   |                                          |
 
 _⚠️ = partially supported_
 _⏱ = planned partial support_

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -12,13 +12,16 @@ name = "llrt_fetch"
 path = "src/lib.rs"
 
 [features]
-default = ["http1", "http2", "compression-c", "platform-roots"]
+default = ["http1", "flate2", "zstd", "platform-roots"]
+#default = ["std"]
+std = ["http1", "http2", "brotli", "flate2", "zstd", "platform-roots"]
 
 http1 = ["hyper/http1", "hyper-rustls/http1"]
 http2 = ["hyper/http2", "hyper-rustls/http2"]
 
-compression-c = ["llrt_compression/all-c"]
-compression-rust = ["llrt_compression/all-rust"]
+brotli = ["llrt_compression/brotli-c"]
+flate2 = ["llrt_compression/flate2-c"]
+zstd = ["llrt_compression/zstd-c"]
 
 platform-roots = ["hyper-rustls/rustls-platform-verifier"]
 builtin-roots = ["hyper-rustls/webpki-tokio", "webpki-roots"]

--- a/modules/llrt_fetch/src/response.rs
+++ b/modules/llrt_fetch/src/response.rs
@@ -185,6 +185,7 @@ impl<'js> Response<'js> {
             let mut data: Vec<u8> = Vec::with_capacity(bytes.len());
             match content_encoding {
                 "zstd" => llrt_compression::zstd::decoder(&bytes[..])?.read_to_end(&mut data)?,
+                #[cfg(feature = "brotli")]
                 "br" => llrt_compression::brotli::decoder(&bytes[..]).read_to_end(&mut data)?,
                 "gzip" => llrt_compression::gz::decoder(&bytes[..]).read_to_end(&mut data)?,
                 "deflate" => llrt_compression::zlib::decoder(&bytes[..]).read_to_end(&mut data)?,

--- a/modules/llrt_os/Cargo.toml
+++ b/modules/llrt_os/Cargo.toml
@@ -8,7 +8,9 @@ repository = "https://github.com/awslabs/llrt"
 readme = "README.md"
 
 [features]
-default = ["network", "statistics", "system"]
+default = []
+#default = ["std"]
+std = ["network", "statistics", "system"]
 
 network = ["sysinfo/network", "system"]
 statistics = ["system"]

--- a/modules/llrt_zlib/Cargo.toml
+++ b/modules/llrt_zlib/Cargo.toml
@@ -12,13 +12,17 @@ name = "llrt_zlib"
 path = "src/lib.rs"
 
 [features]
-default = ["compression-c"]
+default = ["zlib", "zstd"]
+#default = ["std"]
+std = ["brotli", "zlib", "zstd"]
 
-compression-c = ["llrt_compression/brotli-c", "llrt_compression/flate2-c"]
-compression-rust = [
-  "llrt_compression/brotli-rust",
-  "llrt_compression/flate2-rust",
-]
+brotli = ["llrt_compression/brotli-c"]
+zlib = ["llrt_compression/flate2-c"]
+zstd = ["llrt_compression/zstd-c"]
+
+brotli-rs = ["llrt_compression/brotli-rust"]
+zlib-rs = ["llrt_compression/flate2-rust"]
+zstd-rs = ["llrt_compression/zstd-rust"]
 
 [dependencies]
 llrt_buffer = { version = "0.5.1-beta", path = "../llrt_buffer" }

--- a/modules/llrt_zlib/src/brotli.rs
+++ b/modules/llrt_zlib/src/brotli.rs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::io::Read;
+
+use llrt_buffer::Buffer;
+use llrt_context::CtxExtension;
+use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
+use rquickjs::{
+    prelude::{Opt, Rest},
+    Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
+};
+
+use crate::{define_cb_function, define_sync_function};
+
+enum BrotliCommand {
+    Compress,
+    Decompress,
+}
+
+fn brotli_converter<'js>(
+    ctx: Ctx<'js>,
+    bytes: ObjectBytes<'js>,
+    _options: Opt<Value<'js>>,
+    command: BrotliCommand,
+) -> Result<Value<'js>> {
+    let src = bytes.as_bytes(&ctx)?;
+
+    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
+
+    let _ = match command {
+        BrotliCommand::Compress => llrt_compression::brotli::encoder(src).read_to_end(&mut dst)?,
+        BrotliCommand::Decompress => {
+            llrt_compression::brotli::decoder(src).read_to_end(&mut dst)?
+        },
+    };
+
+    Buffer(dst).into_js(&ctx)
+}
+
+define_cb_function!(br_comp, brotli_converter, BrotliCommand::Compress);
+define_sync_function!(br_comp_sync, brotli_converter, BrotliCommand::Compress);
+
+define_cb_function!(br_decomp, brotli_converter, BrotliCommand::Decompress);
+define_sync_function!(br_decomp_sync, brotli_converter, BrotliCommand::Decompress);

--- a/modules/llrt_zlib/src/lib.rs
+++ b/modules/llrt_zlib/src/lib.rs
@@ -1,22 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::io::Read;
-
-use llrt_buffer::Buffer;
-use llrt_context::CtxExtension;
-use llrt_utils::{
-    bytes::ObjectBytes,
-    module::{export_default, ModuleInfo},
-    object::ObjectExt,
-    result::ResultExt,
-};
+use llrt_utils::module::{export_default, ModuleInfo};
 use rquickjs::function::Func;
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
-    prelude::{Opt, Rest},
-    Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
+    Ctx, Result,
 };
 
+#[cfg(any(feature = "brotli", feature = "brotli-rs"))]
+mod brotli;
+#[cfg(any(feature = "brotli", feature = "brotli-rs"))]
+use crate::brotli::*;
+
+#[cfg(any(feature = "zlib", feature = "zlib-rs"))]
+mod zlib;
+#[cfg(any(feature = "zlib", feature = "zlib-rs"))]
+use crate::zlib::*;
+
+#[macro_export]
 macro_rules! define_sync_function {
     ($fn_name:ident, $converter:expr, $command:expr) => {
         pub fn $fn_name<'js>(
@@ -29,6 +30,7 @@ macro_rules! define_sync_function {
     };
 }
 
+#[macro_export]
 macro_rules! define_cb_function {
     ($fn_name:ident, $converter:expr, $command:expr) => {
         pub fn $fn_name<'js>(
@@ -63,124 +65,39 @@ macro_rules! define_cb_function {
     };
 }
 
-enum ZlibCommand {
-    Deflate,
-    DeflateRaw,
-    Gzip,
-    Inflate,
-    InflateRaw,
-    Gunzip,
-}
-
-fn zlib_converter<'js>(
-    ctx: Ctx<'js>,
-    bytes: ObjectBytes<'js>,
-    options: Opt<Value<'js>>,
-    command: ZlibCommand,
-) -> Result<Value<'js>> {
-    let src = bytes.as_bytes(&ctx)?;
-
-    let mut level = llrt_compression::zlib::Compression::default();
-    if let Some(options) = options.0 {
-        if let Some(opt) = options.get_optional("level")? {
-            level = llrt_compression::zlib::Compression::new(opt);
-        }
-    }
-
-    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
-
-    let _ = match command {
-        ZlibCommand::Deflate => {
-            llrt_compression::zlib::encoder(src, level).read_to_end(&mut dst)?
-        },
-        ZlibCommand::DeflateRaw => {
-            llrt_compression::deflate::encoder(src, level).read_to_end(&mut dst)?
-        },
-        ZlibCommand::Gzip => llrt_compression::gz::encoder(src, level).read_to_end(&mut dst)?,
-        ZlibCommand::Inflate => llrt_compression::zlib::decoder(src).read_to_end(&mut dst)?,
-        ZlibCommand::InflateRaw => llrt_compression::deflate::decoder(src).read_to_end(&mut dst)?,
-        ZlibCommand::Gunzip => llrt_compression::gz::decoder(src).read_to_end(&mut dst)?,
-    };
-
-    Buffer(dst).into_js(&ctx)
-}
-
-define_cb_function!(deflate, zlib_converter, ZlibCommand::Deflate);
-define_sync_function!(deflate_sync, zlib_converter, ZlibCommand::Deflate);
-
-define_cb_function!(deflate_raw, zlib_converter, ZlibCommand::DeflateRaw);
-define_sync_function!(deflate_raw_sync, zlib_converter, ZlibCommand::DeflateRaw);
-
-define_cb_function!(gzip, zlib_converter, ZlibCommand::Gzip);
-define_sync_function!(gzip_sync, zlib_converter, ZlibCommand::Gzip);
-
-define_cb_function!(inflate, zlib_converter, ZlibCommand::Inflate);
-define_sync_function!(inflate_sync, zlib_converter, ZlibCommand::Inflate);
-
-define_cb_function!(inflate_raw, zlib_converter, ZlibCommand::InflateRaw);
-define_sync_function!(inflate_raw_sync, zlib_converter, ZlibCommand::InflateRaw);
-
-define_cb_function!(gunzip, zlib_converter, ZlibCommand::Gunzip);
-define_sync_function!(gunzip_sync, zlib_converter, ZlibCommand::Gunzip);
-
-enum BrotliCommand {
-    Compress,
-    Decompress,
-}
-
-fn brotli_converter<'js>(
-    ctx: Ctx<'js>,
-    bytes: ObjectBytes<'js>,
-    _options: Opt<Value<'js>>,
-    command: BrotliCommand,
-) -> Result<Value<'js>> {
-    let src = bytes.as_bytes(&ctx)?;
-
-    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
-
-    let _ = match command {
-        BrotliCommand::Compress => llrt_compression::brotli::encoder(src).read_to_end(&mut dst)?,
-        BrotliCommand::Decompress => {
-            llrt_compression::brotli::decoder(src).read_to_end(&mut dst)?
-        },
-    };
-
-    Buffer(dst).into_js(&ctx)
-}
-
-define_cb_function!(br_comp, brotli_converter, BrotliCommand::Compress);
-define_sync_function!(br_comp_sync, brotli_converter, BrotliCommand::Compress);
-
-define_cb_function!(br_decomp, brotli_converter, BrotliCommand::Decompress);
-define_sync_function!(br_decomp_sync, brotli_converter, BrotliCommand::Decompress);
-
 pub struct ZlibModule;
 
 impl ModuleDef for ZlibModule {
     fn declare(declare: &Declarations) -> Result<()> {
-        declare.declare("deflate")?;
-        declare.declare("deflateSync")?;
+        #[cfg(any(feature = "zlib", feature = "zlib-rs"))]
+        {
+            declare.declare("deflate")?;
+            declare.declare("deflateSync")?;
 
-        declare.declare("deflateRaw")?;
-        declare.declare("deflateRawSync")?;
+            declare.declare("deflateRaw")?;
+            declare.declare("deflateRawSync")?;
 
-        declare.declare("gzip")?;
-        declare.declare("gzipSync")?;
+            declare.declare("gzip")?;
+            declare.declare("gzipSync")?;
 
-        declare.declare("inflate")?;
-        declare.declare("inflateSync")?;
+            declare.declare("inflate")?;
+            declare.declare("inflateSync")?;
 
-        declare.declare("inflateRaw")?;
-        declare.declare("inflateRawSync")?;
+            declare.declare("inflateRaw")?;
+            declare.declare("inflateRawSync")?;
 
-        declare.declare("gunzip")?;
-        declare.declare("gunzipSync")?;
+            declare.declare("gunzip")?;
+            declare.declare("gunzipSync")?;
+        }
 
-        declare.declare("brotliCompress")?;
-        declare.declare("brotliCompressSync")?;
+        #[cfg(any(feature = "brotli", feature = "brotli-rs"))]
+        {
+            declare.declare("brotliCompress")?;
+            declare.declare("brotliCompressSync")?;
 
-        declare.declare("brotliDecompress")?;
-        declare.declare("brotliDecompressSync")?;
+            declare.declare("brotliDecompress")?;
+            declare.declare("brotliDecompressSync")?;
+        }
 
         declare.declare("default")?;
         Ok(())
@@ -188,29 +105,35 @@ impl ModuleDef for ZlibModule {
 
     fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
         export_default(ctx, exports, |default| {
-            default.set("deflate", Func::from(deflate))?;
-            default.set("deflateSync", Func::from(deflate_sync))?;
+            #[cfg(any(feature = "zlib", feature = "zlib-rs"))]
+            {
+                default.set("deflate", Func::from(deflate))?;
+                default.set("deflateSync", Func::from(deflate_sync))?;
 
-            default.set("deflateRaw", Func::from(deflate_raw))?;
-            default.set("deflateRawSync", Func::from(deflate_raw_sync))?;
+                default.set("deflateRaw", Func::from(deflate_raw))?;
+                default.set("deflateRawSync", Func::from(deflate_raw_sync))?;
 
-            default.set("gzip", Func::from(gzip))?;
-            default.set("gzipSync", Func::from(gzip_sync))?;
+                default.set("gzip", Func::from(gzip))?;
+                default.set("gzipSync", Func::from(gzip_sync))?;
 
-            default.set("inflate", Func::from(inflate))?;
-            default.set("inflateSync", Func::from(inflate_sync))?;
+                default.set("inflate", Func::from(inflate))?;
+                default.set("inflateSync", Func::from(inflate_sync))?;
 
-            default.set("inflateRaw", Func::from(inflate_raw))?;
-            default.set("inflateRawSync", Func::from(inflate_raw_sync))?;
+                default.set("inflateRaw", Func::from(inflate_raw))?;
+                default.set("inflateRawSync", Func::from(inflate_raw_sync))?;
 
-            default.set("gunzip", Func::from(gunzip))?;
-            default.set("gunzipSync", Func::from(gunzip_sync))?;
+                default.set("gunzip", Func::from(gunzip))?;
+                default.set("gunzipSync", Func::from(gunzip_sync))?;
+            }
 
-            default.set("brotliCompress", Func::from(br_comp))?;
-            default.set("brotliCompressSync", Func::from(br_comp_sync))?;
+            #[cfg(any(feature = "brotli", feature = "brotli-rs"))]
+            {
+                default.set("brotliCompress", Func::from(br_comp))?;
+                default.set("brotliCompressSync", Func::from(br_comp_sync))?;
 
-            default.set("brotliDecompress", Func::from(br_decomp))?;
-            default.set("brotliDecompressSync", Func::from(br_decomp_sync))?;
+                default.set("brotliDecompress", Func::from(br_decomp))?;
+                default.set("brotliDecompressSync", Func::from(br_decomp_sync))?;
+            }
 
             Ok(())
         })

--- a/modules/llrt_zlib/src/zlib.rs
+++ b/modules/llrt_zlib/src/zlib.rs
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::io::Read;
+
+use llrt_buffer::Buffer;
+use llrt_context::CtxExtension;
+use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
+use rquickjs::{
+    prelude::{Opt, Rest},
+    Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
+};
+
+use crate::{define_cb_function, define_sync_function};
+
+enum ZlibCommand {
+    Deflate,
+    DeflateRaw,
+    Gzip,
+    Inflate,
+    InflateRaw,
+    Gunzip,
+}
+
+fn zlib_converter<'js>(
+    ctx: Ctx<'js>,
+    bytes: ObjectBytes<'js>,
+    options: Opt<Value<'js>>,
+    command: ZlibCommand,
+) -> Result<Value<'js>> {
+    let src = bytes.as_bytes(&ctx)?;
+
+    let mut level = llrt_compression::zlib::Compression::default();
+    if let Some(options) = options.0 {
+        if let Some(opt) = options.get_optional("level")? {
+            level = llrt_compression::zlib::Compression::new(opt);
+        }
+    }
+
+    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
+
+    let _ = match command {
+        ZlibCommand::Deflate => {
+            llrt_compression::zlib::encoder(src, level).read_to_end(&mut dst)?
+        },
+        ZlibCommand::DeflateRaw => {
+            llrt_compression::deflate::encoder(src, level).read_to_end(&mut dst)?
+        },
+        ZlibCommand::Gzip => llrt_compression::gz::encoder(src, level).read_to_end(&mut dst)?,
+        ZlibCommand::Inflate => llrt_compression::zlib::decoder(src).read_to_end(&mut dst)?,
+        ZlibCommand::InflateRaw => llrt_compression::deflate::decoder(src).read_to_end(&mut dst)?,
+        ZlibCommand::Gunzip => llrt_compression::gz::decoder(src).read_to_end(&mut dst)?,
+    };
+
+    Buffer(dst).into_js(&ctx)
+}
+
+define_cb_function!(deflate, zlib_converter, ZlibCommand::Deflate);
+define_sync_function!(deflate_sync, zlib_converter, ZlibCommand::Deflate);
+
+define_cb_function!(deflate_raw, zlib_converter, ZlibCommand::DeflateRaw);
+define_sync_function!(deflate_raw_sync, zlib_converter, ZlibCommand::DeflateRaw);
+
+define_cb_function!(gzip, zlib_converter, ZlibCommand::Gzip);
+define_sync_function!(gzip_sync, zlib_converter, ZlibCommand::Gzip);
+
+define_cb_function!(inflate, zlib_converter, ZlibCommand::Inflate);
+define_sync_function!(inflate_sync, zlib_converter, ZlibCommand::Inflate);
+
+define_cb_function!(inflate_raw, zlib_converter, ZlibCommand::InflateRaw);
+define_sync_function!(inflate_raw_sync, zlib_converter, ZlibCommand::InflateRaw);
+
+define_cb_function!(gunzip, zlib_converter, ZlibCommand::Gunzip);
+define_sync_function!(gunzip_sync, zlib_converter, ZlibCommand::Gunzip);

--- a/tests/unit/zlib.test.ts
+++ b/tests/unit/zlib.test.ts
@@ -50,7 +50,13 @@ describe("gzip/gunzip", () => {
 });
 
 describe("brotli", () => {
-  it("brotliCompress/brotliDecompress", (done) => {
+  const hasBrotli =
+    typeof zlib?.brotliCompress === "function" &&
+    typeof zlib?.brotliDecompress === "function" &&
+    typeof zlib?.brotliCompressSync === "function" &&
+    typeof zlib?.brotliDecompressSync === "function";
+
+  (hasBrotli ? it : it.skip)("brotliCompress/brotliDecompress", (done) => {
     zlib.brotliCompress(data, (err, compressed) => {
       zlib.brotliDecompress(compressed, (err, decompressed) => {
         expect(data).toEqual(decompressed.toString());
@@ -58,7 +64,7 @@ describe("brotli", () => {
       });
     });
   });
-  it("brotliCompressSync/brotliDecompressSync", () => {
+  (hasBrotli ? it : it.skip)("brotliCompressSync/brotliDecompressSync", () => {
     const compressed = zlib.brotliCompressSync(data);
     const decompressed = zlib.brotliDecompressSync(compressed);
     expect(data).toEqual(decompressed.toString());


### PR DESCRIPTION
### Issue # (if available)

Closed: #1007

### Description of changes

When building llrt, some crates' large or less important features are optional. Optional features can be enabled by including the following in the features section of llrt_modules.

- fetch-brotli
- fetch-http2
- os-network
- os-statistics
- os-system
- zlib-brotli

By having these features disabled by default, binary sizes are further reduced.

before(full-sdk):
```
% du -k ./target/aarch64-apple-darwin/release/llrt
10492   ./target/aarch64-apple-darwin/release/llrt

% cargo bloat --profile=flame --crates

 File  .text     Size Crate
13.6%  20.8%   1.4MiB rquickjs_core
11.1%  16.9%   1.2MiB [Unknown]
 7.4%  11.2% 795.0KiB std
 3.3%   5.0% 353.6KiB h2
 3.1%   4.8% 339.6KiB llrt_stream_web
 2.4%   3.7% 260.3KiB rustls
 2.0%   3.1% 217.7KiB zstd_sys
 1.7%   2.7% 188.9KiB tokio
 1.4%   2.1% 147.9KiB ring
 1.3%   2.0% 141.0KiB llrt_crypto
 1.2%   1.8% 124.7KiB hyper
 1.1%   1.7% 117.0KiB llrt_core
 1.0%   1.6% 112.9KiB hyper_util
 0.9%   1.4% 100.7KiB rquickjs_sys
 0.9%   1.3%  92.0KiB brotlic_sys
 0.8%   1.2%  83.6KiB llrt
 0.6%   1.0%  67.3KiB num_bigint_dig
 0.6%   0.9%  66.8KiB primeorder
 0.6%   0.9%  63.2KiB llrt_utils
 0.6%   0.9%  61.0KiB http
10.2%  15.6%   1.1MiB And 120 more crates. Use -n N to show more.
65.4% 100.0%   6.9MiB .text section size, the file size is 10.5MiB
```

after(full-sdk):
```
% du -k ./target/aarch64-apple-darwin/release/llrt
9004    ./target/aarch64-apple-darwin/release/llrt

% cargo bloat --profile=flame --crates

 File  .text     Size Crate
16.1%  23.4%   1.4MiB rquickjs_core
10.7%  15.6% 963.7KiB [Unknown]
 8.2%  12.0% 740.6KiB std
 3.8%   5.5% 339.6KiB llrt_stream_web
 2.8%   4.1% 254.0KiB rustls
 2.4%   3.5% 217.7KiB zstd_sys
 2.1%   3.0% 187.1KiB tokio
 1.6%   2.4% 147.9KiB ring
 1.6%   2.3% 141.2KiB llrt_crypto
 1.2%   1.8% 111.3KiB llrt_core
 1.1%   1.6% 100.7KiB rquickjs_sys
 1.1%   1.6%  97.4KiB hyper
 1.0%   1.5%  91.3KiB hyper_util
 0.9%   1.3%  82.8KiB llrt
 0.7%   1.1%  67.2KiB num_bigint_dig
 0.7%   1.1%  66.8KiB primeorder
 0.7%   1.0%  63.0KiB llrt_utils
 0.6%   0.9%  54.6KiB llrt_fetch
 0.6%   0.8%  51.8KiB der
 0.6%   0.8%  50.0KiB url
10.4%  15.2% 938.3KiB And 118 more crates. Use -n N to show more.
68.7% 100.0%   6.0MiB .text section size, the file size is 8.8MiB
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
