### PR TITLE
fix: initialize BasePrimordials in process_input test

### DIFF
--- a/llrt/src/repl.rs
+++ b/llrt/src/repl.rs
@@ -245,6 +245,7 @@ fn write_history(history: &VecDeque<String>, history_file: Option<&Path>) {
 #[cfg(test)]
 mod tests {
 
+    use llrt_core::libs::utils::primordials::{BasePrimordials, Primordial};
     use llrt_test::test_async_with;
 
     use crate::repl::process_input;
@@ -253,6 +254,7 @@ mod tests {
     async fn test_process_input() {
         test_async_with(|ctx| {
             Box::pin(async move {
+                BasePrimordials::init(&ctx).unwrap();
                 let output = process_input(&ctx, "throw new Error('err')", false).await;
 
                 assert_eq!(output, "Error: err\n  at <eval> (eval_script:1:10)");


### PR DESCRIPTION
### Issue # (if available)

Fix https://github.com/awslabs/llrt/issues/1186

### Description of changes

Initialize BasePrimordials in process_input test

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
