### PR TITLE
fix(buffers): improve FileAPI standards compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,10 +1676,12 @@ dependencies = [
 name = "llrt_buffer"
 version = "0.6.0-beta"
 dependencies = [
+ "itoa",
  "llrt_encoding",
  "llrt_test",
  "llrt_utils",
  "rquickjs",
+ "ryu",
  "tokio",
 ]
 

--- a/modules/llrt_buffer/Cargo.toml
+++ b/modules/llrt_buffer/Cargo.toml
@@ -11,12 +11,14 @@ name = "llrt_buffer"
 path = "src/lib.rs"
 
 [dependencies]
+itoa = { version = "1", default-features = false }
 llrt_encoding = { version = "0.6.0-beta", path = "../../libs/llrt_encoding" }
 llrt_utils = { version = "0.6.0-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "futures",
   "macro",
 ], default-features = false }
+ryu = { version = "1", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -5,25 +5,8 @@ Error: [Blob.arrayBuffer()] promise_test: Unhandled rejection with value: object
 FileAPI/blob > should pass Blob-bytes.any.js tests
 Error: [Blob.bytes()] promise_test: Unhandled rejection with value: object "ReferenceError: assert_true is not defined"
 
-FileAPI/blob > should pass Blob-slice-overflow.any.js tests
-undefined: undefined
-
------ LAST STDERR: -----
-
-thread 'main' panicked at modules/llrt_buffer/src/blob.rs:115:30:
-slice index starts at 2001 but ends at 2000
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
 FileAPI/blob > should pass Blob-stream.any.js tests
 Error: [Blob.stream()] promise_test: Unhandled rejection with value: object "TypeError: not a function"
-
-FileAPI/blob > should pass Blob-text.any.js tests
-Error: [Blob.text() non-unicode] assert_equals: expected "å" but got "97,204,138"
-
-
-🧪/wpt/FileAPI.file.test.js 
-FileAPI/file > should pass File-constructor.any.js tests
-Error: [Empty File fileBits] assert_equals: expected 0 but got 13
 
 
 🧪/wpt/WebCryptoAPI.digest.test.js 
@@ -320,22 +303,8 @@ Error: [tee() should not call Promise.prototype.then()] patched then() called
 
 
 🧪/wpt/streams.writable-streams.test.js 
-streams/writable-streams > should pass aborting.any.js tests
-undefined: undefined
-
------ LAST STDERR: -----
-
-thread 'main' panicked at /Users/shinya/Workspaces/llrt/libs/llrt_utils/src/primordials.rs:58:35:
-called `Option::unwrap()` on a `None` value
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-thread 'main' panicked at /Users/shinya/Workspaces/llrt/libs/llrt_utils/src/primordials.rs:58:35:
-called `Option::unwrap()` on a `None` value
-
-streams/writable-streams > should pass bad-strategies.any.js tests
-Error: Test timed out after 5000ms
-    at tick (llrt:test/index:480:15)
-    at <anonymous> (llrt:test/index:160:12)
+streams/writable-streams > should pass general.any.js tests
+Error: [WritableStream's strategy.size should not be called as a method] promise_test: Unhandled rejection with value: object "Error: size called as a method"
 
 
 🧪/wpt/url.test.js 


### PR DESCRIPTION
### Description of changes

- Fixed WPTs test failures for File/Blob objects.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
