### PR TITLE
Add process.env types to process.d.ts

### DIFF
--- a/types/process.d.ts
+++ b/types/process.d.ts
@@ -375,5 +375,90 @@ declare module "process" {
      * @param id A group name or ID
      */
     setegid?: (id: number) => void;
+    /**
+     * The `process.env` property returns an object containing the user environment.
+     * See [`environ(7)`](http://man7.org/linux/man-pages/man7/environ.7.html).
+     *
+     * An example of this object looks like:
+     *
+     * ```js
+     * {
+     *   TERM: 'xterm-256color',
+     *   SHELL: '/usr/local/bin/bash',
+     *   USER: 'maciej',
+     *   PATH: '~/.bin/:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin',
+     *   PWD: '/Users/maciej',
+     *   EDITOR: 'vim',
+     *   SHLVL: '1',
+     *   HOME: '/Users/maciej',
+     *   LOGNAME: 'maciej',
+     *   _: '/usr/local/bin/node'
+     * }
+     * ```
+     *
+     * It is possible to modify this object, but such modifications will not be
+     * reflected outside the Node.js process, or (unless explicitly requested)
+     * to other `Worker` threads.
+     * In other words, the following example would not work:
+     *
+     * ```bash
+     * node -e 'process.env.foo = "bar"' &#x26;&#x26; echo $foo
+     * ```
+     *
+     * While the following will:
+     *
+     * ```js
+     * import { env } from 'node:process';
+     *
+     * env.foo = 'bar';
+     * console.log(env.foo);
+     * ```
+     *
+     * Assigning a property on `process.env` will implicitly convert the value
+     * to a string. **This behavior is deprecated.** Future versions of Node.js may
+     * throw an error when the value is not a string, number, or boolean.
+     *
+     * ```js
+     * import { env } from 'node:process';
+     *
+     * env.test = null;
+     * console.log(env.test);
+     * // => 'null'
+     * env.test = undefined;
+     * console.log(env.test);
+     * // => 'undefined'
+     * ```
+     *
+     * Use `delete` to delete a property from `process.env`.
+     *
+     * ```js
+     * import { env } from 'node:process';
+     *
+     * env.TEST = 1;
+     * delete env.TEST;
+     * console.log(env.TEST);
+     * // => undefined
+     * ```
+     *
+     * On Windows operating systems, environment variables are case-insensitive.
+     *
+     * ```js
+     * import { env } from 'node:process';
+     *
+     * env.TEST = 1;
+     * console.log(env.test);
+     * // => 1
+     * ```
+     *
+     * Unless explicitly specified when creating a `Worker` instance,
+     * each `Worker` thread has its own copy of `process.env`, based on its
+     * parent thread's `process.env`, or whatever was specified as the `env` option
+     * to the `Worker` constructor. Changes to `process.env` will not be visible
+     * across `Worker` threads, and only the main thread can make changes that
+     * are visible to the operating system or to native add-ons. On Windows, a copy of `process.env` on a `Worker` instance operates in a case-sensitive manner
+     * unlike the main thread.
+     * @since v0.1.27
+     */
+    env: ProcessEnv;
   }
 }


### PR DESCRIPTION
### Description of changes

Adds the env property to the process.d.ts type definition.

This allows TypeScript users to access process.env without encountering type errors.
