### PR TITLE
feat(embedded): expose stream/promises by polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,35 +104,36 @@ The test runner also has support for filters. Using filters is as simple as addi
 > [!NOTE]
 > LLRT only support a fraction of the Node.js APIs. It is **NOT** a drop in replacement for Node.js, nor will it ever be. Below is a high level overview of partially supported APIs and modules. For more details consult the [API](API.md) documentation
 
-| Modules        | Node.js | LLRT ⚠️ |
-| -------------- | ------- | ------- |
-| assert         | ✔︎     | ✔︎️    |
-| async_hooks    | ✔︎     | ✔︎️    |
-| buffer         | ✔︎     | ✔︎️    |
-| child_process  | ✔︎     | ✔︎⏱   |
-| console        | ✔︎     | ✔︎     |
-| crypto         | ✔︎     | ✔︎     |
-| dns            | ✔︎     | ✔︎     |
-| events         | ✔︎     | ✔︎     |
-| fs/promises    | ✔︎     | ✔︎     |
-| fs             | ✔︎     | ✘⏱     |
-| http           | ✔︎     | ✘⏱\*\* |
-| https          | ✔︎     | ✘⏱\*\* |
-| net:sockets    | ✔︎     | ✔︎⏱   |
-| net:server     | ✔︎     | ✔︎     |
-| os             | ✔︎     | ✔︎     |
-| path           | ✔︎     | ✔︎     |
-| perf_hooks     | ✔︎     | ✔︎     |
-| process        | ✔︎     | ✔︎     |
-| streams        | ✔︎     | ✔︎\*   |
-| string_decoder | ✔︎     | ✔︎     |
-| timers         | ✔︎     | ✔︎     |
-| tty            | ✔︎     | ✔︎     |
-| url            | ✔︎     | ✔︎     |
-| util           | ✔︎     | ✔︎     |
-| tls            | ✔︎     | ✘⏱     |
-| zlib           | ✔︎     | ✔︎     |
-| Other modules  | ✔︎     | ✘       |
+| Modules         | Node.js | LLRT ⚠️ |
+| --------------- | ------- | ------- |
+| assert          | ✔︎     | ✔︎️    |
+| async_hooks     | ✔︎     | ✔︎️    |
+| buffer          | ✔︎     | ✔︎️    |
+| child_process   | ✔︎     | ✔︎⏱   |
+| console         | ✔︎     | ✔︎     |
+| crypto          | ✔︎     | ✔︎     |
+| dns             | ✔︎     | ✔︎     |
+| events          | ✔︎     | ✔︎     |
+| fs/promises     | ✔︎     | ✔︎     |
+| fs              | ✔︎     | ✘⏱     |
+| http            | ✔︎     | ✘⏱\*\* |
+| https           | ✔︎     | ✘⏱\*\* |
+| net:sockets     | ✔︎     | ✔︎⏱   |
+| net:server      | ✔︎     | ✔︎     |
+| os              | ✔︎     | ✔︎     |
+| path            | ✔︎     | ✔︎     |
+| perf_hooks      | ✔︎     | ✔︎     |
+| process         | ✔︎     | ✔︎     |
+| stream/promises | ✔︎     | ✔︎\*   |
+| stream          | ✔︎     | ✔︎\*   |
+| string_decoder  | ✔︎     | ✔︎     |
+| timers          | ✔︎     | ✔︎     |
+| tty             | ✔︎     | ✔︎     |
+| url             | ✔︎     | ✔︎     |
+| util            | ✔︎     | ✔︎     |
+| tls             | ✔︎     | ✘⏱     |
+| zlib            | ✔︎     | ✔︎     |
+| Other modules   | ✔︎     | ✘       |
 
 | Features    | Node.js | LLRT ⚠️ |
 | ----------- | ------- | ------- |

--- a/build.mjs
+++ b/build.mjs
@@ -44,7 +44,12 @@ const AWS_JSON_SHARED_COMMAND_REGEX2 =
   /{\s*const\s*headers\s*=\s*sharedHeaders\(("\w+")\);\s*let body;\s*body\s*=\s*JSON.stringify\((\w+)\(input,\s*context\)\);\s*return buildHttpRpcRequest\(context,\s*headers,\s*"\/",\s*undefined,\s*body\);\s*}/gm;
 const MINIFY_JS = process.env.JS_MINIFY !== "0";
 const SDK_UTILS_PACKAGE = "sdk-utils";
-const ENTRYPOINTS = ["stream", "@llrt/test/index", "@llrt/test/worker"];
+const ENTRYPOINTS = [
+  "stream",
+  "stream/promises",
+  "@llrt/test/index",
+  "@llrt/test/worker",
+];
 
 const ES_BUILD_OPTIONS = {
   splitting: MINIFY_JS,

--- a/llrt_core/src/modules/js/stream/promises.ts
+++ b/llrt_core/src/modules/js/stream/promises.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// @ts-ignore
+import { finished, pipeline } from "readable-stream/lib/stream/promises.js";
+
+export { finished, pipeline };

--- a/llrt_modules/README.md
+++ b/llrt_modules/README.md
@@ -137,7 +137,7 @@ async fn main() -> Result<(), Error> {
 | os             | ✔︎     | ⚠️           | `os`             | `llrt_os`             |
 | path           | ✔︎     | ✔︎          | `path`           | `llrt_path`           |
 | perf hooks     | ✔︎     | ⚠️           | `perf-hooks`     | `llrt_perf_hooks`     |
-| stream         | ✔︎     | ⚠️           | N/A              | `llrt_stream`         |
+| stream (lib)   | N/A     | ✔︎          | N/A              | `llrt_stream`         |
 | string_decoder | ✔︎     | ✔︎          | `string_decoder` | `llrt_string_decoder` |
 | timers         | ✔︎     | ✔︎          | `timers`         | `llrt_timers`         |
 | process        | ✔︎     | ✔︎          | `process`        | `llrt_process`        |


### PR DESCRIPTION
### Description of changes

- Currently, LLRT exposes a node-compatible stream-polyfill as embedded code.
- This PR exposes `stream/promises` in the same way as `stream`.

```javascript
// reproduction.js
import { Readable } from "node:stream"; console.log(Readable);
import { Writable } from "node:stream"; console.log(Writable);
import { Duplex } from "node:stream"; console.log(Duplex);
import { Transform } from "node:stream"; console.log(Transform);
import { PassThrough } from "node:stream"; console.log(PassThrough);
import { finished } from "node:stream"; console.log(finished);
import { pipeline } from "node:stream"; console.log(pipeline);

import { finished as promises_finished } from "node:stream/promises"; console.log(promises_finished);
import { pipeline as promises_pipeline } from "node:stream/promises"; console.log(promises_pipeline);
```

```
% llrt reproduction.js              
[function: Readable]
[function: Writable]
[function: Duplex]
[function: Transform]
[function: PassThrough]
[function: finished]
[function: pipeline]
[function: finished]
[function: pipeline]
```

However, this is for compatibility purposes only, and since it is not native code written in Rust, you cannot expect performance improvements.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
