### PR TITLE
feat(wpt): expand the scope of wpt testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,14 +185,17 @@ init-wpt:
 	git config core.sparsecheckout false
 	echo "/README.md" > ./.git/modules/wpt/info/sparse-checkout
 	echo "/console" >> ./.git/modules/wpt/info/sparse-checkout
+	echo "/docs" >> ./.git/modules/wpt/info/sparse-checkout
 	echo "/encoding" >> ./.git/modules/wpt/info/sparse-checkout
 	echo "/FileAPI" >> ./.git/modules/wpt/info/sparse-checkout
 	echo "/fetch" >> ./.git/modules/wpt/info/sparse-checkout
 	echo "/hr-time" >> ./.git/modules/wpt/info/sparse-checkout
 	echo "/streams" >> ./.git/modules/wpt/info/sparse-checkout
+	echo "/tools" >> ./.git/modules/wpt/info/sparse-checkout
 	echo "/url" >> ./.git/modules/wpt/info/sparse-checkout
 	echo "/WebCryptoAPI" >> ./.git/modules/wpt/info/sparse-checkout
 	echo "/webidl" >> ./.git/modules/wpt/info/sparse-checkout
+	echo "wpt" >> ./.git/modules/wpt/info/sparse-checkout
 	git config core.sparsecheckout true
 
 update-wpt:

--- a/modules/llrt_fetch/src/fetch.rs
+++ b/modules/llrt_fetch/src/fetch.rs
@@ -12,7 +12,12 @@ use hyper_util::client::legacy::connect::Connect;
 use hyper_util::client::legacy::Client;
 use llrt_abort::AbortSignal;
 use llrt_encoding::bytes_from_b64;
