### PR TITLE
fix(stream/web): primordials are used before initialization

### DIFF
--- a/modules/llrt_stream_web/src/lib.rs
+++ b/modules/llrt_stream_web/src/lib.rs
@@ -90,12 +90,6 @@ impl ModuleDef for StreamWebModule {
             Class::<ByteLengthQueuingStrategy>::define(default)?;
             Class::<CountQueuingStrategy>::define(default)?;
 
-            BasePrimordials::init(ctx)?;
-            PromisePrimordials::init(ctx)?;
-            ArrayConstructorPrimordials::init(ctx)?;
-            WritableStreamDefaultControllerPrimordials::init(ctx)?;
-            IteratorPrimordials::init(ctx)?;
-
             Ok(())
         })?;
 
@@ -114,6 +108,12 @@ impl From<StreamWebModule> for ModuleInfo<StreamWebModule> {
 
 pub fn init(ctx: &Ctx) -> Result<()> {
     let globals = &ctx.globals();
+
+    BasePrimordials::init(ctx)?;
+    PromisePrimordials::init(ctx)?;
+    ArrayConstructorPrimordials::init(ctx)?;
+    WritableStreamDefaultControllerPrimordials::init(ctx)?;
+    IteratorPrimordials::init(ctx)?;
 
     // https://min-common-api.proposal.wintertc.org/#api-index
     Class::<ByteLengthQueuingStrategy>::define(globals)?;

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -277,22 +277,8 @@ Error: [tee() should not call Promise.prototype.then()] patched then() called
 
 
 🧪/wpt/streams.writable-streams.test.js 
-streams/writable-streams > should pass aborting.any.js tests
-undefined: undefined
-
------ LAST STDERR: -----
-
-thread 'main' panicked at /Users/shinya/Workspaces/llrt/libs/llrt_utils/src/primordials.rs:58:35:
-called `Option::unwrap()` on a `None` value
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
-thread 'main' panicked at /Users/shinya/Workspaces/llrt/libs/llrt_utils/src/primordials.rs:58:35:
-called `Option::unwrap()` on a `None` value
-
-streams/writable-streams > should pass bad-strategies.any.js tests
-Error: Test timed out after 5000ms
-    at tick (llrt:test/index:480:15)
-    at <anonymous> (llrt:test/index:160:12)
+streams/writable-streams > should pass general.any.js tests
+Error: [WritableStream's strategy.size should not be called as a method] promise_test: Unhandled rejection with value: object "Error: size called as a method"
 
 
 🧪/wpt/url.test.js 


### PR DESCRIPTION
### Issue # (if available)

Fixed #1183 

### Description of changes

- The initialization routine was written in a location that runs when loaded as a `stream/web` module.
- This caused an issue where the routine was used before initialization when accessed from global, which has now been fixed.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
