### PR TITLE
chore(core,test): remove the old rand dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "98dc20cae677f0af161d98f18463804b680f9af060f6dbe6d4249bd7e838bca1"
 dependencies = [
  "hybrid-array",
  "num-traits",
- "rand_core 0.9.3",
+ "rand_core",
  "serdect",
  "subtle",
  "zeroize",
@@ -684,7 +684,7 @@ checksum = "ae744b9f528151f8c440cf67498f24d2d1ac0ab536b5ce7b1f87a7a5961bd1c1"
 dependencies = [
  "crypto-bigint",
  "libm",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -862,7 +862,7 @@ dependencies = [
  "hkdf",
  "hybrid-array",
  "pkcs8",
- "rand_core 0.9.3",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -916,7 +916,7 @@ version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core",
  "subtle",
 ]
 
@@ -1119,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
 dependencies = [
  "ff",
- "rand_core 0.9.3",
+ "rand_core",
  "subtle",
 ]
 
@@ -1750,7 +1750,6 @@ dependencies = [
  "llrt_test",
  "llrt_utils",
  "md-5 0.11.0-rc.0",
- "nanoid",
  "once_cell",
  "phf 0.13.1",
  "phf_codegen",
@@ -1797,7 +1796,7 @@ dependencies = [
  "p384",
  "p521",
  "pkcs8",
- "rand 0.9.2",
+ "rand",
  "ring",
  "rquickjs",
  "rsa",
@@ -1998,7 +1997,7 @@ dependencies = [
  "llrt_stream",
  "llrt_test",
  "llrt_utils",
- "rand 0.9.2",
+ "rand",
  "rquickjs",
  "tokio",
  "tracing",
@@ -2012,7 +2011,7 @@ dependencies = [
  "itoa",
  "llrt_test",
  "llrt_utils",
- "rand 0.9.2",
+ "rand",
  "rquickjs",
  "ryu",
 ]
@@ -2045,7 +2044,7 @@ dependencies = [
  "llrt_utils",
  "memchr",
  "once_cell",
- "rand 0.9.2",
+ "rand",
  "rquickjs",
 ]
 
@@ -2108,9 +2107,9 @@ dependencies = [
 name = "llrt_test"
 version = "0.6.2-beta"
 dependencies = [
- "nanoid",
  "rquickjs",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2249,15 +2248,6 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -2588,7 +2578,7 @@ checksum = "adc85f9f75dc05486f61bc61858535c0501a0ca81ca3117ab17befbead13c110"
 dependencies = [
  "crypto-bigint",
  "ff",
- "rand_core 0.9.3",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -2674,33 +2664,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2710,16 +2679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -2908,7 +2868,7 @@ dependencies = [
  "digest 0.11.0-rc.0",
  "pkcs1",
  "pkcs8",
- "rand_core 0.9.3",
+ "rand_core",
  "sha2",
  "signature",
  "spki",
@@ -3141,7 +3101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4835c3b5ecb10171941a4998a95a3a76ecac1c5ae8e6954f2ad030acd1c7e8ab"
 dependencies = [
  "digest 0.11.0-rc.0",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -3499,7 +3459,7 @@ dependencies = [
  "getrandom 0.3.3",
  "js-sys",
  "md-5 0.10.6",
- "rand 0.9.2",
+ "rand",
  "sha1_smol",
  "wasm-bindgen",
 ]
@@ -4034,7 +3994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2a76f35d0d6fa96ffc48330f09dc230cd6bdc118b0fce43c25085ced5d72c6b"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.9.3",
+ "rand_core",
  "zeroize",
 ]
 

--- a/libs/llrt_test/Cargo.toml
+++ b/libs/llrt_test/Cargo.toml
@@ -11,10 +11,10 @@ name = "llrt_test"
 path = "src/lib.rs"
 
 [dependencies]
-nanoid = { version = "0.4", default-features = false }
 rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0", features = [
   "futures",
   "loader",
   "parallel",
 ], default-features = false }
 tokio = { version = "1", features = ["fs"], default-features = false }
+uuid = { version = "1", features = ["v4"], default-features = false }

--- a/libs/llrt_test/src/lib.rs
+++ b/libs/llrt_test/src/lib.rs
@@ -15,7 +15,7 @@ use rquickjs::{
 
 pub async fn given_file(content: &str) -> PathBuf {
     let tmp_dir = std::env::temp_dir();
-    let path = tmp_dir.join(nanoid::nanoid!());
+    let path = tmp_dir.join(uuid::Uuid::new_v4().to_string());
     tokio::fs::write(&path, content).await.unwrap();
     path
 }

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -72,8 +72,8 @@ rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.9.0"
 ], default-features = false }
 phf_codegen = { version = "0.13", default-features = false }
 jwalk = { version = "0.8", default-features = false }
-nanoid = { version = "0.4", default-features = false }
 llrt_build = { path = "../libs/llrt_build" }
+uuid = { version = "1", features = ["v4"], default-features = false }
 
 [dev-dependencies]
 wiremock = { version = "0.6", default-features = false }

--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -233,7 +233,7 @@ fn compress_bytecode(dictionary_path: String, source_files: Vec<String>) -> io::
         info!("Compressing {}...", filename);
 
         let tmp_filename = tmp_dir
-            .join(nanoid::nanoid!())
+            .join(uuid::Uuid::new_v4().to_string())
             .to_string_lossy()
             .to_string();
 


### PR DESCRIPTION
### Description of changes

- When creating temporary files with LLRT, we used the `nanoid` crate to get unique file names.
- However, `nanoid` hasn't been updated in a long time, so it relies on an outdated `rand`, and Cargo.lock contained a mix of two versions of `rand`.
- It seemed like there would be no problem if we could generate random temporary file names, so in this PR we tidied up the dependencies by using `uuid`(v4).

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
