### PR TITLE
fix(encoding): fix trimming even if BOM character code does not match

### DIFF
--- a/libs/llrt_encoding/src/lib.rs
+++ b/libs/llrt_encoding/src/lib.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 
 use hex_simd::AsciiCase;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum Encoder {
     Hex,
     Base64,

--- a/modules/llrt_util/src/text_decoder.rs
+++ b/modules/llrt_util/src/text_decoder.rs
@@ -56,10 +56,10 @@ impl<'js> TextDecoder {
     pub fn decode(&self, ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<String> {
         let bytes = bytes.as_bytes(&ctx)?;
         let start_pos = if !self.ignore_bom {
-            match bytes.get(..3) {
-                Some([0xFF, 0xFE, ..]) if self.encoder == Encoder::Utf16le => 2,
-                Some([0xFE, 0xFF, ..]) if self.encoder == Encoder::Utf16be => 2,
-                Some([0xEF, 0xBB, 0xBF]) if self.encoder == Encoder::Utf8 => 3,
+            match (&self.encoder, bytes.get(..3)) {
+                (Encoder::Utf16le, Some([0xFF, 0xFE, ..])) => 2,
+                (Encoder::Utf16be, Some([0xFE, 0xFF, ..])) => 2,
+                (Encoder::Utf8, Some([0xEF, 0xBB, 0xBF])) => 3,
                 _ => 0,
             }
         } else {

--- a/modules/llrt_util/src/text_decoder.rs
+++ b/modules/llrt_util/src/text_decoder.rs
@@ -57,8 +57,9 @@ impl<'js> TextDecoder {
         let bytes = bytes.as_bytes(&ctx)?;
         let start_pos = if !self.ignore_bom {
             match bytes.get(..3) {
-                Some([0xFF, 0xFE, ..]) | Some([0xFE, 0xFF, ..]) => 2,
-                Some([0xEF, 0xBB, 0xBF]) => 3,
+                Some([0xFF, 0xFE, ..]) if self.encoder == Encoder::Utf16le => 2,
+                Some([0xFE, 0xFF, ..]) if self.encoder == Encoder::Utf16be => 2,
+                Some([0xEF, 0xBB, 0xBF]) if self.encoder == Encoder::Utf8 => 3,
                 _ => 0,
             }
         } else {

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -41,9 +41,6 @@ Error: [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination le
 encoding > should pass textdecoder-arguments.any.js tests
 Error: [TextDecoder decode() with explicit undefined] assert_equals: Undefined as first arg should flush the stream expected "\ufffd" but got ""
 
-encoding > should pass textdecoder-byte-order-marks.any.js tests
-Error: [Byte-order marks: utf-8] assert_not_equals: Mismatching BOM should not be ignored - treated as garbage bytes. got disallowed value "z¢水𝄞􏿽"
-
 encoding > should pass textdecoder-copy.any.js tests
 Error: [Modify buffer after passing it in (ArrayBuffer)] assert_equals: expected "" but got "\ufffd"
 


### PR DESCRIPTION
### Description of changes

- Unmatched BOMs are not ignored and are treated as garbage bytes.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
