### PR TITLE
fix(test): correctly call beforeEach/afterEach for tests

### DIFF
--- a/llrt_core/src/modules/js/@llrt/test/worker.ts
+++ b/llrt_core/src/modules/js/@llrt/test/worker.ts
@@ -282,7 +282,7 @@ class TestAgent {
     return JSON.parse(response) as SocketReturnType<T>;
   }
 
-  private async runTests(testSuite: RootSuite, tests: Test[] = []) {
+  private async runTests(testSuite: TestSuite, tests: Test[] = []) {
     for (const test of tests) {
       if (test.skip || (this.onlyCount > 0 && !test.only)) {
         continue;
@@ -454,7 +454,7 @@ class TestAgent {
           if (suite.beforeAll) {
             await this.executeAsyncOrCallbackFn(suite.beforeAll);
           }
-          await this.runTests(testSuite, suite.tests);
+          await this.runTests(suite, suite.tests);
           if (suite.afterAll) {
             await this.executeAsyncOrCallbackFn(suite.afterAll);
           }

--- a/tests/unit/jest-expect.test.ts
+++ b/tests/unit/jest-expect.test.ts
@@ -499,3 +499,53 @@ describe("toSatisfy()", () => {
 });
 
 it("timeout", () => new Promise((resolve) => setTimeout(resolve, 0)));
+
+describe("beforeEach", () => {
+  let value: string;
+  beforeEach(() => {
+    value = "beforeEach";
+  });
+
+  it("should have value", () => {
+    expect(value).toEqual("beforeEach");
+  });
+
+  describe("nested beforeEach", () => {
+    beforeEach(() => {
+      value += " nested";
+    });
+
+    it("should have aggregated value", () => {
+      expect(value).toEqual("beforeEach nested");
+    });
+  });
+});
+
+describe("afterEach", () => {
+  let value: string;
+  afterEach(() => {
+    value = "afterEach";
+  });
+
+  afterAll(() => {
+    expect(value).toEqual("afterEach");
+  });
+
+  it("should have value", () => {
+    // do nothing
+  });
+
+  describe("nested afterEach", () => {
+    afterEach(() => {
+      value += " nested";
+    });
+
+    afterAll(() => {
+      expect(value).toEqual("afterEach nested");
+    });
+
+    it("should have aggregated value", () => {
+      // do nothing
+    });
+  });
+});


### PR DESCRIPTION
### Issue # (if available)

Closes #1071

### Description of changes

This PR passes the current test suite to `runTests`, in order for it to correctly invoke the `beforeEach` and `afterEach` hooks.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] ~~Added relevant type info in `types/` directory~~
- [ ] ~~Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)~~

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