-use llrt_utils::{bytes::ObjectBytes, mc_oneshot, result::ResultExt, VERSION};
+use llrt_utils::{
+    bytes::{bytes_to_typed_array, ObjectBytes},
+    mc_oneshot,
+    result::ResultExt,
+    VERSION,
+};
 use percent_encoding::percent_decode_str;
 use rquickjs::{
     atom::PredefinedAtom,
@@ -358,7 +363,13 @@ fn get_fetch_options<'js>(
         if let Some(body_opt) =
             get_option::<Value>("body", arg_opts.as_ref(), resource_opts.as_ref())?
         {
-            let bytes = ObjectBytes::from(ctx, &body_opt)?;
+            let bytes = if let Ok(blob) = Class::<Blob>::from_value(&body_opt) {
+                let blob = blob.borrow();
+                let typed_array = bytes_to_typed_array(ctx.clone(), &blob.get_bytes())?;
+                ObjectBytes::from(ctx, &typed_array)?
+            } else {
+                ObjectBytes::from(ctx, &body_opt)?
+            };
             body = Some(BodyBytes::new(ctx.clone(), bytes)?);
         }
 

--- a/modules/llrt_fetch/src/fetch.rs
+++ b/modules/llrt_fetch/src/fetch.rs
@@ -226,6 +226,9 @@ fn build_request(
     if !detected_headers.contains("accept-encoding") {
         req = req.header("accept-encoding", "zstd, br, gzip, deflate");
     }
+    if !detected_headers.contains("accept-language") {
+        req = req.header("accept-language", "*");
+    }
     if !detected_headers.contains("accept") {
         req = req.header("accept", "*/*");
     }

--- a/tests/wpt/README.md
+++ b/tests/wpt/README.md
@@ -33,13 +33,23 @@ git submodule add --force -b master https://github.com/web-platform-tests/wpt wp
 make update-wpt
 ```
 
-5. **Run the WPTs**
+5. **Run the WPT server**
+
+```sh
+./wpt/wpt serve
+```
+
+> [!IMPORTANT]
+> The first time you do this, you will need to add the hostname required by wpt to hosts. For more information, please refer to the URL below.
+> https://web-platform-tests.org/running-tests/from-local-system.html#hosts-file-setup
+
+6. **Run the WPTs**
 
 ```sh
 make test-wpt
 ```
 
-6. **Organizing the results of the WPT**
+7. **Organizing the results of the WPT**
 
 ```sh
 make tidyup-wpt

--- a/tests/wpt/WebCryptoAPI.derive_bits_keys.test.ts
+++ b/tests/wpt/WebCryptoAPI.derive_bits_keys.test.ts
@@ -6,8 +6,10 @@ import { fileURLToPath } from "url";
 const SKIP_FILES = [
   "cfrg_curves_bits_curve25519.https.any.js", // ReferenceError: define_tests_25519 is not defined
   "cfrg_curves_bits_curve448.https.any.js", // ReferenceError: define_tests_448 is not defined
+  "cfrg_curves_bits_curve448.tentative.https.any.js", // ReferenceError: define_tests_448 is not defined
   "cfrg_curves_keys_curve25519.https.any.js", // ReferenceError: define_tests_25519 is not defined
   "cfrg_curves_keys_curve448.https.any.js", // ReferenceError: define_tests_448 is not defined
+  "cfrg_curves_keys_curve448.tentative.https.any.js", // ReferenceError: define_tests_448 is not defined
   "derive_key_and_encrypt.https.any.js", // ReferenceError: define_tests is not defined
   "derived_bits_length.https.any.js", // ReferenceError: define_tests is not defined
   "ecdh_bits.https.any.js", // ReferenceError: define_tests is not defined

--- a/tests/wpt/fetch.api.basic.test.ts
+++ b/tests/wpt/fetch.api.basic.test.ts
@@ -7,6 +7,7 @@ const SKIP_FILES = [
   "request-forbidden-headers.any.js", // ReferenceError: promise_test is not defined
   "request-private-network-headers.tentative.any.js", // ReferenceError: promise_test is not defined
   "request-referrer.any.js", // TypeError: cannot read property 'href' of undefined
+  "request-upload.h2.any.js",
   "scheme-blob.sub.any.js", // TypeError: not a function
 ];
 

--- a/tests/wpt/fetch.harness.js
+++ b/tests/wpt/fetch.harness.js
@@ -24,26 +24,7 @@ export const runTestDynamic = (testSource, baseDir, done) => {
     setTimeout: setTimeout,
     DOMException: DOMException,
     location: {},
-    RESOURCES_DIR: "",
-
-    fetch: (url, option) => {
-      let data;
-      switch (url) {
-        case "../cors/resources/not-cors-safelisted.json":
-          data = require(
-            baseDir + "/fetch/api/cors/resources/not-cors-safelisted.json"
-          );
-          break;
-        case "../resources/data.json":
-          data = require(baseDir + "/fetch/api/resources/data.json");
-          break;
-        default:
-          return _fetch(url, option);
-      }
-      return Promise.resolve({
-        json: () => Promise.resolve(data),
-      });
-    },
+    RESOURCES_DIR: "http://web-platform.test:8000/fetch/api/resources/",
   };
 
   resourcesIdlharness(context);

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -74,9 +74,6 @@ Error: [Aborting rejects with AbortError] promise_rejects_dom: function "functio
 
 
 🧪/wpt/fetch.api.basic.test.js 
-fetch/api/basic > should pass accept-header.any.js tests
-Error: [Request through fetch should have a 'accept-language' header] assert_true: expected true got false
-
 fetch/api/basic > should pass conditional-get.any.js tests
 Error: [Testing conditional GET with ETags] token is not defined
 
@@ -316,22 +313,8 @@ Error: [tee() should not call Promise.prototype.then()] patched then() called
 
 
 🧪/wpt/streams.writable-streams.test.js 
-streams/writable-streams > should pass aborting.any.js tests
-undefined: undefined
-
------ LAST STDERR: -----
-
-thread 'main' panicked at /Users/shinya/Workspaces/llrt/libs/llrt_utils/src/primordials.rs:58:35:
-called `Option::unwrap()` on a `None` value
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-thread 'main' panicked at /Users/shinya/Workspaces/llrt/libs/llrt_utils/src/primordials.rs:58:35:
-called `Option::unwrap()` on a `None` value
-
-streams/writable-streams > should pass bad-strategies.any.js tests
-Error: Test timed out after 5000ms
-    at tick (llrt:test/index:480:15)
-    at <anonymous> (llrt:test/index:160:12)
+streams/writable-streams > should pass general.any.js tests
+Error: [WritableStream's strategy.size should not be called as a method] promise_test: Unhandled rejection with value: object "Error: size called as a method"
 
 
 🧪/wpt/url.test.js 

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -128,7 +128,7 @@ fetch/api/basic > should pass request-headers.any.js tests
 Error: [Fetch with PUT without body] assert_equals: Request should have header origin: undefined expected (undefined) undefined but got (object) null
 
 fetch/api/basic > should pass request-upload.any.js tests
-Error: [Fetch with POST with Blob body] assert_equals: expected "Test" but got "[object Blob]"
+Error: [Fetch with POST with DataView body] assert_equals: expected "\0\0\0\0" but got "\0\0\0\0\0\0\0\0"
 
 fetch/api/basic > should pass response-null-body.any.js tests
 Error: [Response.body is null for responses with status=204 (method=GET)] assert_equals: the body should be null expected (object) null but got (undefined) undefined

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -313,8 +313,22 @@ Error: [tee() should not call Promise.prototype.then()] patched then() called
 
 
 🧪/wpt/streams.writable-streams.test.js 
-streams/writable-streams > should pass general.any.js tests
-Error: [WritableStream's strategy.size should not be called as a method] promise_test: Unhandled rejection with value: object "Error: size called as a method"
+streams/writable-streams > should pass aborting.any.js tests
+undefined: undefined
+
+----- LAST STDERR: -----
+
+thread 'main' panicked at /Users/shinya/Workspaces/llrt/libs/llrt_utils/src/primordials.rs:58:35:
+called `Option::unwrap()` on a `None` value
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+thread 'main' panicked at /Users/shinya/Workspaces/llrt/libs/llrt_utils/src/primordials.rs:58:35:
+called `Option::unwrap()` on a `None` value
+
+streams/writable-streams > should pass bad-strategies.any.js tests
+Error: Test timed out after 5000ms
+    at tick (llrt:test/index:480:15)
+    at <anonymous> (llrt:test/index:160:12)
 
 
 🧪/wpt/url.test.js 

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -68,12 +68,14 @@ Error: [USVString handling: lone surrogate lead] Conversion from string failed: 
 
 🧪/wpt/fetch.api.abort.test.js 
 fetch/api/abort > should pass general.any.js tests
-Error: [Aborting rejects with AbortError] assert_unreached: Should have rejected: undefined Reached unreachable code
+Error: [Aborting rejects with AbortError] promise_rejects_dom: function "function() {
+            throw e;
+          }" threw object "Error: invalid format" that is not a DOMException AbortError: property "code" is equal to undefined, expected 20
 
 
 🧪/wpt/fetch.api.basic.test.js 
 fetch/api/basic > should pass accept-header.any.js tests
-Error: [Request through fetch should have 'accept' header with value '*/*'] promise_test: Unhandled rejection with value: object "Error: invalid format"
+Error: [Request through fetch should have a 'accept-language' header] assert_true: expected true got false
 
 fetch/api/basic > should pass conditional-get.any.js tests
 Error: [Testing conditional GET with ETags] token is not defined
@@ -98,19 +100,19 @@ fetch/api/basic > should pass http-response-code.any.js tests
 Error: [Fetch on 425 response should not be retried for non TLS early data.] promise_test: Unhandled rejection with value: object "ReferenceError: token is not defined"
 
 fetch/api/basic > should pass integrity.sub.any.js tests
-Error: [Empty string integrity] promise_test: Unhandled rejection with value: object "Error: client error (UserAbsoluteUriRequired)"
+Error: [Invalid integrity] assert_unreached: Should have rejected: undefined Reached unreachable code
 
 fetch/api/basic > should pass keepalive.any.js tests
 Error: [[keepalive] simple GET request on 'load' [no payload]; setting up] promise_test: Unhandled rejection with value: object "ReferenceError: token is not defined"
 
 fetch/api/basic > should pass mode-no-cors.sub.any.js tests
-Error: [Fetch top.txt with no-cors mode] promise_test: Unhandled rejection with value: object "Error: invalid format"
+Error: [Fetch http://{{host}}:{{ports[http][0]}}/fetch/api/resources/top.txt with no-cors mode] promise_test: Unhandled rejection with value: object "Error: invalid uri character"
 
 fetch/api/basic > should pass mode-same-origin.any.js tests
-Error: [Fetch top.txt with same-origin mode] promise_test: Unhandled rejection with value: object "Error: client error (UserAbsoluteUriRequired)"
+Error: [Fetch http://{{host}}:{{ports[http][0]}}/fetch/api/resources/top.txt with same-origin mode] promise_test: Unhandled rejection with value: object "Error: invalid uri character"
 
 fetch/api/basic > should pass referrer.any.js tests
-Error: [origin-when-cross-origin policy on a same-origin URL] promise_test: Unhandled rejection with value: object "Error: invalid format"
+Error: [origin-when-cross-origin policy on a same-origin URL] assert_equals: Request's referrer is correct expected (string) "[object Object]" but got (object) null
 
 fetch/api/basic > should pass request-head.any.js tests
 Error: [Fetch with HEAD with body] promise_rejects_js: function "function() {
@@ -126,16 +128,13 @@ fetch/api/basic > should pass request-headers-nonascii.any.js tests
 Error: [Non-ascii bytes in request headers] promise_test: Unhandled rejection with value: object "Error: invalid format"
 
 fetch/api/basic > should pass request-headers.any.js tests
-Error: [Fetch with GET] promise_test: Unhandled rejection with value: object "Error: invalid format"
+Error: [Fetch with PUT without body] assert_equals: Request should have header origin: undefined expected (undefined) undefined but got (object) null
 
 fetch/api/basic > should pass request-upload.any.js tests
-Error: [Fetch with PUT with body] promise_test: Unhandled rejection with value: object "Error: client error (UserAbsoluteUriRequired)"
-
-fetch/api/basic > should pass request-upload.h2.any.js tests
-Error: Timeout after 5000ms
+Error: [Fetch with POST with Blob body] assert_equals: expected "Test" but got "[object Blob]"
 
 fetch/api/basic > should pass response-null-body.any.js tests
-Error: [Response.body is null for responses with status=204 (method=GET)] promise_test: Unhandled rejection with value: object "Error: invalid format"
+Error: [Response.body is null for responses with status=204 (method=GET)] assert_equals: the body should be null expected (object) null but got (undefined) undefined
 
 fetch/api/basic > should pass response-url.sub.any.js tests
 Error: [Testing response url getter with http://{{host}}:{{ports[http][0]}}/ada] promise_test: Unhandled rejection with value: object "Error: invalid uri character"
@@ -158,7 +157,7 @@ fetch/api/basic > should pass status.h2.any.js tests
 Error: [statusText over H2 for status 200 should be the empty string] promise_test: Unhandled rejection with value: object "Error: client error (UserAbsoluteUriRequired)"
 
 fetch/api/basic > should pass stream-response.any.js tests
-Error: [Stream response's body when content-type is present] promise_test: Unhandled rejection with value: object "Error: invalid format"
+Error: [Stream response's body when content-type is present] assert_unreached: Body does not exist in response Reached unreachable code
 
 fetch/api/basic > should pass stream-safe-creation.any.js tests
 Error: [throwing Object.prototype.start accessor should not affect stream creation by 'fetch'] promise_test: Unhandled rejection with value: object "Error: client error (UserAbsoluteUriRequired)"
@@ -178,6 +177,9 @@ Error: [Headers iterator is correctly updated with set-cookie changes] assert_ar
 
 fetch/api/headers > should pass headers-basic.any.js tests
 Error: [Check keys method] assert_equals: expected object "[object Iterator]" but got object "[object Object]"
+
+fetch/api/headers > should pass headers-no-cors.any.js tests
+Error: [Loading data…] promise_test: Unhandled rejection with value: object "Error: invalid format"
 
 fetch/api/headers > should pass headers-record.any.js tests
 Error: [Basic operation with one property] assert_array_equals: lengths differ, expected array ["get", object "[object Object]", symbol "Symbol(Symbol.iterator)", object "[object Object]"] length 4, got ["has", object "[object Object]", symbol "Symbol(Symbol.iterator)"] length 3
@@ -244,7 +246,7 @@ fetch/api/response > should pass response-from-stream.any.js tests
 Error: [Constructing a Response with a stream on which getReader() is called] assert_throws_js: function "() => new Response(stream)" did not throw
 
 fetch/api/response > should pass response-headers-guard.any.js tests
-Error: [Ensure response headers are immutable] promise_test: Unhandled rejection with value: object "TypeError: cannot read property 'get' of undefined"
+Error: [Ensure response headers are immutable] promise_test: Unhandled rejection with value: object "Error: invalid format"
 
 fetch/api/response > should pass response-init-001.any.js tests
 Error: [Check default value for type attribute] assert_equals: Expect default response.type is default expected "default" but got "basic"


### PR DESCRIPTION
### Description of changes

- Although the available environments may be limited, in order to expand the scope of wpt testing, we have made it a prerequisite for running `wpt serve` when running wpt tests.
- Some tests that could not be run because the server was not present can now be run and produce different results. Some tests have insufficient URL support, which seems to have caused a regression, but we will make adjustments in another PR.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
