### PR TITLE
fix(core): fix incompatibilities caused by the latest cargo fix

### DIFF
--- a/libs/llrt_logging/src/lib.rs
+++ b/libs/llrt_logging/src/lib.rs
@@ -856,21 +856,21 @@ pub fn print_error_and_exit<'js>(ctx: &Ctx<'js>, err: CaughtError<'js>) -> ! {
     use std::fmt::Write;
 
     let mut error_str = String::new();
-    write!(error_str, "Error: {:?}", err).unwrap();
+    write!(error_str, "Error: {err:?}").unwrap();
 
     if let Ok(error) = err.into_value(ctx) {
         if print_error(ctx, Rest(vec![error.clone()])).is_err() {
-            eprintln!("{}", error_str);
+            eprintln!("{error_str}");
         };
         if cfg!(test) {
-            panic!("{:?}", error);
+            panic!("{error:?}");
         } else {
             exit(1)
         }
     } else if cfg!(test) {
         panic!("{}", error_str);
     } else {
-        eprintln!("{}", error_str);
+        eprintln!("{error_str}");
         exit(1)
     };
 }

--- a/libs/llrt_utils/src/result.rs
+++ b/libs/llrt_utils/src/result.rs
@@ -27,7 +27,7 @@ impl<T, E: std::fmt::Display> ResultExt<T> for StdResult<T, E> {
             let mut message = String::with_capacity(100);
             message.push_str(msg);
             message.push_str(". ");
-            write!(message, "{}", e).unwrap();
+            write!(message, "{e}").unwrap();
             Exception::throw_message(ctx, &message)
         })
     }
@@ -39,7 +39,7 @@ impl<T, E: std::fmt::Display> ResultExt<T> for StdResult<T, E> {
                 message.push_str(msg);
                 message.push_str(". ");
             }
-            write!(message, "{}", e).unwrap();
+            write!(message, "{e}").unwrap();
             Exception::throw_range(ctx, &message)
         })
     }
@@ -51,7 +51,7 @@ impl<T, E: std::fmt::Display> ResultExt<T> for StdResult<T, E> {
                 message.push_str(msg);
                 message.push_str(". ");
             }
-            write!(message, "{}", e).unwrap();
+            write!(message, "{e}").unwrap();
             Exception::throw_type(ctx, &message)
         })
     }

--- a/llrt/src/main.rs
+++ b/llrt/src/main.rs
@@ -180,14 +180,14 @@ async fn start_cli(vm: &Vm) {
                     if file_exists {
                         return vm.run_file(arg, true, global).await;
                     } else {
-                        eprintln!("No such file: {}", arg);
+                        eprintln!("No such file: {arg}");
                         exit(1);
                     }
                 } else {
                     if file_exists {
                         return vm.run_file(arg, true, false).await;
                     }
-                    eprintln!("Unknown command: {}", arg);
+                    eprintln!("Unknown command: {arg}");
                     usage();
                     exit(1);
                 }

--- a/llrt/src/repl.rs
+++ b/llrt/src/repl.rs
@@ -115,7 +115,7 @@ pub(crate) async fn run_repl(ctx: &AsyncContext) {
                 stdout(),
                 cursor::MoveToColumn(0),
                 Clear(ClearType::CurrentLine),
-                Print(format!("> {}", current_input)),
+                Print(format!("> {current_input}")),
                 cursor::MoveToColumn(cursor_pos as u16 + 2)
             )?;
 

--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -75,7 +75,7 @@ fn generate_sdk_client_endpoint_map(out_dir: &str) -> StdResult<(), Box<dyn Erro
                 if package_name == sdks_to_init {
                     ph_map.entry(package_name, r#""""#);
                 } else {
-                    ph_map.entry(package_name, format!("\"{}\"", sdks_to_init));
+                    ph_map.entry(package_name, format!("\"{sdks_to_init}\""));
                 }
             }
         }
