### PR TITLE
fix(fetch): remove the BOM from body.text() and body.json()

### DIFF
--- a/modules/llrt_fetch/src/body.rs
+++ b/modules/llrt_fetch/src/body.rs
@@ -9,7 +9,7 @@ use rquickjs::{
     ArrayBuffer, Class, Ctx, Exception, IntoJs, JsLifetime, Null, Result, TypedArray, Value,
 };
 
-use super::Blob;
+use super::{strip_bom, Blob};
 
 // WARN: We don't use that code since we don't have an implementation of ReadableStream.
 // We will revisit later.
@@ -41,13 +41,12 @@ impl<'js> Trace<'js> for Body<'js> {
 impl<'js> Body<'js> {
     pub async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
         let bytes = self.take_bytes(&ctx).await?;
-        Ok(String::from_utf8_lossy(&bytes).to_string())
+        Ok(String::from_utf8_lossy(strip_bom(&bytes)).to_string())
     }
 
     pub async fn json(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         let bytes = self.take_bytes(&ctx).await?;
-        let json = json_parse(&ctx, bytes)?;
-        Ok(json)
+        json_parse(&ctx, strip_bom(&bytes))
     }
 
     pub async fn array_buffer(&mut self, ctx: Ctx<'js>) -> Result<ArrayBuffer<'js>> {

--- a/modules/llrt_fetch/src/body.rs
+++ b/modules/llrt_fetch/src/body.rs
@@ -41,7 +41,7 @@ impl<'js> Trace<'js> for Body<'js> {
 impl<'js> Body<'js> {
     pub async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
         let bytes = self.take_bytes(&ctx).await?;
-        Ok(String::from_utf8_lossy(strip_bom(&bytes)).to_string())
+        Ok(String::from_utf8_lossy(&strip_bom(&bytes)).to_string())
     }
 
     pub async fn json(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {

--- a/modules/llrt_fetch/src/body.rs
+++ b/modules/llrt_fetch/src/body.rs
@@ -41,12 +41,12 @@ impl<'js> Trace<'js> for Body<'js> {
 impl<'js> Body<'js> {
     pub async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
         let bytes = self.take_bytes(&ctx).await?;
-        Ok(String::from_utf8_lossy(&strip_bom(&bytes)).to_string())
+        Ok(String::from_utf8_lossy(&strip_bom(bytes)).to_string())
     }
 
     pub async fn json(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         let bytes = self.take_bytes(&ctx).await?;
-        json_parse(&ctx, strip_bom(&bytes))
+        json_parse(&ctx, strip_bom(bytes))
     }
 
     pub async fn array_buffer(&mut self, ctx: Ctx<'js>) -> Result<ArrayBuffer<'js>> {

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -138,7 +138,7 @@ fn get_http_version() -> HttpVersion {
     })
 }
 
-fn strip_bom<'a>(bytes: impl Into<Cow<'a, [u8]>>) -> Cow<'a, [u8]> {
+pub(crate) fn strip_bom<'a>(bytes: impl Into<Cow<'a, [u8]>>) -> Cow<'a, [u8]> {
     let cow = bytes.into();
     if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
         Cow::Borrowed(&cow[3..])

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -137,6 +137,14 @@ fn get_http_version() -> HttpVersion {
     })
 }
 
+pub(crate) fn strip_bom(bytes: &[u8]) -> &[u8] {
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        &bytes[3..]
+    } else {
+        bytes
+    }
+}
+
 pub type HyperClient =
     Client<HttpsConnector<HttpConnector<CachedDnsResolver>>, BoxBody<Bytes, Infallible>>;
 pub static HTTP_CLIENT: Lazy<io::Result<HyperClient>> = Lazy::new(|| {

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use std::{
+    borrow::Cow,
     convert::Infallible,
     io,
     sync::{
@@ -137,11 +138,15 @@ fn get_http_version() -> HttpVersion {
     })
 }
 
-pub(crate) fn strip_bom(bytes: &[u8]) -> &[u8] {
-    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
-        &bytes[3..]
+pub(crate) fn strip_bom<'a>(bytes: impl Into<Cow<'a, [u8]>>) -> Cow<'a, [u8]> {
+    let cow = bytes.into();
+    if cow.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        match cow {
+            Cow::Borrowed(b) => Cow::Borrowed(&b[3..]),
+            Cow::Owned(b) => Cow::Owned(b[3..].to_vec()),
+        }
     } else {
-        bytes
+        cow
     }
 }
 

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -138,13 +138,10 @@ fn get_http_version() -> HttpVersion {
     })
 }
 
-pub(crate) fn strip_bom<'a>(bytes: impl Into<Cow<'a, [u8]>>) -> Cow<'a, [u8]> {
+fn strip_bom<'a>(bytes: impl Into<Cow<'a, [u8]>>) -> Cow<'a, [u8]> {
     let cow = bytes.into();
-    if cow.starts_with(&[0xEF, 0xBB, 0xBF]) {
-        match cow {
-            Cow::Borrowed(b) => Cow::Borrowed(&b[3..]),
-            Cow::Owned(b) => Cow::Owned(b[3..].to_vec()),
-        }
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        Cow::Borrowed(&cow[3..])
     } else {
         cow
     }

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -140,7 +140,7 @@ fn get_http_version() -> HttpVersion {
 
 pub(crate) fn strip_bom<'a>(bytes: impl Into<Cow<'a, [u8]>>) -> Cow<'a, [u8]> {
     let cow = bytes.into();
