### PR TITLE
fix(require): support resolving modules when require path ends with a trailing slash

### DIFF
--- a/llrt_core/src/modules/embedded/resolver.rs
+++ b/llrt_core/src/modules/embedded/resolver.rs
@@ -16,6 +16,8 @@ pub struct EmbeddedResolver;
 impl Resolver for EmbeddedResolver {
     fn resolve(&mut self, _ctx: &Ctx, base: &str, name: &str) -> Result<String> {
         let name = name.trim_start_matches(CJS_IMPORT_PREFIX);
+        let name = name.trim_start_matches("node:").trim_end_matches("/");
+
         let base = base.trim_start_matches(CJS_IMPORT_PREFIX);
 
         trace!("Try resolve '{}' from '{}'", name, base);

--- a/llrt_core/src/modules/require/mod.rs
+++ b/llrt_core/src/modules/require/mod.rs
@@ -77,7 +77,10 @@ pub fn require(ctx: Ctx<'_>, specifier: String) -> Result<Value<'_>> {
         let specifier = if is_bytecode_or_json {
             specifier
         } else {
-            specifier.trim_start_matches("node:").to_string()
+            specifier
+                .trim_start_matches("node:")
+                .trim_end_matches("/")
+                .to_string()
         };
 
         if module_list.contains(specifier.as_str()) {

--- a/llrt_modules/src/module_builder.rs
+++ b/llrt_modules/src/module_builder.rs
@@ -54,7 +54,7 @@ impl ModuleResolver {
 
 impl Resolver for ModuleResolver {
     fn resolve(&mut self, _: &Ctx<'_>, base: &str, name: &str) -> Result<String> {
-        let name = name.trim_start_matches("node:");
+        let name = name.trim_start_matches("node:").trim_end_matches("/");
         if self.modules.contains(name) {
             Ok(name.into())
         } else {


### PR DESCRIPTION
### Issue # (if available)

Fixed #1150 
Related #1111

### Description of changes

- Fixed an issue where trailing slashes would not resolve correctly if the module was an internal module and not a package.

```javascript
// reproduction.js
const a = require('middy/middlewares');
console.log(a);
```

```
% llrt reproduction.js 
{
  cache: [function: (anonymous)],
  cors: [function: (anonymous)],
  doNotWaitForEmptyEventLoop: [function: (anonymous)],
  httpContentNegotiation: [function: (anonymous)],
  httpErrorHandler: [function: (anonymous)],
  httpEventNormalizer: [function: (anonymous)],
  httpHeaderNormalizer: [function: (anonymous)],
  httpMultipartBodyParser: [function: (anonymous)],
  httpPartialResponse: [function: (anonymous)],
  httpSecurityHeaders: [function: (anonymous)],
  jsonBodyParser: [function: (anonymous)],
  s3KeyNormalizer: [function: (anonymous)],
  secretsManager: [function: (anonymous)],
  ssm: [function: (anonymous)],
  urlEncodeBodyParser: [function: (anonymous)],
  validator: [function: (anonymous)],
  warmup: [function: (anonymous)]
}
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
