### PR TITLE
feat(console): Improve console namespace compatibility

### DIFF
--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -372,15 +372,12 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     console.set("log", Func::from(log))?;
     console.set("trace", Func::from(log_trace))?;
     console.set("warn", Func::from(log_warn))?;
-
     console.prop(
         PredefinedAtom::SymbolToStringTag,
         Property::from("console").configurable(),
     )?;
-    globals.prop(
-        "console",
-        Property::from(console.clone()).writable().configurable(),
-    )?;
+
+    globals.prop("console", Property::from(console).writable().configurable())?;
 
     Ok(())
 }

--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -360,9 +360,8 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
 
     let globals = ctx.globals();
 
-    // NOTE: Console must be created from an empty object with no prototype.
-    // https://console.spec.whatwg.org/#console-namespace
-    let console = ctx.eval::<Object, &str>("Object.create({})")?;
+    let proto = Object::new(ctx.clone())?;
+    let console = Object::new_proto(ctx.clone(), Some(&proto))?;
 
     console.set("assert", Func::from(log_assert))?;
     console.set("clear", Func::from(clear))?;

--- a/llrt_core/src/modules/console.rs
+++ b/llrt_core/src/modules/console.rs
@@ -11,7 +11,9 @@ use std::{
 
 use jiff::Timestamp;
 use rquickjs::{
+    atom::PredefinedAtom,
     module::{Declarations, Exports, ModuleDef},
+    object::Property,
     prelude::{Func, Rest},
     Array, Class, Ctx, Object, Result, Value,
 };
@@ -358,7 +360,9 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
 
     let globals = ctx.globals();
 
-    let console = Object::new(ctx.clone())?;
+    // NOTE: Console must be created from an empty object with no prototype.
+    // https://console.spec.whatwg.org/#console-namespace
+    let console = ctx.eval::<Object, &str>("Object.create({})")?;
 
     console.set("assert", Func::from(log_assert))?;
     console.set("clear", Func::from(clear))?;
@@ -369,7 +373,14 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     console.set("trace", Func::from(log_trace))?;
     console.set("warn", Func::from(log_warn))?;
 
-    globals.set("console", console)?;
+    console.prop(
+        PredefinedAtom::SymbolToStringTag,
+        Property::from("console").configurable(),
+    )?;
+    globals.prop(
+        "console",
+        Property::from(console.clone()).writable().configurable(),
+    )?;
 
     Ok(())
 }

--- a/modules/llrt_console/src/lib.rs
+++ b/modules/llrt_console/src/lib.rs
@@ -157,15 +157,12 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     console.set("log", Func::from(log))?;
     console.set("trace", Func::from(log_trace))?;
     console.set("warn", Func::from(log_warn))?;
-
     console.prop(
         PredefinedAtom::SymbolToStringTag,
         Property::from("console").configurable(),
     )?;
-    globals.prop(
-        "console",
-        Property::from(console.clone()).writable().configurable(),
-    )?;
+
+    globals.prop("console", Property::from(console).writable().configurable())?;
 
     Ok(())
 }

--- a/modules/llrt_console/src/lib.rs
+++ b/modules/llrt_console/src/lib.rs
@@ -145,9 +145,8 @@ impl From<ConsoleModule> for ModuleInfo<ConsoleModule> {
 pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     let globals = ctx.globals();
 
-    // NOTE: Console must be created from an empty object with no prototype.
-    // https://console.spec.whatwg.org/#console-namespace
-    let console = ctx.eval::<Object, &str>("Object.create({})")?;
+    let proto = Object::new(ctx.clone())?;
+    let console = Object::new_proto(ctx.clone(), Some(&proto))?;
 
     console.set("assert", Func::from(log_assert))?;
     console.set("clear", Func::from(clear))?;

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -32,18 +32,8 @@ Error: [SubtleCrypto.supports method exists] assert_true: SubtleCrypto.supports 
 
 
 🧪/wpt/console.test.js 
-console > should pass console-is-a-namespace.any.js tests
-Error: [console has the right property descriptors] assert_equals: must not be enumerable expected false but got true
-
 console > should pass console-label-conversion.any.js tests
 Error: [console.count()'s label gets converted to string via label.toString() when label is an object] not a function
-
-console > should pass console-namespace-object-class-string.any.js tests
-Error: [@@toStringTag exists on the namespace object with the appropriate descriptor] assert_own_property: expected property symbol "Symbol(Symbol.toStringTag)" missing
-
------ LAST STDOUT: -----
-[ 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x'... 9999900 more items ]
-Uint8Array [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0... 9999900 more items ]
 
 
 🧪/wpt/encoding.test.js 


### PR DESCRIPTION
### Description of changes

The console implementation has been tweaked to be more web standards compliant.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
