### PR TITLE
feat: add Symbol.toStringTag to Web API classes

### DIFF
--- a/modules/llrt_abort/src/abort_controller.rs
+++ b/modules/llrt_abort/src/abort_controller.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use rquickjs::{
+    atom::PredefinedAtom,
     prelude::{Opt, This},
     Class, Ctx, JsLifetime, Result, Value,
 };
@@ -32,6 +33,11 @@ impl<'js> AbortController<'js> {
     #[qjs(get)]
     pub fn signal(&self) -> Class<'js, AbortSignal<'js>> {
         self.signal.clone()
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(AbortController)
     }
 
     pub fn abort(

--- a/modules/llrt_abort/src/abort_signal.rs
+++ b/modules/llrt_abort/src/abort_signal.rs
@@ -6,6 +6,7 @@ use llrt_events::{Emitter, EventEmitter, EventList};
 use llrt_exceptions::{DOMException, DOMExceptionName};
 use llrt_utils::mc_oneshot;
 use rquickjs::{
+    atom::PredefinedAtom,
     class::{Trace, Tracer},
     function::OnceFn,
     prelude::{Opt, This},
@@ -146,6 +147,11 @@ impl<'js> AbortSignal<'js> {
     #[qjs(get)]
     pub fn reason(&self) -> Option<Value<'js>> {
         self.reason.clone()
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(AbortSignal)
     }
 
     #[qjs(set, rename = "reason")]

--- a/modules/llrt_url/src/url_class.rs
+++ b/modules/llrt_url/src/url_class.rs
@@ -229,6 +229,11 @@ impl<'js> URL<'js> {
         self.search_params.as_value()
     }
 
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(URL)
+    }
+
     #[qjs(get)]
     pub fn username(&self) -> String {
         quirks::username(&self.url.borrow()).to_string()

--- a/modules/llrt_url/src/url_search_params.rs
+++ b/modules/llrt_url/src/url_search_params.rs
@@ -76,6 +76,11 @@ impl<'js> URLSearchParams {
         self.url.borrow().query_pairs().count()
     }
 
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(URLSearchParams)
+    }
+
     //
     // Instance methods
     //

--- a/modules/llrt_util/src/text_decoder.rs
+++ b/modules/llrt_util/src/text_decoder.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use llrt_encoding::Encoder;
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
-use rquickjs::{function::Opt, Ctx, Object, Result};
+use rquickjs::{atom::PredefinedAtom, function::Opt, Ctx, Object, Result};
 
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace, rquickjs::JsLifetime)]
@@ -51,6 +51,11 @@ impl<'js> TextDecoder {
     #[qjs(get, rename = "ignoreBOM")]
     fn ignore_bom(&self) -> bool {
         self.ignore_bom
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(TextDecoder)
     }
 
     pub fn decode(&self, ctx: Ctx<'js>, bytes: ObjectBytes<'js>) -> Result<String> {

--- a/modules/llrt_util/src/text_encoder.rs
+++ b/modules/llrt_util/src/text_encoder.rs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use llrt_utils::result::ResultExt;
-use rquickjs::{function::Opt, Ctx, Exception, Object, Result, TypedArray, Value};
+use rquickjs::{
+    atom::PredefinedAtom, function::Opt, Ctx, Exception, Object, Result, TypedArray, Value,
+};
 
 #[derive(rquickjs::class::Trace, rquickjs::JsLifetime)]
 #[rquickjs::class]
@@ -23,6 +25,11 @@ impl TextEncoder {
     #[qjs(get)]
     fn encoding(&self) -> &str {
         "utf-8"
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(TextEncoder)
     }
 
     pub fn encode<'js>(&self, ctx: Ctx<'js>, string: Opt<Value<'js>>) -> Result<Value<'js>> {

--- a/tests/unit/symbol-to-string-tag.test.ts
+++ b/tests/unit/symbol-to-string-tag.test.ts
@@ -1,0 +1,120 @@
+describe("Symbol.toStringTag", () => {
+  describe("URL module", () => {
+    it("URL should have correct Symbol.toStringTag", () => {
+      const url = new URL("https://example.com");
+      expect(url[Symbol.toStringTag]).toBe("URL");
+      expect(Object.prototype.toString.call(url)).toBe("[object URL]");
+    });
+
+    it("URLSearchParams should have correct Symbol.toStringTag", () => {
+      const params = new URLSearchParams("foo=bar");
+      expect(params[Symbol.toStringTag]).toBe("URLSearchParams");
+      expect(Object.prototype.toString.call(params)).toBe(
+        "[object URLSearchParams]"
+      );
+    });
+  });
+
+  describe("Encoding", () => {
+    it("TextEncoder should have correct Symbol.toStringTag", () => {
+      const encoder = new TextEncoder();
+      expect(encoder[Symbol.toStringTag]).toBe("TextEncoder");
+      expect(Object.prototype.toString.call(encoder)).toBe(
+        "[object TextEncoder]"
+      );
+    });
+
+    it("TextDecoder should have correct Symbol.toStringTag", () => {
+      const decoder = new TextDecoder();
+      expect(decoder[Symbol.toStringTag]).toBe("TextDecoder");
+      expect(Object.prototype.toString.call(decoder)).toBe(
+        "[object TextDecoder]"
+      );
+    });
+  });
+
+  describe("Abort API", () => {
+    it("AbortController should have correct Symbol.toStringTag", () => {
+      const controller = new AbortController();
+      expect(controller[Symbol.toStringTag]).toBe("AbortController");
+      expect(Object.prototype.toString.call(controller)).toBe(
+        "[object AbortController]"
+      );
+    });
+
+    it("AbortSignal should have correct Symbol.toStringTag", () => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      expect(signal[Symbol.toStringTag]).toBe("AbortSignal");
+      expect(Object.prototype.toString.call(signal)).toBe(
+        "[object AbortSignal]"
+      );
+    });
+  });
+
+  describe("Fetch API", () => {
+    it("Headers should have correct Symbol.toStringTag", () => {
+      const headers = new Headers();
+      expect(headers[Symbol.toStringTag]).toBe("Headers");
+      expect(Object.prototype.toString.call(headers)).toBe("[object Headers]");
+    });
+
+    it("Request should have correct Symbol.toStringTag", () => {
+      const request = new Request("https://example.com");
+      expect(request[Symbol.toStringTag]).toBe("Request");
+      expect(Object.prototype.toString.call(request)).toBe("[object Request]");
+    });
+
+    it("Response should have correct Symbol.toStringTag", () => {
+      const response = new Response();
+      expect(response[Symbol.toStringTag]).toBe("Response");
+      expect(Object.prototype.toString.call(response)).toBe(
+        "[object Response]"
+      );
+    });
+
+    it("FormData should have correct Symbol.toStringTag", () => {
+      const formData = new FormData();
+      expect(formData[Symbol.toStringTag]).toBe("FormData");
+      expect(Object.prototype.toString.call(formData)).toBe(
+        "[object FormData]"
+      );
+    });
+  });
+
+  describe("Blob API", () => {
+    it("Blob should have correct Symbol.toStringTag", () => {
+      const blob = new Blob(["test"]);
+      expect(blob[Symbol.toStringTag]).toBe("Blob");
+      expect(Object.prototype.toString.call(blob)).toBe("[object Blob]");
+    });
+
+    it("File should have correct Symbol.toStringTag", () => {
+      const file = new File(["test"], "test.txt");
+      expect(file[Symbol.toStringTag]).toBe("File");
+      expect(Object.prototype.toString.call(file)).toBe("[object File]");
+    });
+  });
+
+  describe("Crypto API", () => {
+    it("CryptoKey should have correct Symbol.toStringTag", async () => {
+      const key = await crypto.subtle.generateKey(
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign", "verify"]
+      );
+      expect(key[Symbol.toStringTag]).toBe("CryptoKey");
+      expect(Object.prototype.toString.call(key)).toBe("[object CryptoKey]");
+    });
+  });
+
+  describe("Exceptions", () => {
+    it("DOMException should have correct Symbol.toStringTag", () => {
+      const exception = new DOMException("test", "TestError");
+      expect(exception[Symbol.toStringTag]).toBe("DOMException");
+      expect(Object.prototype.toString.call(exception)).toBe(
+        "[object DOMException]"
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Issue # (if available)

Closes #967

### Description of changes

Add Symbol.toStringTag implementation to remaining Web API classes for improved type detection without relying on instanceof checks.

Classes updated:
- URL
- URLSearchParams
- TextEncoder
- TextDecoder
- AbortController
- AbortSignal

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
