### PR TITLE
feat: add --executable flag to llrt compile

### DIFF
--- a/llrt_core/src/bytecode.rs
+++ b/llrt_core/src/bytecode.rs
@@ -4,6 +4,7 @@
 pub const BYTECODE_VERSION: &str = "lrt01";
 pub const BYTECODE_COMPRESSED: u8 = b'c';
 pub const BYTECODE_UNCOMPRESSED: u8 = b'u';
+pub const BYTECODE_SELF_CONTAINED_EXECUTABLE_MARKER: &str = "lrtx";
 
 macro_rules! define_extension {
     ($base:ident, $file:ident, $ext:expr) => {

--- a/llrt_core/src/compiler.rs
+++ b/llrt_core/src/compiler.rs
@@ -1,12 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::{fs, io, path::Path};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+};
 
 use rquickjs::{CatchResultExt, Context, Module, Runtime, WriteOptions};
 use tracing::trace;
 use zstd::bulk::Compressor;
 
-use crate::bytecode::add_bytecode_header;
+use crate::bytecode::{add_bytecode_header, BYTECODE_SELF_CONTAINED_EXECUTABLE_MARKER};
 use crate::compiler_common::{human_file_size, DummyLoader, DummyResolver};
 use crate::libs::{logging::print_error_and_exit, utils::result::ResultExt};
 use crate::modules::embedded::COMPRESSION_DICT;
@@ -23,6 +26,7 @@ fn compress_module(bytes: &[u8]) -> io::Result<Vec<u8>> {
 pub async fn compile_file(
     input_filename: &Path,
     output_filename: &Path,
+    create_executable: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let resolver = (DummyResolver,);
     let loader = (DummyLoader,);
@@ -52,11 +56,43 @@ pub async fn compile_file(
 
             let module = Module::declare(ctx.clone(), module_name, source)?;
             let bytes = module.write(WriteOptions::default())?;
-            let compressed = compress_module(&bytes)?;
-            fs::write(output_filename, &compressed)?;
+            let mut compressed = compress_module(&bytes)?;
 
             total_bytes += bytes.len();
             compressed_bytes += compressed.len();
+
+            if create_executable {
+                // Create the executable by prepending the LLRT runtime to the bytecode
+                let mut exe_content = Vec::new();
+
+                let executable_path = env::current_exe()
+                    .unwrap_or_else(|_| PathBuf::from(env::args().next().unwrap_or_default()));
+                let mut content = fs::read(executable_path)?;
+                exe_content.append(&mut content);
+
+                exe_content.append(&mut compressed);
+
+                let size = u64::try_from(compressed_bytes).unwrap();
+                let size_bytes = size.to_le_bytes();
+                exe_content.extend_from_slice(&size_bytes);
+
+                let marker_bytes = BYTECODE_SELF_CONTAINED_EXECUTABLE_MARKER.as_bytes();
+                exe_content.extend_from_slice(marker_bytes);
+
+                fs::write(output_filename, &exe_content)?;
+
+                // Set executable permissions on Unix systems
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let mut perms = fs::metadata(output_filename)?.permissions();
+                    perms.set_mode(0o755);
+                    fs::set_permissions(output_filename, perms)?;
+                }
+            } else {
+                fs::write(output_filename, &compressed)?;
+            }
+
             Ok(())
         })()
         .catch(&ctx)

--- a/tests/unit/compile.test.ts
+++ b/tests/unit/compile.test.ts
@@ -1,7 +1,6 @@
 import fs from "fs/promises";
 import { spawn } from "child_process";
-import { tmpdir, platform } from "os";
-const IS_WINDOWS = platform() === "win32";
+import { tmpdir } from "os";
 
 const spawnCapture = async (cmd: string, args: string[]) => {
   const child = spawn(cmd, args);
@@ -28,8 +27,17 @@ const spawnCapture = async (cmd: string, args: string[]) => {
   return { stdout, stderr, status, signal };
 };
 
-const compile = async (filename: string, outputFilename: string) =>
-  await spawnCapture(process.argv0, ["compile", filename, outputFilename]);
+const compile = async (
+  filename: string,
+  outputFilename: string,
+  executable = false
+) => {
+  const args = ["compile", filename, outputFilename];
+  if (executable) {
+    args.push("--executable");
+  }
+  return await spawnCapture(process.argv0, args);
+};
 
 const run = async (filename: string) =>
   await spawnCapture(process.argv0, [filename]);
@@ -81,6 +89,23 @@ if (false) {
       expect(runResult.stdout).toEqual("");
       expect(runResult.stderr).toEqual("42\n");
       expect(runResult.status).toEqual(1);
+    });
+
+    it("can create a self-contained executable", async () => {
+      const tmpExe = `${tmpDir}/hello_exe`;
+
+      // Create a self-contained executable
+      const compileResult = await compile("fixtures/hello.js", tmpExe, true);
+
+      expect(compileResult.stderr).toEqual("");
+      expect(compileResult.signal).toEqual(undefined);
+
+      // Check that the file exists and is executable
+      const stat = await fs.stat(tmpExe);
+      expect(stat.isFile()).toBe(true);
+
+      // 0o111 is the executable bits (uga+x)
+      expect(!!(stat.mode & 0o111)).toBe(true);
     });
 
     afterAll(async () => {

--- a/tests/unit/executable.test.ts
+++ b/tests/unit/executable.test.ts
@@ -1,0 +1,81 @@
+import { spawn } from "child_process";
+import {
+  accessSync,
+  constants,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { platform, tmpdir } from "os";
+import { join } from "path";
+
+const IS_WINDOWS = platform() === "win32";
+
+describe("executable compilation", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "llrt-test-compile"));
+  });
+
+  afterEach(async () => {
+    rmSync(tmpDir, { force: true, recursive: true });
+  });
+
+  it("should compile JavaScript to a self-contained executable", async function () {
+    // Create a temporary test script
+    const testScript = `
+      console.log("LLRT executable test");
+      console.log("Args:", process.argv);
+      process.exit(42);
+    `;
+
+    const scriptPath = join(tmpDir, "exe_test.js");
+    const exePath = join(tmpDir, "exe_test");
+
+    writeFileSync(scriptPath, testScript, "utf8");
+
+    const compileResult = await new Promise<number>((resolve, reject) => {
+      // Use cargo run to compile the script (more reliable in test environment)
+      spawn("cargo", [
+        "run",
+        "--",
+        "compile",
+        scriptPath,
+        exePath,
+        "--executable",
+      ])
+        .on("error", (err: Error) => reject(err))
+        .on("close", (code: number | null) => resolve(code ?? -1));
+    });
+
+    if (compileResult !== 0) {
+      throw new Error(`Compilation failed with exit code ${compileResult}`);
+    }
+
+    const stats = statSync(exePath);
+    if (!stats.isFile()) {
+      throw new Error("Created file is not a regular file");
+    } else if (stats.size <= 0) {
+      throw new Error("Created file is empty");
+    }
+
+    // Check executable permissions on non-Windows platforms
+    if (!IS_WINDOWS) {
+      accessSync(exePath, constants.X_OK);
+    }
+
+    // Run the executable
+    const execResult = await new Promise<number>((resolve, reject) =>
+      spawn(exePath)
+        .on("error", (err: Error) => reject(err))
+        .on("close", (code: number | null) => resolve(code ?? -1))
+    );
+
+    // Verify exit code and output
+    if (execResult !== 42) {
+      throw new Error(`Expected exit code 42, got ${execResult}`);
+    }
+  }, 60000);
+});


### PR DESCRIPTION
### Issue # (if available)

Closes #787

This is a leaner implementation than #990, but still adapts a lot of the existing work from @darcyclarke.
Instead of reading the whole binary into memory, this implementation seeks to the end of it and checks for a specific marker.

I am fairly new to Rust, so I probably made some mistakes or did not follow best practices.
If this PR were to be an acceptable starting point, I can adapt/optimize the implementation as requested.

### Description of changes

This introduces support for generating self-contained executables by passing the `--executable` option to `llrt compile`, enabling embedding of bytecode along with the runtime for easier distribution (e.g. CLI tools).

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] ~~Added relevant type info in `types/` directory~~
- [ ] ~~Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)~~

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
