### PR TITLE
fix: use qjs helper functions to get the pointer

### DIFF
--- a/libs/llrt_json/src/stringify.rs
+++ b/libs/llrt_json/src/stringify.rs
@@ -3,7 +3,8 @@
 use std::{collections::HashSet, rc::Rc};
 
 use rquickjs::{
-    atom::PredefinedAtom, function::This, Ctx, Exception, Function, Object, Result, Type, Value,
+    atom::PredefinedAtom, function::This, qjs, Ctx, Exception, Function, Object, Result, Type,
+    Value,
 };
 
 use crate::escape::escape_json_string;
@@ -317,8 +318,8 @@ fn detect_circular_reference(
     ancestors: &mut Vec<(usize, Rc<str>)>,
     itoa_buffer: &mut itoa::Buffer,
 ) -> Result<()> {
-    let parent_ptr = unsafe { parent.unwrap_unchecked().as_raw().u.ptr as usize };
-    let current_ptr = unsafe { value.as_raw().u.ptr as usize };
+    let parent_ptr = unsafe { qjs::JS_VALUE_GET_PTR(parent.unwrap_unchecked().as_raw()) as usize };
+    let current_ptr = unsafe { qjs::JS_VALUE_GET_PTR(value.as_raw()) as usize };
 
     while !ancestors.is_empty()
         && match ancestors.last() {

--- a/llrt_core/src/modules/require/mod.rs
+++ b/llrt_core/src/modules/require/mod.rs
@@ -138,7 +138,7 @@ pub fn require(ctx: Ctx<'_>, specifier: String) -> Result<Value<'_>> {
     let mut executing_timers = Vec::new();
 
     // SAFETY: Since it checks in advance whether it is an Object type, we can always get a pointer to the object.
-    let uid = unsafe { obj.as_object().unwrap().as_raw().u.ptr } as usize;
+    let uid = unsafe { qjs::JS_VALUE_GET_PTR(obj.as_object().unwrap().as_raw()) } as usize;
     register_finalization_registry(&ctx, obj.clone().into_value(), uid)?;
     invoke_async_hook(&ctx, HookType::Init, ProviderType::TimerWrap, uid)?;
 

--- a/modules/llrt_async_hooks/src/lib.rs
+++ b/modules/llrt_async_hooks/src/lib.rs
@@ -11,6 +11,7 @@ use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
     prelude::Func,
     promise::PromiseHookType,
+    qjs,
     runtime::PromiseHook,
     Ctx, Function, JsLifetime, Object, Result, Value,
 };
@@ -211,11 +212,11 @@ pub fn promise_hook_tracker() -> PromiseHook {
             // SAFETY: Since it checks in advance whether it is an Object type, we can always get a pointer to the object.
             let object = promise
                 .as_object()
-                .map(|v| unsafe { v.as_raw().u.ptr } as usize)
+                .map(|v| unsafe { qjs::JS_VALUE_GET_PTR(v.as_raw()) } as usize)
                 .unwrap();
             let parent = parent
                 .as_object()
-                .map(|v| unsafe { v.as_raw().u.ptr } as usize);
+                .map(|v| unsafe { qjs::JS_VALUE_GET_PTR(v.as_raw()) } as usize);
 
             if type_ == PromiseHookType::Init {
                 let _ = register_finalization_registry(&ctx, promise, object);

--- a/modules/llrt_dns/src/lib.rs
+++ b/modules/llrt_dns/src/lib.rs
@@ -11,7 +11,7 @@ use llrt_utils::{
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
     prelude::{Func, Rest},
-    Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
+    qjs, Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
 };
 
 fn lookup<'js>(ctx: Ctx<'js>, hostname: String, args: Rest<Value<'js>>) -> Result<()> {
@@ -22,7 +22,7 @@ fn lookup<'js>(ctx: Ctx<'js>, hostname: String, args: Rest<Value<'js>>) -> Resul
         .or_throw_msg(&ctx, "Callback parameter is not a function")?;
 
     // SAFETY: Since it checks in advance whether it is an Function type, we can always get a pointer to the Function.
-    let uid = unsafe { cb.as_raw().u.ptr } as usize;
+    let uid = unsafe { qjs::JS_VALUE_GET_PTR(cb.as_raw()) } as usize;
     register_finalization_registry(&ctx, cb.clone().into_value(), uid)?;
     invoke_async_hook(&ctx, HookType::Init, ProviderType::GetAddrInfoReqWrap, uid)?;
 

--- a/modules/llrt_timers/src/lib.rs
+++ b/modules/llrt_timers/src/lib.rs
@@ -79,7 +79,7 @@ impl Default for Timeout {
 
 fn queue_microtask<'js>(_ctx: Ctx<'js>, cb: Function<'js>) -> Result<()> {
     // SAFETY: Since it checks in advance whether it is an Function type, we can always get a pointer to the Function.
-    let uid = unsafe { cb.as_raw().u.ptr } as usize;
+    let uid = unsafe { qjs::JS_VALUE_GET_PTR(cb.as_raw()) } as usize;
     register_finalization_registry(&_ctx, cb.clone().into_value(), uid)?;
     invoke_async_hook(&_ctx, HookType::Init, ProviderType::Microtask, uid)?;
     // NOTE: Defer simply registers a task in a microtask queue
@@ -97,7 +97,7 @@ pub fn set_timeout_interval<'js>(
     provider_type: ProviderType,
 ) -> Result<usize> {
     // SAFETY: Since it checks in advance whether it is an Function type, we can always get a pointer to the Function.
-    let uid = unsafe { cb.as_raw().u.ptr } as usize;
+    let uid = unsafe { qjs::JS_VALUE_GET_PTR(cb.as_raw()) } as usize;
 
     // NOTE: https://noncodersuccess.medium.com/understanding-setimmediate-vs-settimeout-in-node-js-6a3ef8fc02d4
     // If `setImmediate(fn)` and `setTimeout(fn, 0) are queued at the exact same time,
@@ -372,7 +372,7 @@ pub fn poll_timers(
 
             if let Ok(timeout) = timeout.restore(&ctx2) {
                 // SAFETY: Since it checks in advance whether it is an Function type, we can always get a pointer to the Function.
-                let uid: usize = unsafe { timeout.as_raw().u.ptr } as usize;
+                let uid: usize = unsafe { qjs::JS_VALUE_GET_PTR(timeout.as_raw()) } as usize;
 
                 invoke_async_hook(&ctx2, HookType::Before, ProviderType::None, uid)?;
 


### PR DESCRIPTION
### Issue # (if available)

Fixed #1093

### Description of changes

- We can probably get the pointer properly by using qjs's helper functions.

64bit: https://github.com/DelSkayn/rquickjs/blob/50cbbf2b163122c2456ff0ade7a242c068ee136a/sys/src/inlines/ptr_64.rs#L27-L29
```rust
#[inline]
pub unsafe fn JS_VALUE_GET_PTR(v: JSValue) -> *mut c_void {
    v.u.ptr
}
```

32bit: https://github.com/DelSkayn/rquickjs/blob/50cbbf2b163122c2456ff0ade7a242c068ee136a/sys/src/inlines/ptr_32_nan_boxing.rs#L17-L19
```rust
#[inline]
pub unsafe fn JS_VALUE_GET_PTR(v: JSValue) -> *mut c_void {
    v as isize as *mut c_void
}
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