-    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+    if cow.starts_with(&[0xEF, 0xBB, 0xBF]) {
         Cow::Borrowed(&cow[3..])
     } else {
         cow

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -141,7 +141,13 @@ fn get_http_version() -> HttpVersion {
 pub(crate) fn strip_bom<'a>(bytes: impl Into<Cow<'a, [u8]>>) -> Cow<'a, [u8]> {
     let cow = bytes.into();
     if cow.starts_with(&[0xEF, 0xBB, 0xBF]) {
-        Cow::Borrowed(&cow[3..])
+        match cow {
+            Cow::Borrowed(bytes) => Cow::Borrowed(&bytes[3..]),
+            Cow::Owned(mut bytes) => {
+                bytes.drain(0..3); //memmove instead of copy
+                Cow::Owned(bytes)
+            },
+        }
     } else {
         cow
     }

--- a/modules/llrt_fetch/src/request.rs
+++ b/modules/llrt_fetch/src/request.rs
@@ -178,7 +178,7 @@ impl<'js> Request<'js> {
     pub async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             let bytes = bytes.as_bytes(&ctx)?;
-            return Ok(String::from_utf8_lossy(strip_bom(bytes)).to_string());
+            return Ok(String::from_utf8_lossy(&strip_bom(bytes)).to_string());
         }
         Ok("".into())
     }

--- a/modules/llrt_fetch/src/request.rs
+++ b/modules/llrt_fetch/src/request.rs
@@ -11,7 +11,7 @@ use rquickjs::{
 
 use super::{
     headers::{Headers, HeadersGuard, HEADERS_KEY_CONTENT_TYPE},
-    Blob, MIME_TYPE_APPLICATION, MIME_TYPE_TEXT,
+    strip_bom, Blob, MIME_TYPE_APPLICATION, MIME_TYPE_TEXT,
 };
 
 #[derive(Clone, Default, PartialEq)]
@@ -178,14 +178,15 @@ impl<'js> Request<'js> {
     pub async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
             let bytes = bytes.as_bytes(&ctx)?;
-            return Ok(String::from_utf8_lossy(bytes).to_string());
+            return Ok(String::from_utf8_lossy(strip_bom(bytes)).to_string());
         }
         Ok("".into())
     }
 
     pub async fn json(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
-            return json_parse(&ctx, bytes.as_bytes(&ctx)?);
+            let bytes = bytes.as_bytes(&ctx)?;
+            return json_parse(&ctx, strip_bom(bytes));
         }
         Err(Exception::throw_syntax(&ctx, "JSON input is empty"))
     }

--- a/modules/llrt_fetch/src/response.rs
+++ b/modules/llrt_fetch/src/response.rs
@@ -397,7 +397,7 @@ impl<'js> Response<'js> {
 
     pub(crate) async fn text(&self, ctx: Ctx<'js>) -> Result<String> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
-            return Ok(String::from_utf8_lossy(strip_bom(&bytes)).to_string());
+            return Ok(String::from_utf8_lossy(&strip_bom(&bytes)).to_string());
         }
         Ok("".into())
     }

--- a/modules/llrt_fetch/src/response.rs
+++ b/modules/llrt_fetch/src/response.rs
@@ -397,14 +397,14 @@ impl<'js> Response<'js> {
 
     pub(crate) async fn text(&self, ctx: Ctx<'js>) -> Result<String> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
-            return Ok(String::from_utf8_lossy(&strip_bom(&bytes)).to_string());
+            return Ok(String::from_utf8_lossy(&strip_bom(bytes)).to_string());
         }
         Ok("".into())
     }
 
     pub(crate) async fn json(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
-            return json_parse(&ctx, strip_bom(&bytes));
+            return json_parse(&ctx, strip_bom(bytes));
         }
         Err(Exception::throw_syntax(&ctx, "JSON input is empty"))
     }

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -167,7 +167,7 @@ fetch/api/basic > should pass stream-safe-creation.any.js tests
 Error: [throwing Object.prototype.start accessor should not affect stream creation by 'fetch'] promise_test: Unhandled rejection with value: object "Error: client error (UserAbsoluteUriRequired)"
 
 fetch/api/basic > should pass text-utf8.any.js tests
-Error: [UTF-8 with BOM with Request.text()] assert_equals: Request.text() should decode data as UTF-8 expected "三村かな子" but got "﻿三村かな子"
+Error: [UTF-8 with BOM with fetched data (UTF-8 charset)] promise_test: Unhandled rejection with value: object "Error: invalid format"
 
 
 🧪/wpt/fetch.api.body.test.js 
@@ -226,7 +226,7 @@ Error: [Request has formData method] assert_true: request has formData method ex
 
 🧪/wpt/fetch.api.response.test.js 
 fetch/api/response > should pass json.any.js tests
-Error: [Ensure the correct JSON parser is used] promise_test: Unhandled rejection with value: object "Error: "﻿{ "b": 1, "a": 2, "b": 3 }" not valid JSON at index 0 ('ï')"
+Error: [Ensure UTF-16 results in an error] promise_test: Unhandled rejection with value: object "Error: client error (UserAbsoluteUriRequired)"
 
 fetch/api/response > should pass response-blob-realm.any.js tests
 Error: Timeout after 5000ms


### PR DESCRIPTION
### Description of changes

- The BOM must be ignored (do nothing) in `body.text()` and `body.json()`.
- The same is true for `Request` and `Response`, which is the body-mixin.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
