### PR TITLE
fix(fetch): Improve Headers/Request/Response class conformance to Fetch standards

### DIFF
--- a/modules/llrt_fetch/src/response.rs
+++ b/modules/llrt_fetch/src/response.rs
@@ -16,7 +16,7 @@ use hyper::{
 use llrt_abort::AbortSignal;
 use llrt_context::CtxExtension;
 use llrt_json::parse::json_parse;
-use llrt_url::url_class::URL;
+use llrt_url::{url_class::URL, url_search_params::URLSearchParams};
 use llrt_utils::bytes::ObjectBytes;
 use llrt_utils::{mc_oneshot, result::ResultExt};
 use once_cell::sync::Lazy;
@@ -24,8 +24,8 @@ use rquickjs::{
     atom::PredefinedAtom,
     class::{Trace, Tracer},
     function::Opt,
-    ArrayBuffer, Class, Coerced, Ctx, Exception, JsLifetime, Null, Object, Result, TypedArray,
-    Value,
+    ArrayBuffer, Class, Coerced, Ctx, Exception, IntoJs, JsLifetime, Null, Object, Result,
+    TypedArray, Value,
 };
 use tokio::select;
 
@@ -275,19 +275,41 @@ impl<'js> Response<'js> {
             }
         }
 
-        let headers = Class::instance(ctx.clone(), headers.unwrap_or_default())?;
-        let content_encoding = headers.get("content-encoding")?;
+        let mut content_type: Option<String> = None;
 
         let body = body
             .0
             .and_then(|body| {
                 if body.is_null() || body.is_undefined() {
                     None
+                } else if let Some(blob) = body.as_object().and_then(Class::<Blob>::from_object) {
+                    let blob = blob.borrow();
+                    if !blob.mime_type().is_empty() {
+                        content_type = Some(blob.mime_type());
+                    }
+                    Some(BodyVariant::Provided(Some(body)))
+                } else if body
+                    .as_object()
+                    .and_then(Class::<URLSearchParams>::from_object)
+                    .is_some()
+                {
+                    content_type = Some("application/x-www-form-urlencoded;charset=UTF-8".into());
+                    Some(BodyVariant::Provided(Some(body)))
                 } else {
                     Some(BodyVariant::Provided(Some(body)))
                 }
             })
             .unwrap_or_else(|| BodyVariant::Empty);
+
+        let mut headers = headers.unwrap_or_default();
+        if !headers.has(ctx.clone(), "content-type".into())? {
+            if let Some(value) = content_type {
+                headers.set(ctx.clone(), "content-type".into(), value.into_js(&ctx)?)?;
+            }
+        }
+        let headers = Class::instance(ctx.clone(), headers)?;
+
+        let content_encoding = headers.get("content-encoding")?;
 
         Ok(Self {
             body: RwLock::new(body),
@@ -396,15 +418,16 @@ impl<'js> Response<'js> {
     }
 
     async fn blob(&self, ctx: Ctx<'js>) -> Result<Blob> {
+        let headers =
+            Headers::from_value(&ctx, self.headers().as_value().clone(), HeadersGuard::None)?;
+        let mime_type = headers
+            .iter()
+            .find_map(|(k, v)| (k == "content-type").then(|| v.to_string()));
+
         if let Some(bytes) = self.take_bytes(&ctx).await? {
-            let headers =
-                Headers::from_value(&ctx, self.headers().as_value().clone(), HeadersGuard::None)?;
-            let mime_type = headers
-                .iter()
-                .find_map(|(k, v)| (k == "content-type").then(|| v.to_string()));
             return Ok(Blob::from_bytes(bytes, mime_type));
         }
-        Ok(Blob::from_bytes(Vec::<u8>::new(), None))
+        Ok(Blob::from_bytes(Vec::<u8>::new(), mime_type))
     }
 
     pub(crate) fn clone(&self, ctx: Ctx<'js>) -> Result<Self> {

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -304,7 +304,7 @@ describe("Request class", () => {
     });
     expect(await request.text()).toEqual("Hello, world!");
     expect((await request.blob()).size).toEqual(blob.size);
-    expect((await request.blob()).type).toEqual("");
+    expect((await request.blob()).type).toEqual("text/plain");
   });
 
   it("should set the body to a Blob if Blob and content-type are provided", async () => {

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -176,9 +176,6 @@ Error: [UTF-8 with BOM with Request.text()] assert_equals: Request.text() should
 fetch/api/body > should pass formdata.any.js tests
 Error: [Consume empty response.formData() as FormData] promise_test: Unhandled rejection with value: object "ReferenceError: FormData is not defined"
 
-fetch/api/body > should pass mime-type.any.js tests
-Error: [Request: overriding explicit Content-Type] assert_equals: expected "test/test" but got ""
-
 
 🧪/wpt/fetch.api.headers.test.js 
 fetch/api/headers > should pass header-setcookie.any.js tests
@@ -212,7 +209,7 @@ fetch/api/request > should pass request-headers.any.js tests
 Error: [Adding invalid request header "Accept-Charset: KO"] assert_equals: expected (object) null but got (string) "KO"
 
 fetch/api/request > should pass request-init-contenttype.any.js tests
-Error: [Default Content-Type for Request with Blob body (set type)] assert_equals: expected (string) "a/b; c=d" but got (object) null
+Error: [Default Content-Type for Request with FormData body] promise_test: Unhandled rejection with value: object "ReferenceError: FormData is not defined"
 
 fetch/api/request > should pass request-init-priority.any.js tests
 Error: [new Request() throws a TypeError if any of RequestInit's members' values are invalid] assert_throws_js: a new Request() must throw a TypeError if RequestInit's priority is an invalid value function "() => {
@@ -258,7 +255,7 @@ fetch/api/response > should pass response-init-001.any.js tests
 Error: [Check default value for type attribute] assert_equals: Expect default response.type is default expected "default" but got "basic"
 
 fetch/api/response > should pass response-init-contenttype.any.js tests
-Error: [Default Content-Type for Response with Blob body (set type)] assert_equals: expected (string) "a/b; c=d" but got (object) null
+Error: [Default Content-Type for Response with FormData body] promise_test: Unhandled rejection with value: object "ReferenceError: FormData is not defined"
 
 fetch/api/response > should pass response-static-error.any.js tests
 Error: [the 'guard' of the Headers instance should be immutable] assert_throws_js: function "function () { headers.append('name', 'value'); }" did not throw


### PR DESCRIPTION
### Description of changes

Improved Fetch standard conformance for `Headers`, `Request` and `Response` objects.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
