### PR TITLE
fix(require):  correctly handle wildcards in package.json

### DIFF
--- a/fixtures/node_modules/elem-hono/dist/cjs/utils/url.js
+++ b/fixtures/node_modules/elem-hono/dist/cjs/utils/url.js
@@ -1,0 +1,6 @@
+exports = module.exports;
+
+exports.str = "foo";
+exports.url = function url() {
+    return exports.str;
+}

--- a/fixtures/node_modules/elem-hono/dist/index.js
+++ b/fixtures/node_modules/elem-hono/dist/index.js
@@ -1,0 +1,6 @@
+exports = module.exports;
+
+exports.str = "bar";
+exports.url = function url() {
+    return exports.str;
+}

--- a/fixtures/node_modules/elem-hono/package.json
+++ b/fixtures/node_modules/elem-hono/package.json
@@ -1,0 +1,10 @@
+{
+    "module": "dist/index.js",
+    "exports": {
+        "./utils/*": {
+            "types": "./dist/types/utils/*.d.ts",
+            "import": "./dist/utils/*.js",
+            "require": "./dist/cjs/utils/*.js"
+        }
+    }
+}

--- a/fixtures/test_modules/test-elem-hono.js
+++ b/fixtures/test_modules/test-elem-hono.js
@@ -1,0 +1,5 @@
+const assert = require("assert");
+
+const utils = require("elem-hono/utils/url");
+
+assert.ok(utils.url() === "foo");

