### PR TITLE
Install Rust toolchain before adding target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,26 +105,26 @@ build: js
 
 ifeq ($(DETECTED_OS),windows)
 stdlib:
-	rustup target add $(TARGET_windows_x86_64)
 	rustup toolchain install $(RUST_VERSION) --target $(TARGET_windows_x86_64)
+	rustup target add $(TARGET_windows_x86_64)
 	rustup component add rust-src --toolchain $(RUST_VERSION) --target $(TARGET_windows_x86_64)
 else
 stdlib-x64:
-	rustup target add $(TARGET_linux_x86_64)
 	rustup toolchain install $(RUST_VERSION) --target $(TARGET_linux_x86_64)
+	rustup target add $(TARGET_linux_x86_64)
 	rustup component add rust-src --toolchain $(RUST_VERSION) --target $(TARGET_linux_x86_64)
 
 stdlib-arm64:
-	rustup target add $(TARGET_linux_arm64)
 	rustup toolchain install $(RUST_VERSION) --target $(TARGET_linux_arm64)
+	rustup target add $(TARGET_linux_arm64)
 	rustup component add rust-src --toolchain $(RUST_VERSION) --target $(TARGET_linux_arm64)
 
 stdlib: | stdlib-x64 stdlib-arm64
 endif
 
 toolchain:
-	rustup target add $(CURRENT_TARGET)
 	rustup toolchain install $(RUST_VERSION) --target $(CURRENT_TARGET)
+	rustup target add $(CURRENT_TARGET)
 	rustup component add rust-src --toolchain $(RUST_VERSION) --target $(CURRENT_TARGET)
 
 clean-js:


### PR DESCRIPTION
### Issue # (if available)

<!--  **Please post the link to the resolved issue** -->

### Description of changes

In systems that uses rustup from the distro's repository (e.g. Debian 13, Arch Linux), the default toolchain may not be set during fresh install.

<img width="1032" height="115" alt="Screenshot_20251103_180238" src="https://github.com/user-attachments/assets/9aa94a46-19d1-467b-a684-5cbfa6c43241" />

<img width="1028" height="113" alt="Screenshot_20251103_170138" src="https://github.com/user-attachments/assets/06c7ae53-e983-4aba-9cac-fb8e648b7b46" />

This will cause build errors with the current Makefile where adding a Rust target is done first before adding any toolchain that rustup can use.

The solution is to install a toolchain before adding a target. Doing this does not affect anything in the current build routine and is compatible with llrt's recommended installation of rustup via online shell script.

Note that rustup will suggest to set a default toolchain like `rustup default stable`. This is not needed nor mattered when building llrt. We can go straight install the nightly toolchain and the rest of the build commands in Makefile will be able to use this.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes
- [ ] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
