### PR TITLE
fix(fetch): correctly handle percent encoding in data-urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1866,6 +1866,7 @@ dependencies = [
  "llrt_url",
  "llrt_utils",
  "once_cell",
+ "percent-encoding",
  "pin-project-lite",
  "quick_cache",
  "rquickjs",

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -43,6 +43,7 @@ llrt_url = { version = "0.6.2-beta", path = "../llrt_url" }
 llrt_utils = { version = "0.6.2-beta", path = "../../libs/llrt_utils", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 once_cell = { version = "1", features = ["std"], default-features = false }
+percent-encoding = { version = "2", features = ["std"], default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", features = [
   "either",
   "std",

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -147,9 +147,6 @@ Error: [Fetching about:blank with method GET is KO] promise_rejects_js: function
     [native code]
 }" ("TypeError")
 
-fetch/api/basic > should pass scheme-data.any.js tests
-Error: [Fetching data:,response%27s%20body is OK] assert_equals: Response's body is correct expected "response's body" but got "response%27s%20body"
-
 fetch/api/basic > should pass scheme-others.sub.any.js tests
 Error: [Fetching aaa://{{host}}:{{ports[http][0]}}/ is KO] promise_rejects_js: function "function() {
             throw e;


### PR DESCRIPTION
### Description of changes

- It passes WPT by correctly handling percent encoding in data-urls.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