--- a/llrt_core/src/modules/require/resolver.rs
+++ b/llrt_core/src/modules/require/resolver.rs
@@ -785,9 +785,8 @@ fn package_exports_resolve<'a>(
             }
             // Check for wildcard pattern
             if let Some(scope) = wildcard.1 {
-                let scope = scope.as_str();
                 // Check for exports -> scope -> platform(browser or node) -> [import | require]
-                if let Some(BorrowedValue::Object(name)) = exports.get(scope) {
+                if let Some(BorrowedValue::Object(name)) = exports.get(scope.as_str()) {
                     if let Some(BorrowedValue::Object(platform)) = name.get(LLRT_PLATFORM.as_str())
                     {
                         if let Some(BorrowedValue::String(ident)) = platform.get(ident) {

--- a/llrt_core/src/modules/require/resolver.rs
+++ b/llrt_core/src/modules/require/resolver.rs
@@ -745,11 +745,9 @@ fn package_exports_resolve<'a>(
         modules_name
     };
 
-    let n = modules_name.bytes().filter(|&b| b == b'/').count();
-
-    let wildcard = if n > 1 {
-        let (_name, _scope, _) = get_name_and_scope(modules_name, n - 1);
-        (Some(_name), Some([_scope, "/*"].concat()))
+    let wildcard = if let Some(pos) = modules_name.rmatch_indices('/').nth(1) {
+        let (name, scope, _) = get_name_and_scope(modules_name, pos.0);
+        (Some(name), Some([scope, "/*"].concat()))
     } else {
         (None, None)
     };
@@ -861,11 +859,7 @@ fn package_exports_resolve<'a>(
 }
 
 fn replace_star(scope: &str, name: &str) -> String {
-    if scope.contains('*') {
-        scope.replace("*", name)
-    } else {
-        scope.into()
-    }
+    scope.replace("*", name)
 }
 
 // Implementation equivalent to PACKAGE_IMPORTS_RESOLVE including RESOLVE_ESM_MATCH

--- a/llrt_core/src/modules/require/resolver.rs
+++ b/llrt_core/src/modules/require/resolver.rs
@@ -655,10 +655,10 @@ fn load_package_exports<'a>(
         return Ok(sub_module.into());
     }
 
-    let (module_path, is_cjs) = package_exports_resolve(&package_json, name, is_esm)?;
-
+    let (module_path, resolve_path, is_cjs) = package_exports_resolve(&package_json, name, is_esm)?;
+    let module_path = resolve_path.unwrap_or_else(|| module_path.to_string());
     let module_path = to_abs_path(correct_extensions(
-        [dir, "/", scope, "/", module_path].concat(),
+        [dir, "/", scope, "/", &module_path].concat(),
     ))?;
 
     if is_cjs && is_esm {
@@ -712,10 +712,11 @@ fn load_package_self(ctx: &Ctx<'_>, x: &str, dir: &str, is_esm: bool) -> Result<
     //    "." + X.slice("name".length), `package.json` "exports", ["node", "require"])
     //    <a href="esm.md#resolver-algorithm-specification">defined in the ESM resolver</a>.
     // 6. RESOLVE_ESM_MATCH(MATCH)
-    if let Ok((path, _)) = package_exports_resolve(&package_json, name, is_esm) {
+    if let Ok((path, resolve_path, _)) = package_exports_resolve(&package_json, name, is_esm) {
+        let path = resolve_path.unwrap_or_else(|| path.to_string());
         trace!("|  load_package_self(2.c): {}", path);
         let dir = package_json_path.trim_end_matches("package.json");
-        let module_path = correct_extensions([dir, path].concat());
+        let module_path = correct_extensions([dir, &path].concat());
         return Ok(Some(module_path.into()));
     }
 
@@ -735,13 +736,22 @@ fn package_exports_resolve<'a>(
     package_json: &'a BorrowedValue<'a>,
     modules_name: &str,
     is_esm: bool,
-) -> Result<(&'a str, bool)> {
+) -> Result<(&'a str, Option<String>, bool)> {
     let ident = if is_esm { "import" } else { "require" };
 
     let modules_name = if modules_name != "." {
         &["./", modules_name].concat()
     } else {
         modules_name
+    };
+
+    let n = modules_name.bytes().filter(|&b| b == b'/').count();
+
+    let wildcard = if n > 1 {
+        let (_name, _scope, _) = get_name_and_scope(modules_name, n - 1);
+        (Some(_name), Some([_scope, "/*"].concat()))
+    } else {
+        (None, None)
     };
 
     if let BorrowedValue::Object(map) = package_json {
@@ -753,59 +763,100 @@ fn package_exports_resolve<'a>(
                 // Check for exports -> name -> platform(browser or node) -> [import | require]
                 if let Some(BorrowedValue::Object(platform)) = name.get(LLRT_PLATFORM.as_str()) {
                     if let Some(BorrowedValue::String(ident)) = platform.get(ident) {
-                        return Ok((ident.as_ref(), is_cjs));
+                        return Ok((ident.as_ref(), None, is_cjs));
                     }
                 }
                 // Check for exports -> name -> [import | require] -> default
                 if let Some(BorrowedValue::Object(ident)) = name.get(ident) {
                     if let Some(BorrowedValue::String(default)) = ident.get("default") {
-                        return Ok((default.as_ref(), is_cjs));
+                        return Ok((default.as_ref(), None, is_cjs));
                     }
                 }
                 // Check for exports -> name -> [import | require]
                 if let Some(BorrowedValue::String(ident)) = name.get(ident) {
-                    return Ok((ident.as_ref(), is_cjs));
+                    return Ok((ident.as_ref(), None, is_cjs));
                 }
                 // [CJS only] Check for exports -> name -> default
                 if !is_esm {
                     if let Some(BorrowedValue::String(default)) = name.get("default") {
-                        return Ok((default.as_ref(), is_cjs));
+                        return Ok((default.as_ref(), None, is_cjs));
+                    }
+                }
+            }
+            // Check for wildcard pattern
+            if let Some(scope) = wildcard.1 {
+                let scope = scope.as_str();
+                // Check for exports -> scope -> platform(browser or node) -> [import | require]
+                if let Some(BorrowedValue::Object(name)) = exports.get(scope) {
+                    if let Some(BorrowedValue::Object(platform)) = name.get(LLRT_PLATFORM.as_str())
+                    {
+                        if let Some(BorrowedValue::String(ident)) = platform.get(ident) {
+                            let resolve_star = replace_star(ident, wildcard.0.unwrap());
+                            return Ok((ident.as_ref(), Some(resolve_star), is_cjs));
+                        }
+                    }
+                    // Check for exports -> scope -> [import | require] -> default
+                    if let Some(BorrowedValue::Object(ident)) = name.get(ident) {
+                        if let Some(BorrowedValue::String(default)) = ident.get("default") {
+                            let resolve_star = replace_star(default, wildcard.0.unwrap());
+                            return Ok((default.as_ref(), Some(resolve_star), is_cjs));
+                        }
+                    }
+                    // Check for exports -> scope -> [import | require]
+                    if let Some(BorrowedValue::String(ident)) = name.get(ident) {
+                        let resolve_star = replace_star(ident, wildcard.0.unwrap());
+                        return Ok((ident.as_ref(), Some(resolve_star), is_cjs));
+                    }
+                    // [CJS only] Check for exports -> scope -> default
+                    if !is_esm {
+                        if let Some(BorrowedValue::String(default)) = name.get("default") {
+                            let resolve_star = replace_star(default, wildcard.0.unwrap());
+                            return Ok((default.as_ref(), Some(resolve_star), is_cjs));
+                        }
                     }
                 }
             }
             // Check for exports -> [import | require] -> default
             if let Some(BorrowedValue::Object(ident)) = exports.get(ident) {
                 if let Some(BorrowedValue::String(default)) = ident.get("default") {
-                    return Ok((default.as_ref(), is_cjs));
+                    return Ok((default.as_ref(), None, is_cjs));
                 }
             }
             // Check for exports -> [import | require]
             if let Some(BorrowedValue::String(ident)) = exports.get(ident) {
-                return Ok((ident.as_ref(), is_cjs));
+                return Ok((ident.as_ref(), None, is_cjs));
             }
             // [CJS only] Check for exports -> default
             if !is_esm {
                 if let Some(BorrowedValue::String(default)) = exports.get("default") {
-                    return Ok((default.as_ref(), is_cjs));
+                    return Ok((default.as_ref(), None, is_cjs));
                 }
             }
         }
         // Check for platform(browser or node) field
         if let Some(BorrowedValue::String(platform)) = map.get(LLRT_PLATFORM.as_str()) {
-            return Ok((platform.as_ref(), is_cjs));
+            return Ok((platform.as_ref(), None, is_cjs));
         }
         // [ESM only] Check for module field
         if is_esm {
             if let Some(BorrowedValue::String(module)) = map.get("module") {
-                return Ok((module.as_ref(), is_cjs));
+                return Ok((module.as_ref(), None, is_cjs));
             }
         }
         // Check for main field
         if let Some(BorrowedValue::String(main)) = map.get("main") {
-            return Ok((main.as_ref(), is_cjs));
+            return Ok((main.as_ref(), None, is_cjs));
         }
     }
-    Ok(("./index.js", true))
+    Ok(("./index.js", None, true))
+}
+
+fn replace_star(scope: &str, name: &str) -> String {
+    if scope.contains('*') {
+        scope.replace("*", name)
+    } else {
+        scope.into()
+    }
 }
 
 // Implementation equivalent to PACKAGE_IMPORTS_RESOLVE including RESOLVE_ESM_MATCH

--- a/llrt_core/src/modules/require/resolver.rs
+++ b/llrt_core/src/modules/require/resolver.rs
@@ -778,11 +778,9 @@ fn package_exports_resolve<'a>(
                 if let Some(BorrowedValue::String(ident)) = name.get(ident) {
                     return Ok((ident.as_ref(), None, is_cjs));
                 }
-                // [CJS only] Check for exports -> name -> default
-                if !is_esm {
-                    if let Some(BorrowedValue::String(default)) = name.get("default") {
-                        return Ok((default.as_ref(), None, is_cjs));
-                    }
+                // Check for exports -> name -> default
+                if let Some(BorrowedValue::String(default)) = name.get("default") {
+                    return Ok((default.as_ref(), None, is_cjs));
                 }
             }
             // Check for wildcard pattern
@@ -814,12 +812,10 @@ fn package_exports_resolve<'a>(
                         let resolve_star = replace_star(ident, wildcard.0.unwrap());
                         return Ok((ident.as_ref(), Some(resolve_star), is_cjs));
                     }
-                    // [CJS only] Check for exports -> scope -> default
-                    if !is_esm {
-                        if let Some(BorrowedValue::String(default)) = name.get("default") {
-                            let resolve_star = replace_star(default, wildcard.0.unwrap());
-                            return Ok((default.as_ref(), Some(resolve_star), is_cjs));
-                        }
+                    //  Check for exports -> scope -> default
+                    if let Some(BorrowedValue::String(default)) = name.get("default") {
+                        let resolve_star = replace_star(default, wildcard.0.unwrap());
+                        return Ok((default.as_ref(), Some(resolve_star), is_cjs));
                     }
                 }
             }

--- a/llrt_core/src/modules/require/resolver.rs
+++ b/llrt_core/src/modules/require/resolver.rs
@@ -772,6 +772,10 @@ fn package_exports_resolve<'a>(
                         return Ok((default.as_ref(), None, is_cjs));
                     }
                 }