@@ -166,7 +166,7 @@ fn generate_bytecode_cache(out_dir: &str) -> StdResult<(), Box<dyn Error>> {
             .map_err(|err| match err {
                 CaughtError::Error(error) => error.to_string(),
                 CaughtError::Exception(ex) => ex.to_string(),
-                CaughtError::Value(value) => format!("{:?}", value),
+                CaughtError::Value(value) => format!("{value:?}"),
             })?;
 
             total_bytes += bytes.len();

--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -198,7 +198,7 @@ fn write_lambda_log<'js>(
         result.push('{');
         //time
         result.push_str("\"time\":\"");
-        write!(result, "{}", formatted_time).unwrap();
+        write!(result, "{formatted_time}").unwrap();
         result.push_str("\",");
 
         //request id
@@ -213,7 +213,7 @@ fn write_lambda_log<'js>(
         result.push_str(&level.to_string());
         result.push('\"');
     } else {
-        write!(result, "{}", formatted_time).unwrap();
+        write!(result, "{formatted_time}").unwrap();
         result.push('\t');
 
         match request_id.as_ref() {

--- a/llrt_core/src/modules/llrt/xml.rs
+++ b/llrt_core/src/modules/llrt/xml.rs
@@ -500,7 +500,7 @@ impl<'js> XmlNode<'js> {
                                 let string_value = child
                                     .clone()
                                     .try_into_string()
-                                    .map_err(|err| format!("Unable to convert {:?} to string", err))
+                                    .map_err(|err| format!("Unable to convert {err:?} to string"))
                                     .or_throw(&ctx)?
                                     .to_string()?;
                                 xml_text.push_str(&string_value);

--- a/llrt_core/src/runtime_client.rs
+++ b/llrt_core/src/runtime_client.rs
@@ -610,8 +610,7 @@ mod tests {
 
         Mock::given(matchers::method("GET"))
             .and(matchers::path(format!(
-                "{}/invocation/next",
-                ENV_RUNTIME_PATH
+                "{ENV_RUNTIME_PATH}/invocation/next"
             )))
             .respond_with(
                 ResponseTemplate::new(200)
@@ -643,7 +642,7 @@ mod tests {
         let vm = Vm::new().await.unwrap();
 
         async fn run_with_handler(vm: &Vm, handler: &str, runtime_api: &str) {
-            println!("Testing {}", handler);
+            println!("Testing {handler}");
             let mock_config = RuntimeConfig {
                 runtime_api: runtime_api.into(),
                 handler: handler.into(),

--- a/modules/llrt_buffer/src/array_buffer_view.rs
+++ b/modules/llrt_buffer/src/array_buffer_view.rs
@@ -148,7 +148,7 @@ impl<'js> ArrayBufferView<'js> {
     /// # Safety
     /// This is only safe if you have a lock on the runtime.
     /// Do not pass it directly to other threads.
-    pub fn as_bytes_mut(&self) -> Option<&mut [u8]> {
+    pub fn as_bytes_mut(&mut self) -> Option<&mut [u8]> {
         self.buffer
             .as_ref()
             .map(|b| unsafe { std::slice::from_raw_parts_mut(b.ptr.as_ptr(), b.len) })

--- a/modules/llrt_child_process/src/lib.rs
+++ b/modules/llrt_child_process/src/lib.rs
@@ -330,7 +330,7 @@ impl<'js> ChildProcess<'js> {
             Err(err) => {
                 let ctx3 = ctx.clone();
 
-                let err_message = format!("Child process failed to spawn \"{}\". {}", command, err);
+                let err_message = format!("Child process failed to spawn \"{command}\". {err}");
 
                 ctx.spawn_exit(async move {
                     if !instance3.borrow().emitter.has_listener_str("error") {
@@ -578,10 +578,7 @@ fn str_to_stdio(ctx: &Ctx<'_>, input: &str) -> Result<StdioEnum> {
         "inherit" => Ok(StdioEnum::Inherit),
         _ => Err(Exception::throw_type(
             ctx,
-            &format!(
-                "Invalid stdio \"{}\". Expected one of: pipe, ignore, inherit",
-                input
-            ),
+            &format!("Invalid stdio \"{input}\". Expected one of: pipe, ignore, inherit"),
         )),
     }
 }

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -372,10 +372,7 @@ impl KeyAlgorithm {
                 if !matches!(length, 128 | 192 | 256) {
                     return Err(Exception::throw_message(
                         ctx,
-                        &format!(
-                            "Algorithm 'length' must be one of: 128, 192, or 256 = {}",
-                            length
-                        ),
+                        &format!("Algorithm 'length' must be one of: 128, 192, or 256 = {length}"),
                     ));
                 }
 

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -588,10 +588,7 @@ mod tests {
                     assert_eq!(
                         value,
                         expected,
-                        "normalize_header_value_inplace failed: input = {:?}, expected = {:?}, got = {:?}",
-                        input,
-                        expected,
-                        value
+                        "normalize_header_value_inplace failed: input = {input:?}, expected = {expected:?}, got = {value:?}"
                     );
                 }
             })

--- a/modules/llrt_fs/src/file_handle.rs
+++ b/modules/llrt_fs/src/file_handle.rs
@@ -136,7 +136,7 @@ impl FileHandle {
             None => ReadOptions::default(),
         };
 
-        let buffer = options_1
+        let mut buffer = options_1
             .buffer
             .or(options_2.buffer)
             .unwrap_or_else_ok(|| {
@@ -396,7 +396,7 @@ fn validate_length_offset(
     if offset > buffer_length {
         return Err(Exception::throw_range(
             ctx,
-            &format!("offset ({}) <= {}", offset, buffer_length),
+            &format!("offset ({offset}) <= {buffer_length}"),
         ));
     }
     if length > buffer_length - offset {

--- a/modules/llrt_net/src/server.rs
+++ b/modules/llrt_net/src/server.rs
@@ -402,7 +402,7 @@ mod tests {
     async fn call_tcp(port: u16) {
         // Connect to server
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
+        let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))
             .await
             .unwrap();
         stream.set_nodelay(true).unwrap();

--- a/modules/llrt_os/src/lib.rs
+++ b/modules/llrt_os/src/lib.rs
@@ -201,13 +201,12 @@ mod tests {
             "test",
             &format!(
                 r#"
-                    import {{ {} }} from 'os';
+                    import {{ {name} }} from 'os';
 
                     export async function test() {{
-                        return {}{}
+                        return {name}{brackets}
                     }}
-                "#,
-                name, name, brackets
+                "#
             ),
         )
         .await
@@ -227,13 +226,12 @@ mod tests {
             "test",
             &format!(
                 r#"
-                    import {{ {} }} from 'os';
+                    import {{ {name} }} from 'os';
 
                     export async function test() {{
-                        return {}()
+                        return {name}()
                     }}
-                "#,
-                name, name
+                "#
             ),
         )
         .await

--- a/modules/llrt_path/benches/slash_replacement.rs
+++ b/modules/llrt_path/benches/slash_replacement.rs
@@ -125,7 +125,7 @@ fn generate_random_path() -> String {
     for _ in 0..depth {
         let name = WORD_LIST.choose(&mut rng).unwrap();
         if rng.gen_bool(PATH_STYLE_PROB) {
-            path.push(format!("{}\\", name));
+            path.push(format!("{name}\\"));
         } else {
             path.push(name);
         }

--- a/modules/llrt_url/src/url_class.rs
+++ b/modules/llrt_url/src/url_class.rs
@@ -62,12 +62,12 @@ impl<'js> URL<'js> {
             if let Some(base) = base.as_string() {
                 if let Ok(base) = base.to_string() {
                     let mut url: Url = base.parse().map_err(|err| {
-                        Exception::throw_type(&ctx, format!("Invalid base URL: {}", err).as_str())
+                        Exception::throw_type(&ctx, format!("Invalid base URL: {err}").as_str())
                     })?;
 
                     if let Ok(input) = input {
                         url = url.join(input.as_str()).map_err(|err| {
-                            Exception::throw_type(&ctx, format!("Invalid URL: {}", err).as_str())
+                            Exception::throw_type(&ctx, format!("Invalid URL: {err}").as_str())
                         })?;
                     }
 


### PR DESCRIPTION
### Description of changes

After applying the latest rust toolchain, we found new incompatibilities and have fixed them.

```
% rustup update
info: syncing channel updates for 'stable-aarch64-apple-darwin'
info: syncing channel updates for 'nightly-aarch64-apple-darwin'
info: checking for self-update

   stable-aarch64-apple-darwin unchanged - rustc 1.88.0 (6b00bc388 2025-06-23)
  nightly-aarch64-apple-darwin unchanged - rustc 1.90.0-nightly (bdaba05a9 2025-06-27)
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
