### PR TITLE
fix: `.toString()` for `NaN`, `Infinity`, and floats

### DIFF
--- a/libs/llrt_logging/src/lib.rs
+++ b/libs/llrt_logging/src/lib.rs
@@ -363,8 +363,7 @@ fn format_raw_inner<'js>(
             if color_enabled {
                 Color::YELLOW.push(result);
             }
-            let mut buffer = ryu::Buffer::new();
-            result.push_str(float_to_string(&mut buffer, unsafe {
+            result.push_str(&float_to_string(unsafe {
                 value.as_float().unwrap_unchecked()
             }));
         },

--- a/tests/unit/numbers.test.ts
+++ b/tests/unit/numbers.test.ts
@@ -3,21 +3,39 @@ describe("Number to base conversion within 32-bit range", () => {
     { num: 0, radix: 2, expected: "0" },
     { num: 1, radix: 2, expected: "1" },
     { num: -1, radix: 2, expected: "-1" },
+    { num: NaN, radix: 2, expected: "NaN" },
+    { num: Infinity, radix: 2, expected: "Infinity" },
 
     { num: 255, radix: 16, expected: "ff" },
     { num: -255, radix: 16, expected: "-ff" },
+    { num: NaN, radix: 16, expected: "NaN" },
+    { num: Infinity, radix: 16, expected: "Infinity" },
 
     { num: 1023, radix: 8, expected: "1777" },
     { num: -1023, radix: 8, expected: "-1777" },
+    { num: NaN, radix: 8, expected: "NaN" },
+    { num: Infinity, radix: 8, expected: "Infinity" },
 
     { num: 123456789, radix: 10, expected: "123456789" },
     { num: -123456789, radix: 10, expected: "-123456789" },
+    { num: 12345.6789, radix: 10, expected: "12345.6789" },
+    { num: -12345.6789, radix: 10, expected: "-12345.6789" },
+    { num: NaN, radix: 10, expected: "NaN" },
+    { num: Infinity, radix: 10, expected: "Infinity" },
+    { num: -Infinity, radix: 10, expected: "-Infinity" },
 
     { num: 2147483647, radix: 16, expected: "7fffffff" }, // max 32bit signed
     { num: -2147483648, radix: 16, expected: "-80000000" }, // min 32bit signed
+    { num: 12345.6789, radix: 16, expected: "3039.adcc63f14" },
+    { num: -12345.6789, radix: 16, expected: "-3039.adcc63f14" },
+    { num: NaN, radix: 16, expected: "NaN" },
+    { num: Infinity, radix: 16, expected: "Infinity" },
+    { num: -Infinity, radix: 16, expected: "-Infinity" },
 
     { num: 100, radix: 36, expected: "2s" },
     { num: -100, radix: 36, expected: "-2s" },
+    { num: NaN, radix: 36, expected: "NaN" },
+    { num: Infinity, radix: 36, expected: "Infinity" },
   ];
 
   testCases.forEach(({ num, radix, expected }) => {


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/1055

### Description of changes

Fixes `.toString()` of `NaN`, `Infinity`, and floats. Before:

```
Welcome to LLRT v0.6.0-beta (darwin, x64)
Type ".exit" or Ctrl+C or Ctrl+D to exit

> NaN.toString()
0
> NaN.toString(2)
0
> NaN.toString(10)
0
> NaN.toString(16)
0
> Infinity.toString()
Infinity
> Infinity.toString(2)
[1]    26123 illegal hardware instruction  ./llrt
> Infinity.toString(10)
[1]    26179 illegal hardware instruction  ./llrt
> Infinity.toString(16)
[1]    26269 illegal hardware instruction  ./llrt
> 123.456.toString()
123
> 123.456.toString(2)
1111011
> 123.456.toString(10)
123
> 123.456.toString(16)
7b
```

After:

```
Welcome to LLRT v0.6.0-beta (darwin, x64)
Type ".exit" or Ctrl+C or Ctrl+D to exit

> NaN.toString()
NaN
> NaN.toString(2)
NaN
> NaN.toString(10)
NaN
> NaN.toString(16)
NaN
> Infinity.toString()
Infinity
> Infinity.toString(2)
Infinity
> Infinity.toString(10)
Infinity
> Infinity.toString(16)
Infinity
> 123.456.toString()
123.456
> 123.456.toString(2)
1111011.011101001011110001101010011111101111100111011
> 123.456.toString(10)
123.456
> 123.456.toString(16)
7b.74bc6a7ef9d
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