+                // Check for exports -> name -> platform(browser or node)
+                if let Some(BorrowedValue::String(platform)) = name.get(LLRT_PLATFORM.as_str()) {
+                    return Ok((platform.as_ref(), None, is_cjs));
+                }
                 // Check for exports -> name -> [import | require]
                 if let Some(BorrowedValue::String(ident)) = name.get(ident) {
                     return Ok((ident.as_ref(), None, is_cjs));
@@ -800,6 +804,12 @@ fn package_exports_resolve<'a>(
                             let resolve_star = replace_star(default, wildcard.0.unwrap());
                             return Ok((default.as_ref(), Some(resolve_star), is_cjs));
                         }
+                    }
+                    // Check for exports -> scope -> platform(browser or node)
+                    if let Some(BorrowedValue::String(platform)) = name.get(LLRT_PLATFORM.as_str())
+                    {
+                        let resolve_star = replace_star(platform, wildcard.0.unwrap());
+                        return Ok((platform.as_ref(), Some(resolve_star), is_cjs));
                     }
                     // Check for exports -> scope -> [import | require]
                     if let Some(BorrowedValue::String(ident)) = name.get(ident) {

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -165,6 +165,10 @@ it("require `@aws-lambda-powertools` module element", () => {
   );
 });
 
+it("require `hono/utils/url` module element", () => {
+  _require(`${CWD}/fixtures/test_modules/test-elem-hono.js`);
+});
+
 it("regression testing for issue #903", () => {
   expect(() => _require(`${CWD}/fixtures/test903/foo.mjs`)).toThrow(
     /Error resolving module /


### PR DESCRIPTION
### Issue # (if available)

Fixed: #1129

### Description of changes

This PR will allow wildcards in package.json exports to be resolved correctly.

```javascript
// reproduction.js
import { getQueryParam } from 'hono/utils/url'
console.log(getQueryParam);
```

```
% llrt reproduction.js 
[function: _getQueryParam]

% bun reproduction.js 
[Function: _getQueryParam]
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
