### PR TITLE
Fix boxed numbers to string

### DIFF
--- a/tests/unit/numbers.test.ts
+++ b/tests/unit/numbers.test.ts
@@ -36,6 +36,9 @@ describe("Number to base conversion within 32-bit range", () => {
     { num: -100, radix: 36, expected: "-2s" },
     { num: NaN, radix: 36, expected: "NaN" },
     { num: Infinity, radix: 36, expected: "Infinity" },
+
+    { num: new Number(0), radix: undefined, expected: "0" },
+    { num: new Number(42), radix: undefined, expected: "42" },
   ];
 
   testCases.forEach(({ num, radix, expected }) => {


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/1062

### Description of changes

Conversion to string did not account for Boxed numbers. Also explicitly passing undefined (or void 0) to toString as argument did not work. This PR addresses those issues

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
