### PR TITLE
chore(tests): refactor test utilities and improve error handling tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,10 +22,10 @@ linker = "./linker/cc-x86_64-linux-musl"
 ar = "./linker/ar"
 
 [env]
-CC_aarch64_apple_darwin = "clang"
-CC_x86_64_apple_darwin = "clang"
-CXX_aarch64_apple_darwin = "clang"
-CXX_x86_64_apple_darwin = "clang"
+CC_aarch64_apple_darwin = "/usr/bin/clang"
+CC_x86_64_apple_darwin = "/usr/bin/clang"
+CXX_aarch64_apple_darwin = "/usr/bin/clang"
+CXX_x86_64_apple_darwin = "/usr/bin/clang"
 
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc", "std", "panic_abort"]

--- a/llrt_core/src/modules/js/@llrt/test/index.ts
+++ b/llrt_core/src/modules/js/@llrt/test/index.ts
@@ -662,8 +662,8 @@ class TestServer {
         }
       }
       process.exitCode = 1;
+      console.error(output);
     }
-    console.error(output);
   }
 
   private printSuiteResult(result: SuiteResult, depth = 0): string {

--- a/tests/unit/compile.test.ts
+++ b/tests/unit/compile.test.ts
@@ -1,31 +1,6 @@
 import fs from "node:fs/promises";
-import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
-
-const spawnCapture = async (cmd: string, args: string[]) => {
-  const child = spawn(cmd, args);
-
-  let stdout = "";
-  let stderr = "";
-
-  child.stdout.on("data", (data) => {
-    stdout += data.toString();
-  });
-
-  child.stderr.on("data", (data) => {
-    stderr += data.toString();
-  });
-
-  const [status, signal] = await new Promise<
-    [number | null, NodeJS.Signals | null]
-  >((resolve) => {
-    child.on("close", (code, sig) => {
-      resolve([code ?? -1, sig]);
-    });
-  });
-
-  return { stdout, stderr, status, signal };
-};
+import { spawnCapture } from "./test-utils";
 
 const compile = async (
   filename: string,
@@ -36,80 +11,83 @@ const compile = async (
   if (executable) {
     args.push("--executable");
   }
-  return await spawnCapture(process.argv0, args);
+  const { code, stdout, stderr } = await spawnCapture(process.argv0, args);
+  return { stdout, stderr, status: code, signal: undefined };
 };
 
-const run = async (filename: string) =>
-  await spawnCapture(process.argv0, [filename]);
+const run = async (filename: string) => {
+  const { code, stdout, stderr } = await spawnCapture(process.argv0, [
+    filename,
+  ]);
+  return { stdout, stderr, status: code };
+};
 
-if (false) {
-  describe("llrt compile", async () => {
-    const tmpDir = await fs.mkdtemp(`${tmpdir()}/llrt-test-compile`);
+describe("llrt compile", async () => {
+  const tmpDir = await fs.mkdtemp(`${tmpdir()}/llrt-test-compile`);
 
-    it("can compile and run empty", async () => {
-      const tmpOutput = `${tmpDir}/empty.lrt`;
+  it("can compile and run empty", async () => {
+    const tmpOutput = `${tmpDir}/empty.lrt`;
 
-      const compileResult = await compile("fixtures/empty.js", tmpOutput);
+    const compileResult = await compile("fixtures/empty.js", tmpOutput);
 
-      expect(compileResult.stderr).toEqual("");
-      expect(compileResult.signal).toEqual(undefined);
+    expect(compileResult.stderr).toEqual("");
+    expect(compileResult.signal).toEqual(undefined);
 
-      const runResult = await run(tmpOutput);
+    const runResult = await run(tmpOutput);
 
-      expect(runResult.stdout).toEqual("");
-      expect(runResult.stderr).toEqual("");
-      expect(runResult.status).toEqual(0);
-    });
-
-    it("can compile and run console.log", async () => {
-      const tmpOutput = `${tmpDir}/console.log.lrt`;
-
-      const compileResult = await compile("fixtures/hello.js", tmpOutput);
-
-      expect(compileResult.stderr).toEqual("");
-      expect(compileResult.signal).toEqual(undefined);
-
-      const runResult = await run(tmpOutput);
-
-      expect(runResult.stdout).toEqual("hello world!\n");
-      expect(runResult.stderr).toEqual("");
-      expect(runResult.status).toEqual(0);
-    });
-
-    it("can compile and run throws", async () => {
-      const tmpOutput = `${tmpDir}/throws.lrt`;
-
-      const compileResult = await compile("fixtures/throw.js", tmpOutput);
-
-      expect(compileResult.stderr).toEqual("");
-      expect(compileResult.signal).toEqual(undefined);
-
-      const runResult = await run(tmpOutput);
-
-      expect(runResult.stdout).toEqual("");
-      expect(runResult.stderr).toEqual("42\n");
-      expect(runResult.status).toEqual(1);
-    });
-
-    it("can create a self-contained executable", async () => {
-      const tmpExe = `${tmpDir}/hello_exe`;
-
-      // Create a self-contained executable
-      const compileResult = await compile("fixtures/hello.js", tmpExe, true);
-
-      expect(compileResult.stderr).toEqual("");
-      expect(compileResult.signal).toEqual(undefined);
-
-      // Check that the file exists and is executable
-      const stat = await fs.stat(tmpExe);
-      expect(stat.isFile()).toBe(true);
-
-      // 0o111 is the executable bits (uga+x)
-      expect(!!(stat.mode & 0o111)).toBe(true);
-    });
-
-    afterAll(async () => {
-      await fs.rmdir(tmpDir, { recursive: true });
-    });
+    expect(runResult.stdout).toEqual("");
+    expect(runResult.stderr).toEqual("");
+    expect(runResult.status).toEqual(0);
   });
-}
+
+  it("can compile and run console.log", async () => {
+    const tmpOutput = `${tmpDir}/console.log.lrt`;
+
+    const compileResult = await compile("fixtures/hello.js", tmpOutput);
+
+    expect(compileResult.stderr).toEqual("");
+    expect(compileResult.signal).toEqual(undefined);
+
+    const runResult = await run(tmpOutput);
+
+    expect(runResult.stdout).toEqual("hello world!\n");
+    expect(runResult.stderr).toEqual("");
+    expect(runResult.status).toEqual(0);
+  });
+
+  it("can compile and run throws", async () => {
+    const tmpOutput = `${tmpDir}/throws.lrt`;
+
+    const compileResult = await compile("fixtures/throw.js", tmpOutput);
+
+    expect(compileResult.stderr).toEqual("");
+    expect(compileResult.signal).toEqual(undefined);
+
+    const runResult = await run(tmpOutput);
+
+    expect(runResult.stdout).toEqual("");
+    expect(runResult.stderr).toEqual("42\n");
+    expect(runResult.status).toEqual(1);
+  });
+
+  it("can create a self-contained executable", async () => {
+    const tmpExe = `${tmpDir}/hello_exe`;
+
+    // Create a self-contained executable
+    const compileResult = await compile("fixtures/hello.js", tmpExe, true);
+
+    expect(compileResult.stderr).toEqual("");
+    expect(compileResult.signal).toEqual(undefined);
+
+    // Check that the file exists and is executable
+    const stat = await fs.stat(tmpExe);
+    expect(stat.isFile()).toBe(true);
+
+    // 0o111 is the executable bits (uga+x)
+    expect(!!(stat.mode & 0o111)).toBe(true);
+  });
+
+  afterAll(async () => {
+    await fs.rmdir(tmpDir, { recursive: true });
+  });
+});

--- a/tests/unit/require.test.ts
+++ b/tests/unit/require.test.ts
@@ -1,6 +1,7 @@
-globalThis._require = require; //used to preserve require during bundling/minification
+const _require = require; //used to preserve require during bundling/minification
 const CWD = process.cwd();
 import { spawn } from "node:child_process";
+import { spawnCapture } from "./test-utils";
 
 import { platform } from "node:os";
 const IS_WINDOWS = platform() === "win32";
@@ -176,21 +177,12 @@ it("regression testing for issue #903", () => {
 });
 
 //create a test that spawns a subprocess and executes require.mjs from fixtures and captures stdout
-it("should handle blocking requires", (done) => {
-  const proc = spawn(process.argv0, [`${CWD}/fixtures/require.mjs`]);
-  let stdout = "";
-  proc.stdout.on("data", (data) => {
-    stdout += data.toString();
-  });
-  proc.on("close", (code) => {
-    try {
-      expect(code).toBe(0);
-      expect(stdout).toBe(
-        ["1", "2", "3", "4", "5", "hello world!", "6", ""].join("\n")
-      );
-      done();
-    } catch (e) {
-      done(e);
-    }
-  });
+it("should handle blocking requires", async () => {
+  const { code, stdout } = await spawnCapture(process.argv0, [
+    `${CWD}/fixtures/require.mjs`,
+  ]);
+  expect(code).toBe(0);
+  expect(stdout).toBe(
+    ["1", "2", "3", "4", "5", "hello world!", "6", ""].join("\n")
+  );
 });

--- a/tests/unit/test-utils.ts
+++ b/tests/unit/test-utils.ts
@@ -1,0 +1,20 @@
+import { spawn } from "node:child_process";
+
+export const spawnCapture = (
+  cmd: string,
+  args: string[] = [],
+  options?: { env?: Record<string, string> }
+): Promise<{ code: number; stdout: string; stderr: string }> =>
+  new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const child = spawn(cmd, args, options);
+    child.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+    child.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+    child.on("close", (code) => resolve({ code: code ?? -1, stdout, stderr }));
+    child.on("error", reject);
+  });


### PR DESCRIPTION
### Description of changes

Minor tests refactor. Also fixed a bug where test output was displayed twice on when there was zero failures.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
