### PR TITLE
feat(zlib): support for zstd compression/decompression

### DIFF
--- a/API.md
+++ b/API.md
@@ -426,6 +426,8 @@ export class URLSearchParams {
 
 ## zlib
 
+### Convenience methods
+
 [deflate](https://nodejs.org/api/zlib.html#zlibdeflatebuffer-options-callback)
 
 [deflateSync](https://nodejs.org/api/zlib.html#zlibdeflatesyncbuffer-options)
@@ -457,6 +459,14 @@ export class URLSearchParams {
 [brotliDecompress](https://nodejs.org/api/zlib.html#zlibbrotlidecompressbuffer-options-callback)
 
 [brotliDecompressSync](https://nodejs.org/api/zlib.html#zlibbrotlidecompresssyncbuffer-options)
+
+[zstdCompress](https://nodejs.org/api/zlib.html#zlibzstdcompressbuffer-options-callback)
+
+[zstdCompressSync](hhttps://nodejs.org/api/zlib.html#zlibzstdcompresssyncbuffer-options)
+
+[zstdDecompress](https://nodejs.org/api/zlib.html#zlibzstddecompressbuffer-options-callback)
+
+[zstdDecompressSync](https://nodejs.org/api/zlib.html#zlibzstddecompresssyncbuffer-options)
 
 ## llrt:hex
 

--- a/libs/llrt_compression/src/lib.rs
+++ b/libs/llrt_compression/src/lib.rs
@@ -6,6 +6,7 @@ pub mod zstd {
     use std::io::{BufReader, Read, Result};
 
     use zstd::stream::read::{Decoder as ZstdDecoder, Encoder as ZstdEncoder};
+    pub use zstd::DEFAULT_COMPRESSION_LEVEL;
 
     pub fn encoder<R: Read>(r: R, level: i32) -> Result<ZstdEncoder<'static, BufReader<R>>> {
         ZstdEncoder::new(r, level)

--- a/modules/llrt_zlib/src/brotli.rs
+++ b/modules/llrt_zlib/src/brotli.rs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::io::Read;
+
+use llrt_buffer::Buffer;
+use llrt_context::CtxExtension;
+use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
+use rquickjs::{
+    prelude::{Opt, Rest},
+    Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
+};
+
+use super::{define_cb_function, define_sync_function};
+
+enum BrotliCommand {
+    Compress,
+    Decompress,
+}
+
+fn brotli_converter<'js>(
+    ctx: Ctx<'js>,
+    bytes: ObjectBytes<'js>,
+    _options: Opt<Value<'js>>,
+    command: BrotliCommand,
+) -> Result<Value<'js>> {
+    let src = bytes.as_bytes(&ctx)?;
+
+    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
+
+    let _ = match command {
+        BrotliCommand::Compress => llrt_compression::brotli::encoder(src).read_to_end(&mut dst)?,
+        BrotliCommand::Decompress => {
+            llrt_compression::brotli::decoder(src).read_to_end(&mut dst)?
+        },
+    };
+
+    Buffer(dst).into_js(&ctx)
+}
+
+define_cb_function!(br_comp, brotli_converter, BrotliCommand::Compress);
+define_sync_function!(br_comp_sync, brotli_converter, BrotliCommand::Compress);
+
+define_cb_function!(br_decomp, brotli_converter, BrotliCommand::Decompress);
+define_sync_function!(br_decomp_sync, brotli_converter, BrotliCommand::Decompress);

--- a/modules/llrt_zlib/src/zlib.rs
+++ b/modules/llrt_zlib/src/zlib.rs
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::io::Read;
+
+use llrt_buffer::Buffer;
+use llrt_context::CtxExtension;
+use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
+use rquickjs::{
+    prelude::{Opt, Rest},
+    Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
+};
+
+use super::{define_cb_function, define_sync_function};
+
+enum ZlibCommand {
+    Deflate,
+    DeflateRaw,
+    Gzip,
+    Inflate,
+    InflateRaw,
+    Gunzip,
+}
+
+fn zlib_converter<'js>(
+    ctx: Ctx<'js>,
+    bytes: ObjectBytes<'js>,
+    options: Opt<Value<'js>>,
+    command: ZlibCommand,
+) -> Result<Value<'js>> {
+    let src = bytes.as_bytes(&ctx)?;
+
+    let mut level = llrt_compression::zlib::Compression::default();
+    if let Some(options) = options.0 {
+        if let Some(opt) = options.get_optional("level")? {
+            level = llrt_compression::zlib::Compression::new(opt);
+        }
+    }
+
+    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
+
+    let _ = match command {
+        ZlibCommand::Deflate => {
+            llrt_compression::zlib::encoder(src, level).read_to_end(&mut dst)?
+        },
+        ZlibCommand::DeflateRaw => {
+            llrt_compression::deflate::encoder(src, level).read_to_end(&mut dst)?
+        },
+        ZlibCommand::Gzip => llrt_compression::gz::encoder(src, level).read_to_end(&mut dst)?,
+        ZlibCommand::Inflate => llrt_compression::zlib::decoder(src).read_to_end(&mut dst)?,
+        ZlibCommand::InflateRaw => llrt_compression::deflate::decoder(src).read_to_end(&mut dst)?,
+        ZlibCommand::Gunzip => llrt_compression::gz::decoder(src).read_to_end(&mut dst)?,
+    };
+
+    Buffer(dst).into_js(&ctx)
+}
+
+define_cb_function!(deflate, zlib_converter, ZlibCommand::Deflate);
+define_sync_function!(deflate_sync, zlib_converter, ZlibCommand::Deflate);
+
+define_cb_function!(deflate_raw, zlib_converter, ZlibCommand::DeflateRaw);
+define_sync_function!(deflate_raw_sync, zlib_converter, ZlibCommand::DeflateRaw);
+
+define_cb_function!(gzip, zlib_converter, ZlibCommand::Gzip);
+define_sync_function!(gzip_sync, zlib_converter, ZlibCommand::Gzip);
+
+define_cb_function!(inflate, zlib_converter, ZlibCommand::Inflate);
+define_sync_function!(inflate_sync, zlib_converter, ZlibCommand::Inflate);
+
+define_cb_function!(inflate_raw, zlib_converter, ZlibCommand::InflateRaw);
+define_sync_function!(inflate_raw_sync, zlib_converter, ZlibCommand::InflateRaw);
+
+define_cb_function!(gunzip, zlib_converter, ZlibCommand::Gunzip);
+define_sync_function!(gunzip_sync, zlib_converter, ZlibCommand::Gunzip);

--- a/modules/llrt_zlib/src/zstd.rs
+++ b/modules/llrt_zlib/src/zstd.rs
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::io::Read;
+
+use llrt_buffer::Buffer;
+use llrt_context::CtxExtension;
+use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
+use rquickjs::{
+    prelude::{Opt, Rest},
+    Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
+};
+
+use super::{define_cb_function, define_sync_function};
+
+enum ZstdCommand {
+    Compress,
+    Decompress,
+}
+
+fn zstd_converter<'js>(
+    ctx: Ctx<'js>,
+    bytes: ObjectBytes<'js>,
+    options: Opt<Value<'js>>,
+    command: ZstdCommand,
+) -> Result<Value<'js>> {
+    let src = bytes.as_bytes(&ctx)?;
+
+    let mut level = llrt_compression::zstd::DEFAULT_COMPRESSION_LEVEL;
+    if let Some(options) = options.0 {
+        if let Some(opt) = options.get_optional("level")? {
+            level = opt;
+        }
+    }
+
+    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
+
+    let _ = match command {
+        ZstdCommand::Compress => {
+            llrt_compression::zstd::encoder(src, level)?.read_to_end(&mut dst)?
+        },
+        ZstdCommand::Decompress => llrt_compression::zstd::decoder(src)?.read_to_end(&mut dst)?,
+    };
+
+    Buffer(dst).into_js(&ctx)
+}
+
+define_cb_function!(zstd_comp, zstd_converter, ZstdCommand::Compress);
+define_sync_function!(zstd_comp_sync, zstd_converter, ZstdCommand::Compress);
+
+define_cb_function!(zstd_decomp, zstd_converter, ZstdCommand::Decompress);
+define_sync_function!(zstd_decomp_sync, zstd_converter, ZstdCommand::Decompress);

--- a/tests/unit/zlib.test.ts
+++ b/tests/unit/zlib.test.ts
@@ -64,3 +64,19 @@ describe("brotli", () => {
     expect(data).toEqual(decompressed.toString());
   });
 });
+
+describe("zstandard", () => {
+  it("zstdCompress/zstdDecompress", (done) => {
+    zlib.zstdCompress(data, (err, compressed) => {
+      zlib.zstdDecompress(compressed, (err, decompressed) => {
+        expect(data).toEqual(decompressed.toString());
+        done();
+      });
+    });
+  });
+  it("zstdCompressSync/zstdDecompressSync", () => {
+    const compressed = zlib.zstdCompressSync(data);
+    const decompressed = zlib.zstdDecompressSync(compressed);
+    expect(data).toEqual(decompressed.toString());
+  });
+});

--- a/types/zlib.d.ts
+++ b/types/zlib.d.ts
@@ -146,4 +146,32 @@ declare module "zlib" {
    * Decompress a chunk of data with `BrotliDecompress`.
    */
   function brotliDecompressSync(buf: InputType): Buffer;
+
+  /**
+   * Compress a chunk of data with `ZstdCompress`.
+   */
+  function zstdCompress(buf: InputType, callback: CompressCallback): void;
+  function zstdCompress(
+    buf: InputType,
+    options: ZstdOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Compress a chunk of data with `ZstdCompress`.
+   */
+  function zstdCompressSync(buf: InputType, options?: ZstdOptions): Buffer;
+
+  /**
+   * Decompress a chunk of data with `ZstdDecompress`.
+   */
+  function zstdDecompress(buf: InputType, callback: CompressCallback): void;
+  function zstdDecompress(
+    buf: InputType,
+    options: ZstdOptions,
+    callback: CompressCallback
+  ): void;
+  /**
+   * Decompress a chunk of data with `ZstdDecompress`.
+   */
+  function zstdDecompressSync(buf: InputType, options?: ZstdOptions): Buffer;
 }


### PR DESCRIPTION
### Issue # (if available)

Closed #898 

### Description of changes

- Supports zstd compression/decompression in line with the Node.js implementation.
- However, due to compatibility issues with the crate being used, it ignores options available in Node.js, and conversely, it supports compression levels that do not exist in Node.js.
- More compression/decompression formats are supported. The code has been split for better maintainability.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
