### PR TITLE
feat(crypto): expose webcrypto in crypto module

### DIFF
--- a/API.md
+++ b/API.md
@@ -134,6 +134,8 @@ Everything else inherited from [Uint8Array](https://developer.mozilla.org/en-US/
 
 [randomUUID](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions)
 
+[webcrypto](https://nodejs.org/api/crypto.html#cryptowebcrypto)
+
 ## crypto.subtle
 
 [subtle.decrypt](https://nodejs.org/api/webcrypto.html#subtledecryptalgorithm-key-data)

--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -256,6 +256,7 @@ impl ModuleDef for CryptoModule {
             declare.declare(class_name)?;
         }
         declare.declare("crypto")?;
+        declare.declare("webcrypto")?;
         declare.declare("default")?;
 
         Ok(())
@@ -291,7 +292,8 @@ impl ModuleDef for CryptoModule {
             default.set("randomFillSync", Func::from(random_fill_sync))?;
             default.set("randomFill", Func::from(random_fill))?;
             default.set("getRandomValues", Func::from(get_random_values))?;
-            default.set("crypto", crypto)?;
+            default.set("crypto", crypto.clone())?;
+            default.set("webcrypto", crypto)?;
             Ok(())
         })?;
 

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -29,6 +29,10 @@ describe("crypto object/module", () => {
     expect(crypto.randomFill).toBeDefined();
     expect(defaultImport.randomFill).toBeDefined();
   });
+  it("should have a webcrypto and should be equal to globalThis.crypto", () => {
+    expect(defaultImport.webcrypto).toBeDefined();
+    expect(defaultImport.webcrypto === globalThis.crypto).toBeTruthy();
+  });
 });
 
 describe("Hashing", () => {


### PR DESCRIPTION
### Issue # (if available)

Related #537

### Description of changes

While looking up how to use LLRT in a repository, I came across a statement that the `nanoid` package would not load. 

```javascript
// reproduction.js
import { nanoid } from "nanoid";
console.log(nanoid());
```
```
% llrt reproduction.js
SyntaxError: Could not find export 'webcrypto' in module 'crypto'
```
As far as the node documentation is concerned, it is equivalent to `globalThis.crypto`, and this has also been confirmed in tests with other runtimes, so LLRT will also expose the same thing as `globalThis.crypto` as `webcrypto`.

```
% llrt reproduction.js
sUR5qTCMiKp8gYRDXjW3o

% bun reproduction.js 
VMPNLBjBGxcqi-FUTh-ER
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
