### PR TITLE
fix(fetch): improved compatibility of bodyUsed property

### DIFF
--- a/modules/llrt_fetch/src/request.rs
+++ b/modules/llrt_fetch/src/request.rs
@@ -181,14 +181,14 @@ impl<'js> Request<'js> {
 
     pub async fn text(&mut self, ctx: Ctx<'js>) -> Result<String> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
-            return Ok(String::from_utf8_lossy(&strip_bom(&bytes)).to_string());
+            return Ok(String::from_utf8_lossy(&strip_bom(bytes)).to_string());
         }
         Ok("".into())
     }
 
     pub async fn json(&mut self, ctx: Ctx<'js>) -> Result<Value<'js>> {
         if let Some(bytes) = self.take_bytes(&ctx).await? {
-            return json_parse(&ctx, strip_bom(&bytes));
+            return json_parse(&ctx, strip_bom(bytes));
         }
         Err(Exception::throw_syntax(&ctx, "JSON input is empty"))
     }

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -207,7 +207,7 @@ describe("Request class", () => {
       method: "POST",
     });
     expect(request.body).toStrictEqual(body);
-    expect(request.bodyUsed).toBeTruthy();
+    expect(request.bodyUsed).toBeFalsy();
   });
 
   it("should accept another request object as argument", () => {
@@ -255,12 +255,13 @@ describe("Request class", () => {
     }).toThrow(/property is not an AbortSignal/);
   });
 
