### PR TITLE
feat(crypto): add Symbol.toStringTag to Crypto and SubtleCrypto

### DIFF
--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -24,6 +24,7 @@ use ring::rand::{SecureRandom, SystemRandom};
 #[cfg(feature = "subtle-rs")]
 use rquickjs::prelude::Async;
 use rquickjs::{
+    atom::PredefinedAtom,
     function::{Constructor, Opt},
     module::{Declarations, Exports, ModuleDef},
     prelude::{Func, Rest},
@@ -220,6 +221,11 @@ impl Crypto {
     #[qjs(constructor)]
     pub fn new(ctx: Ctx<'_>) -> Result<Self> {
         Err(Exception::throw_type(&ctx, "Illegal constructor"))
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(Crypto)
     }
 }
 

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -48,7 +48,7 @@ use aes_gcm::{
 };
 use ctr::{Ctr128BE, Ctr32BE, Ctr64BE};
 use llrt_utils::{object::ObjectExt, str_enum};
-use rquickjs::{Ctx, Exception, Object, Result, Value};
+use rquickjs::{atom::PredefinedAtom, Ctx, Exception, Object, Result, Value};
 
 use crate::sha_hash::ShaAlgorithm;
 
@@ -61,6 +61,11 @@ impl SubtleCrypto {
     #[qjs(constructor)]
     pub fn new(ctx: Ctx<'_>) -> Result<Self> {
         Err(Exception::throw_type(&ctx, "Illegal constructor"))
+    }
+
+    #[qjs(get, rename = PredefinedAtom::SymbolToStringTag)]
+    pub fn to_string_tag(&self) -> &'static str {
+        stringify!(SubtleCrypto)
     }
 }
 

--- a/tests/unit/symbol-to-string-tag.test.ts
+++ b/tests/unit/symbol-to-string-tag.test.ts
@@ -97,6 +97,18 @@ describe("Symbol.toStringTag", () => {
   });
 
   describe("Crypto API", () => {
+    it("Crypto should have correct Symbol.toStringTag", () => {
+      expect(crypto[Symbol.toStringTag]).toBe("Crypto");
+      expect(Object.prototype.toString.call(crypto)).toBe("[object Crypto]");
+    });
+
+    it("SubtleCrypto should have correct Symbol.toStringTag", () => {
+      expect(crypto.subtle[Symbol.toStringTag]).toBe("SubtleCrypto");
+      expect(Object.prototype.toString.call(crypto.subtle)).toBe(
+        "[object SubtleCrypto]"
+      );
+    });
+
     it("CryptoKey should have correct Symbol.toStringTag", async () => {
       const key = await crypto.subtle.generateKey(
         { name: "HMAC", hash: "SHA-256" },


### PR DESCRIPTION
### Issue # (if available)

Fixes #967 

### Description of changes

Add Symbol.toStringTag implementation to Crypto and SubtleCrypto classes, which were overlooked in #1268.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
