### PR TITLE
feat(fs): add mode option support for writeFile on unix

### DIFF
--- a/modules/llrt_fs/src/write_file.rs
+++ b/modules/llrt_fs/src/write_file.rs
@@ -1,17 +1,40 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
-use rquickjs::{Ctx, Result, Value};
+use either::Either;
+use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
+use rquickjs::{function::Opt, Ctx, Error, FromJs, Result, Value};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
-pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> Result<()> {
+pub async fn write_file<'js>(
+    ctx: Ctx<'js>,
+    path: String,
+    data: Value<'js>,
+    options: Opt<Either<String, WriteFileOptions>>,
+) -> Result<()> {
     let write_error_message = &["Can't write file \"", &path, "\""].concat();
 
     let mut file = fs::File::create(&path)
         .await
         .or_throw_msg(&ctx, write_error_message)?;
+
+    #[cfg(unix)]
+    if let Some(Either::Right(opts)) = options.0 {
+        use std::os::unix::fs::PermissionsExt;
+
+        let perm = PermissionsExt::from_mode(opts.mode.unwrap_or(0o666));
+        file.set_permissions(perm)
+            .await
+            .or_throw_msg(&ctx, write_error_message)?;
+    }
+    #[cfg(not(unix))]
+    {
+        _ = options;
+        if let Some(Either::Right(opts)) = options.0 {
+            _ = opts.mode;
+        }
+    }
 
     let bytes = ObjectBytes::from(&ctx, &data)?;
     file.write_all(bytes.as_bytes(&ctx)?)
@@ -22,9 +45,48 @@ pub async fn write_file<'js>(ctx: Ctx<'js>, path: String, data: Value<'js>) -> R
     Ok(())
 }
 
-pub fn write_file_sync<'js>(ctx: Ctx<'js>, path: String, bytes: ObjectBytes<'js>) -> Result<()> {
-    std::fs::write(&path, bytes.as_bytes(&ctx)?)
-        .or_throw_msg(&ctx, &["Can't write \"{}\"", &path].concat())?;
+pub fn write_file_sync<'js>(
+    ctx: Ctx<'js>,
+    path: String,
+    bytes: ObjectBytes<'js>,
+    options: Opt<Either<String, WriteFileOptions>>,
+) -> Result<()> {
+    let write_error_message = &["Can't write file \"", &path, "\""].concat();
+    std::fs::write(&path, bytes.as_bytes(&ctx)?).or_throw_msg(&ctx, write_error_message)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(Either::Right(opts)) = options.0 {
+            use std::os::unix::fs::PermissionsExt;
+
+            std::fs::set_permissions(path, PermissionsExt::from_mode(opts.mode.unwrap_or(0o666)))
+                .or_throw_msg(&ctx, write_error_message)?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        _ = options;
+        if let Some(Either::Right(opts)) = options.0 {
+            _ = opts.mode;
+        }
+    }
 
     Ok(())
+}
+
+pub(crate) struct WriteFileOptions {
+    pub mode: Option<u32>,
+}
+
+impl<'js> FromJs<'js> for WriteFileOptions {
+    fn from_js(_ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
+        let ty_name = value.type_name();
+        let obj = value
+            .as_object()
+            .ok_or(Error::new_from_js(ty_name, "Object"))?;
+
+        let mode = obj.get_optional::<_, u32>("mode")?;
+
+        Ok(Self { mode })
+    }
 }

--- a/tests/unit/fs.test.ts
+++ b/tests/unit/fs.test.ts
@@ -296,9 +296,24 @@ describe("writeFile", () => {
 
     await rmdir(tmpDir, { recursive: true });
   });
+
+  if (!IS_WINDOWS) {
+    it("should write file with permissions", async () => {
+      const tmpDir = await mkdtemp(path.join(os.tmpdir(), "test-"));
+      const filePath = path.join(tmpDir, "test");
+      const fileContents = "hello";
+      const mode = 0o644;
+      await writeFile(filePath, fileContents, { mode });
+
+      const stats = statSync(filePath);
+      expect(stats.mode & 0o777).toEqual(mode);
+
+      await rmdir(tmpDir, { recursive: true });
+    });
+  }
 });
 
-describe("writeFile synchronously", () => {
+describe("writeFileSync", () => {
   it("should write a file", () => {
     const tmpDir = mkdtempSync(path.join(os.tmpdir(), "test-"));
     const filePath = path.join(tmpDir, "test");
@@ -311,6 +326,21 @@ describe("writeFile synchronously", () => {
 
     rmdirSync(tmpDir, { recursive: true });
   });
+
+  if (!IS_WINDOWS) {
+    it("should write file with permissions", async () => {
+      const tmpDir = await mkdtemp(path.join(os.tmpdir(), "test-"));
+      const filePath = path.join(tmpDir, "test");
+      const fileContents = "hello";
+      const mode = 0o644;
+      writeFileSync(filePath, fileContents, { mode });
+
+      const stats = statSync(filePath);
+      expect(stats.mode & 0o777).toEqual(mode);
+
+      rmdirSync(tmpDir, { recursive: true });
+    });
+  }
 });
 
 describe("rm", () => {

--- a/types/fs.d.ts
+++ b/types/fs.d.ts
@@ -287,7 +287,12 @@ declare module "fs" {
       | Buffer
       | QuickJS.ArrayBufferView
       | ArrayBuffer
-      | SharedArrayBuffer
+      | SharedArrayBuffer,
+    options?:
+      | {
+          mode?: Mode | undefined;
+        }
+      | undefined
   ): void;
 
   export namespace constants {

--- a/types/fs/promises.d.ts
+++ b/types/fs/promises.d.ts
@@ -448,7 +448,12 @@ declare module "fs/promises" {
       | Buffer
       | QuickJS.ArrayBufferView
       | ArrayBuffer
-      | SharedArrayBuffer
+      | SharedArrayBuffer,
+    options?:
+      | {
+          mode?: Mode | undefined;
+        }
+      | undefined
   ): Promise<void>;
 
   /**


### PR DESCRIPTION
### Description of changes

Add mode option support for writeFile on unix (i.e. `await writeFile(filePath, fileContents, { mode: 0o644 })`)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