-  it("should set the body to the provided value", async () => {
+  it("should return the provided body via text() and set bodyUsed to true", async () => {
     const body = "Hello, world!";
     const request = new Request("http://localhost", {
       body: body,
       method: "POST",
     });
+    expect(request.bodyUsed).toBeFalsy();
     expect(await request.text()).toStrictEqual(body);
     expect(request.bodyUsed).toBeTruthy();
   });
@@ -271,7 +272,9 @@ describe("Request class", () => {
       body: JSON.stringify(jsonBody),
       method: "POST",
     });
+    expect(request.bodyUsed).toBeFalsy();
     expect(await request.json()).toStrictEqual(jsonBody);
+    expect(request.bodyUsed).toBeTruthy();
   });
 
   it("should set the body to a bytes object if a bytes object is provided", async () => {
@@ -280,7 +283,9 @@ describe("Request class", () => {
       body: myArray,
       method: "POST",
     });
+    expect(request.bodyUsed).toBeFalsy();
     expect(await request.bytes()).toStrictEqual(myArray);
+    expect(request.bodyUsed).toBeTruthy();
   });
 
   it("should set the body to a Blob if a Blob is provided", async () => {
@@ -289,9 +294,11 @@ describe("Request class", () => {
       body: blob,
       method: "POST",
     });
-    expect(await request.text()).toEqual("Hello, world!");
-    expect((await request.blob()).size).toEqual(blob.size);
-    expect((await request.blob()).type).toEqual("text/plain");
+    expect(request.bodyUsed).toBeFalsy();
+    const res = await request.blob();
+    expect(request.bodyUsed).toBeTruthy();
+    expect(res.size).toEqual(blob.size);
+    expect(res.type).toEqual("text/plain");
   });
 
   it("should set the body to a Blob if Blob and content-type are provided", async () => {
@@ -301,9 +308,9 @@ describe("Request class", () => {
       method: "POST",
       headers: { "content-type": "text/plain" },
     });
-    expect(await request.text()).toEqual("Hello, world!");
-    expect((await request.blob()).size).toEqual(blob.size);
-    expect((await request.blob()).type).toEqual("text/plain");
+    const res = await request.blob();
+    expect(res.size).toEqual(blob.size);
+    expect(res.type).toEqual("text/plain");
   });
 
   it("should ignore request options which are not an object", async () => {
@@ -343,13 +350,17 @@ describe("Response class", () => {
   it("should set the body to the provided value", async () => {
     const body = "Hello, world!";
     const response = new Response(body);
+    expect(response.bodyUsed).toBeFalsy();
     expect(await response.text()).toStrictEqual(body);
+    expect(response.bodyUsed).toBeTruthy();
   });
 
   it("should set the body to a Blob if a Blob is provided", async () => {
     const blob = new Blob(["Hello, world!"], { type: "text/plain" });
     const response = new Response(blob);
+    expect(response.bodyUsed).toBeFalsy();
     expect(await response.text()).toEqual("Hello, world!");
+    expect(response.bodyUsed).toBeTruthy();
   });
 
   it("should set the body to a JSON object if a JSON object is provided", async () => {
@@ -357,13 +368,17 @@ describe("Response class", () => {
     const response = new Response(JSON.stringify(jsonBody), {
       headers: { "Content-Type": "application/json" },
     });
+    expect(response.bodyUsed).toBeFalsy();
     expect(await response.json()).toStrictEqual(jsonBody);
+    expect(response.bodyUsed).toBeTruthy();
   });
 
   it("should set the body to a bytes object if a bytes object is provided", async () => {
     const myArray = new Uint8Array([1, 2, 3]);
     const response = new Response(myArray);
+    expect(response.bodyUsed).toBeFalsy();
     expect(await response.bytes()).toStrictEqual(myArray);
+    expect(response.bodyUsed).toBeTruthy();
   });
 
   it("should clone the response with the clone() method", () => {

--- a/tests/wpt/fetch/api/resources/utils.js
+++ b/tests/wpt/fetch/api/resources/utils.js
@@ -14,7 +14,7 @@ export default function (self) {
       switch (attribute) {
         case "headers":
           for (var key in ExpectedValuesDict["headers"].keys()) {
-            assert_equals(
+            self.assert_equals(
               request["headers"].get(key),
               ExpectedValuesDict["headers"].get(key),
               "Check headers attribute has " +
@@ -27,7 +27,7 @@ export default function (self) {
 
         case "body":
           //for checking body's content, a dedicated asyncronous/promise test should be used
-          assert_true(
+          self.assert_true(
             request["headers"].has("Content-Type"),
             "Check request has body using Content-Type header"
           );
@@ -42,7 +42,7 @@ export default function (self) {
         case "integrity":
         case "url":
         case "destination":
-          assert_equals(
+          self.assert_equals(
             request[attribute],
             ExpectedValuesDict[attribute],
             "Check " + attribute + " attribute"
@@ -71,7 +71,7 @@ export default function (self) {
   self.encode_utf8 = encode_utf8;
 
   function validateBufferFromString(buffer, expectedValue, message) {
-    return assert_array_equals(
+    return self.assert_array_equals(
       new Uint8Array(buffer !== undefined ? buffer : []),
       stringToArray(expectedValue),
       message
@@ -87,7 +87,7 @@ export default function (self) {
     // Passing Uint8Array for byte streams; non-byte streams will simply ignore it
     return reader.read(new Uint8Array(64)).then(function (data) {
       if (!data.done) {
-        assert_true(
+        self.assert_true(
           data.value instanceof Uint8Array,
           "Fetch ReadableStream chunks should be Uint8Array"
         );
@@ -120,7 +120,7 @@ export default function (self) {
     // Passing Uint8Array for byte streams; non-byte streams will simply ignore it
     return reader.read(new Uint8Array(64)).then(function (data) {
       if (!data.done) {
-        assert_true(
+        self.assert_true(
           data.value instanceof Uint8Array,
           "Fetch ReadableStream chunks should be Uint8Array"
         );
@@ -142,7 +142,7 @@ export default function (self) {
       }
 
       var string = new TextDecoder("utf-8").decode(retrievedArrayBuffer);
-      return assert_true(
+      return self.assert_true(
         string.search(expectedValue) != -1,
         "Retrieve and verify stream"
       );
@@ -165,10 +165,10 @@ export default function (self) {
 
     promise_test(function (test) {
       return fetch(url + urlParameters, requestInit).then(function (resp) {
-        assert_equals(resp.status, 200, "HTTP status is 200");
-        assert_equals(resp.type, "basic", "Response's type is basic");
+        self.assert_equals(resp.status, 200, "HTTP status is 200");
+        self.assert_equals(resp.type, "basic", "Response's type is basic");
         for (var header in forbiddenHeaders)
-          assert_not_equals(
+          self.assert_not_equals(
             resp.headers.get("x-request-" + header),
             forbiddenHeaders[header],
             header + " does not have the value we defined"

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -192,7 +192,7 @@ Error: [Request on bad port 1 should throw TypeError.] promise_rejects_js: funct
 }" ("TypeError")
 
 fetch/api/request > should pass request-consume.any.js tests
-Error: [Consume String request's body as text] assert_false: bodyUsed is false at init expected false got true
+Error: [Consume DataView request's body as text] assert_equals: Retrieve and verify request's body expected "\"123456\"" but got "\0\"123456\"\0"
 
 fetch/api/request > should pass request-disturbed.any.js tests
 Error: [Request's body: initial state] assert_true: non-null body type expected true got false
@@ -215,7 +215,7 @@ fetch/api/request > should pass request-init-stream.any.js tests
 Error: [Constructing a Request with a stream on which getReader() is called] assert_throws_js: function "() => new Request("...", { method, body, duplex })" did not throw
 
 fetch/api/request > should pass request-keepalive.any.js tests
-Error: [keepalive flag] assert_false: default expected false got true
+Error: [keepalive flag with stream body] assert_throws_js: function "() => {new Request('/', init)}" did not throw
 
 fetch/api/request > should pass request-structure.any.js tests
 Error: [Request has formData method] assert_true: request has formData method expected true got false


### PR DESCRIPTION
### Description of changes

- The support for the bodyUsed property of the Request class was insufficient, so it has been improved.
- Ideally, body handling should be standardized according to the Body-Mixin concept, but this will take time, so we will do it another time.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
