### PR TITLE
feat(fs): add filesystem isolation support

### DIFF
--- a/llrt_core/src/environment.rs
+++ b/llrt_core/src/environment.rs
@@ -4,6 +4,10 @@
 //network
 pub const ENV_LLRT_NET_ALLOW: &str = "LLRT_NET_ALLOW";
 pub const ENV_LLRT_NET_DENY: &str = "LLRT_NET_DENY";
+
+//filesystem
+pub const ENV_LLRT_FS_ALLOW: &str = "LLRT_FS_ALLOW";
+pub const ENV_LLRT_FS_DENY: &str = "LLRT_FS_DENY";
 pub const ENV_LLRT_NET_POOL_IDLE_TIMEOUT: &str = "LLRT_NET_POOL_IDLE_TIMEOUT";
 pub const ENV_LLRT_HTTP_VERSION: &str = "LLRT_HTTP_VERSION";
 pub const ENV_LLRT_TLS_VERSION: &str = "LLRT_TLS_VERSION";

--- a/modules/llrt_fs/src/access.rs
+++ b/modules/llrt_fs/src/access.rs
@@ -6,10 +6,14 @@ use llrt_utils::result::ResultExt;
 use rquickjs::{prelude::Opt, Ctx, Exception, Result};
 use tokio::fs;
 
+use crate::security::ensure_access;
+
 #[allow(dead_code, unused_imports)]
 use super::{CONSTANT_F_OK, CONSTANT_R_OK, CONSTANT_W_OK, CONSTANT_X_OK};
 
 pub async fn access(ctx: Ctx<'_>, path: String, mode: Opt<u32>) -> Result<()> {
+    ensure_access(&ctx, &path)?;
+
     let metadata = fs::metadata(&path).await.or_throw_msg(
         &ctx,
         &["No such file or directory \"", &path, "\""].concat(),
@@ -19,6 +23,8 @@ pub async fn access(ctx: Ctx<'_>, path: String, mode: Opt<u32>) -> Result<()> {
 }
 
 pub fn access_sync(ctx: Ctx<'_>, path: String, mode: Opt<u32>) -> Result<()> {
+    ensure_access(&ctx, &path)?;
+
     let metadata = std::fs::metadata(path.clone()).or_throw_msg(
         &ctx,
         &["No such file or directory \"", &path, "\""].concat(),

--- a/modules/llrt_fs/src/chmod.rs
+++ b/modules/llrt_fs/src/chmod.rs
@@ -4,6 +4,8 @@ use rquickjs::{Ctx, Result};
 #[cfg(unix)]
 use std::os::unix::prelude::PermissionsExt;
 
+use crate::security::ensure_access;
+
 #[cfg(unix)]
 pub(crate) fn chmod_error(path: &str) -> String {
     ["Can't set permissions of \"", path, "\""].concat()
@@ -41,9 +43,11 @@ pub(crate) fn set_mode_sync(ctx: Ctx<'_>, path: &str, mode: u32) -> Result<()> {
 }
 
 pub async fn chmod(ctx: Ctx<'_>, path: String, mode: u32) -> Result<()> {
+    ensure_access(&ctx, &path)?;
     set_mode(ctx, &path, mode).await
 }
 
 pub fn chmod_sync(ctx: Ctx<'_>, path: String, mode: u32) -> Result<()> {
+    ensure_access(&ctx, &path)?;
     set_mode_sync(ctx, &path, mode)
 }

--- a/modules/llrt_fs/src/lib.rs
+++ b/modules/llrt_fs/src/lib.rs
@@ -9,6 +9,7 @@ mod read_dir;
 mod read_file;
 mod rename;
 mod rm;
+pub mod security;
 mod stats;
 mod symlink;
 mod write_file;

--- a/modules/llrt_fs/src/mkdir.rs
+++ b/modules/llrt_fs/src/mkdir.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use crate::chmod::{set_mode, set_mode_sync};
+use crate::security::ensure_access;
 
 use llrt_path::resolve_path;
 use llrt_utils::result::ResultExt;
@@ -10,6 +11,8 @@ use tokio::fs;
 
 pub async fn mkdir<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<String> {
     let (recursive, mode, path) = get_params(&path, options)?;
+
+    ensure_access(&ctx, &path)?;
 
     if recursive {
         fs::create_dir_all(&path).await
@@ -25,6 +28,8 @@ pub async fn mkdir<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) 
 
 pub fn mkdir_sync<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<String> {
     let (recursive, mode, path) = get_params(&path, options)?;
+
+    ensure_access(&ctx, &path)?;
 
     if recursive {
         std::fs::create_dir_all(&path)
@@ -68,6 +73,9 @@ fn random_chars(len: usize) -> String {
 
 pub async fn mkdtemp(ctx: Ctx<'_>, prefix: String) -> Result<String> {
     let path = [prefix.as_str(), random_chars(6).as_str()].join(",");
+
+    ensure_access(&ctx, &path)?;
+
     fs::create_dir_all(&path)
         .await
         .or_throw_msg(&ctx, &["Can't create dir \"", &path, "\""].concat())?;
@@ -76,6 +84,9 @@ pub async fn mkdtemp(ctx: Ctx<'_>, prefix: String) -> Result<String> {
 
 pub fn mkdtemp_sync(ctx: Ctx<'_>, prefix: String) -> Result<String> {
     let path = [prefix.as_str(), random_chars(6).as_str()].join(",");
+
+    ensure_access(&ctx, &path)?;
+
     std::fs::create_dir_all(&path)
         .or_throw_msg(&ctx, &["Can't create dir \"", &path, "\""].concat())?;
     Ok(path)

--- a/modules/llrt_fs/src/open.rs
+++ b/modules/llrt_fs/src/open.rs
@@ -7,6 +7,7 @@ use rquickjs::{function::Opt, Ctx, Exception, Result};
 use tokio::fs::OpenOptions;
 
 use super::file_handle::FileHandle;
+use crate::security::ensure_access;
 
 pub async fn open(
     ctx: Ctx<'_>,
@@ -14,6 +15,8 @@ pub async fn open(
     flags: Opt<String>,
     mode: Opt<u32>,
 ) -> Result<FileHandle> {
+    ensure_access(&ctx, &path)?;
+
     let mut options = OpenOptions::new();
     match flags.0.as_deref().unwrap_or("r") {
         // We are not supporting the sync modes

--- a/modules/llrt_fs/src/read_dir.rs
+++ b/modules/llrt_fs/src/read_dir.rs
@@ -10,6 +10,8 @@ use rquickjs::{
     atom::PredefinedAtom, prelude::Opt, Array, Class, Ctx, IntoJs, Object, Result, Value,
 };
 
+use crate::security::ensure_access;
+
 #[derive(rquickjs::class::Trace, rquickjs::JsLifetime)]
 #[rquickjs::class]
 pub struct Dirent {
@@ -105,7 +107,9 @@ impl<'js> IntoJs<'js> for ReadDir {
     }
 }
 
-pub async fn read_dir(mut path: String, options: Opt<Object<'_>>) -> Result<ReadDir> {
+pub async fn read_dir(ctx: Ctx<'_>, mut path: String, options: Opt<Object<'_>>) -> Result<ReadDir> {
+    ensure_access(&ctx, &path)?;
+
     let (with_file_types, skip_root_pos, mut directory_walker) =
         process_options_and_create_directory_walker(&mut path, options);
 
@@ -126,7 +130,9 @@ pub async fn read_dir(mut path: String, options: Opt<Object<'_>>) -> Result<Read
     Ok(ReadDir { items, root: path })
 }
 
-pub fn read_dir_sync(mut path: String, options: Opt<Object<'_>>) -> Result<ReadDir> {
+pub fn read_dir_sync(ctx: Ctx<'_>, mut path: String, options: Opt<Object<'_>>) -> Result<ReadDir> {
+    ensure_access(&ctx, &path)?;
+
     let (with_file_types, skip_root_pos, mut directory_walker) =
         process_options_and_create_directory_walker(&mut path, options);
 

--- a/modules/llrt_fs/src/read_file.rs
+++ b/modules/llrt_fs/src/read_file.rs
@@ -6,11 +6,15 @@ use llrt_utils::{object::ObjectExt, result::ResultExt};
 use rquickjs::{function::Opt, Ctx, Error, FromJs, IntoJs, Result, Value};
 use tokio::fs;
 
+use crate::security::ensure_access;
+
 pub async fn read_file(
     ctx: Ctx<'_>,
     path: String,
     options: Opt<Either<String, ReadFileOptions>>,
 ) -> Result<Value<'_>> {
+    ensure_access(&ctx, &path)?;
+
     let bytes = fs::read(&path)
         .await
         .or_throw_msg(&ctx, &["Can't read \"", &path, "\""].concat())?;
@@ -23,6 +27,8 @@ pub fn read_file_sync(
     path: String,
     options: Opt<Either<String, ReadFileOptions>>,
 ) -> Result<Value<'_>> {
+    ensure_access(&ctx, &path)?;
+
     let bytes =
         std::fs::read(&path).or_throw_msg(&ctx, &["Can't read \"", &path, "\""].concat())?;
 

--- a/modules/llrt_fs/src/rename.rs
+++ b/modules/llrt_fs/src/rename.rs
@@ -1,6 +1,8 @@
 use llrt_utils::result::ResultExt;
 use rquickjs::{Ctx, Result};
 
+use crate::security::ensure_access;
+
 pub(crate) fn rename_error(from: &str, to: &str) -> String {
     [
         "Can't rename file/folder from \"",
@@ -13,6 +15,9 @@ pub(crate) fn rename_error(from: &str, to: &str) -> String {
 }
 
 pub async fn rename(ctx: Ctx<'_>, old_path: String, new_path: String) -> Result<()> {
+    ensure_access(&ctx, &old_path)?;
+    ensure_access(&ctx, &new_path)?;
+
     tokio::fs::rename(&old_path, &new_path)
         .await
         .or_throw_msg(&ctx, &rename_error(&old_path, &new_path))?;
@@ -20,6 +25,9 @@ pub async fn rename(ctx: Ctx<'_>, old_path: String, new_path: String) -> Result<
 }
 
 pub fn rename_sync(ctx: Ctx<'_>, old_path: String, new_path: String) -> Result<()> {
+    ensure_access(&ctx, &old_path)?;
+    ensure_access(&ctx, &new_path)?;
+
     std::fs::rename(&old_path, &new_path)
         .or_throw_msg(&ctx, &rename_error(&old_path, &new_path))?;
     Ok(())

--- a/modules/llrt_fs/src/rm.rs
+++ b/modules/llrt_fs/src/rm.rs
@@ -4,8 +4,12 @@ use llrt_utils::result::ResultExt;
 use rquickjs::{function::Opt, Ctx, Object, Result};
 use tokio::fs;
 
+use crate::security::ensure_access;
+
 #[allow(clippy::manual_async_fn)]
 pub async fn rmdir<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<()> {
+    ensure_access(&ctx, &path)?;
+
     let recursive = get_params_rm_dir(options);
 
     if recursive {
@@ -20,6 +24,8 @@ pub async fn rmdir<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) 
 
 #[allow(clippy::manual_async_fn)]
 pub fn rmdir_sync<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<()> {
+    ensure_access(&ctx, &path)?;
+
     let recursive = get_params_rm_dir(options);
 
     if recursive {
@@ -33,6 +39,8 @@ pub fn rmdir_sync<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -
 }
 
 pub async fn rmfile<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>) -> Result<()> {
+    ensure_access(&ctx, &path)?;
+
     let (recursive, force) = get_params_rm(options);
 
     let res = async move {
@@ -61,7 +69,9 @@ pub async fn rmfile<'js>(ctx: Ctx<'js>, path: String, options: Opt<Object<'js>>)
     Ok(())
 }
 
-pub fn rmfile_sync(path: String, options: Opt<Object<'_>>) -> Result<()> {
+pub fn rmfile_sync(ctx: Ctx<'_>, path: String, options: Opt<Object<'_>>) -> Result<()> {
+    ensure_access(&ctx, &path)?;
+
     let (recursive, force) = get_params_rm(options);
 
     let res = (|| -> Result<()> {

--- a/modules/llrt_fs/src/security.rs
+++ b/modules/llrt_fs/src/security.rs
@@ -1,0 +1,130 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::path::Path;
+use std::sync::OnceLock;
+
+use rquickjs::{Ctx, Exception, Result};
+
+static FS_ALLOW_LIST: OnceLock<Vec<String>> = OnceLock::new();
+
+static FS_DENY_LIST: OnceLock<Vec<String>> = OnceLock::new();
+
+pub fn set_allow_list(values: Vec<String>) {
+    _ = FS_ALLOW_LIST.set(values);
+}
+
+pub fn get_allow_list() -> Option<&'static Vec<String>> {
+    FS_ALLOW_LIST.get()
+}
+
+pub fn set_deny_list(values: Vec<String>) {
+    _ = FS_DENY_LIST.set(values);
+}
+
+pub fn get_deny_list() -> Option<&'static Vec<String>> {
+    FS_DENY_LIST.get()
+}
+
+/// Check if a path matches a pattern.
+/// Patterns can be:
+/// - Exact paths: "/tmp/file.txt"
+/// - Directory prefixes: "/tmp/" (matches all files under /tmp)
+/// - Glob-like patterns: "/tmp/*.txt" (matches *.txt in /tmp)
+fn path_matches(path: &str, pattern: &str) -> bool {
+    // Normalize the path for comparison
+    let path = Path::new(path);
+    let pattern = pattern.trim();
+
+    // Handle directory prefix patterns (ending with /)
+    if let Some(prefix) = pattern.strip_suffix('/') {
+        return path.starts_with(prefix);
+    }
+
+    // Handle glob patterns with *
+    if pattern.contains('*') {
+        let parts: Vec<&str> = pattern.split('*').collect();
+        if parts.len() == 2 {
+            let path_str = path.to_string_lossy();
+            let prefix = parts[0];
+            let suffix = parts[1];
+
+            // For patterns like "/tmp/*.txt", check if path starts with prefix dir
+            // and the filename ends with the suffix
+            if !prefix.is_empty() && !suffix.is_empty() {
+                // Get the directory part of the pattern
+                if let Some(pattern_dir) = Path::new(prefix).parent() {
+                    if let Some(path_parent) = path.parent() {
+                        // Check if the path is in the same directory as the pattern
+                        if path_parent == pattern_dir || path_parent.starts_with(pattern_dir) {
+                            return path_str.ends_with(suffix);
+                        }
+                    }
+                }
+                // Fallback: simple prefix/suffix matching
+                return path_str.starts_with(prefix) && path_str.ends_with(suffix);
+            }
+
+            // For patterns like "*.txt" or "/tmp/*"
+            return path_str.starts_with(prefix) && path_str.ends_with(suffix);
+        }
+    }
+
+    // Exact match
+    path == Path::new(pattern)
+}
+
+/// Check if access to a path is allowed based on allow/deny lists.
+/// The allow list is checked first - if set, the path must match at least one pattern.
+/// Then the deny list is checked - if set and the path matches, access is denied.
+pub fn ensure_access(ctx: &Ctx<'_>, path: &str) -> Result<()> {
+    // If allow list is set, path must match at least one pattern
+    if let Some(allow_list) = FS_ALLOW_LIST.get() {
+        let allowed = allow_list.iter().any(|pattern| path_matches(path, pattern));
+        if !allowed {
+            return Err(Exception::throw_message(
+                ctx,
+                &["Filesystem path not allowed: ", path].concat(),
+            ));
+        }
+    }
+
+    // If deny list is set, path must not match any pattern
+    if let Some(deny_list) = FS_DENY_LIST.get() {
+        let denied = deny_list.iter().any(|pattern| path_matches(path, pattern));
+        if denied {
+            return Err(Exception::throw_message(
+                ctx,
+                &["Filesystem path denied: ", path].concat(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_matches_exact() {
+        assert!(path_matches("/tmp/file.txt", "/tmp/file.txt"));
+        assert!(!path_matches("/tmp/file.txt", "/tmp/other.txt"));
+    }
+
+    #[test]
+    fn test_path_matches_directory_prefix() {
+        assert!(path_matches("/tmp/file.txt", "/tmp/"));
+        assert!(path_matches("/tmp/subdir/file.txt", "/tmp/"));
+        assert!(!path_matches("/var/file.txt", "/tmp/"));
+    }
+
+    #[test]
+    fn test_path_matches_glob() {
+        assert!(path_matches("/tmp/file.txt", "/tmp/*.txt"));
+        assert!(path_matches("/tmp/other.txt", "/tmp/*.txt"));
+        assert!(!path_matches("/tmp/file.json", "/tmp/*.txt"));
+        assert!(path_matches("/tmp/file.txt", "*.txt"));
+        assert!(path_matches("/tmp/subdir/test", "/tmp/*"));
+    }
+}

--- a/modules/llrt_fs/src/stats.rs
+++ b/modules/llrt_fs/src/stats.rs
@@ -16,6 +16,8 @@ use llrt_utils::result::ResultExt;
 use rquickjs::{Ctx, Result};
 use tokio::fs;
 
+use crate::security::ensure_access;
+
 // The Stats implementation is very much based on Unix. The Windows implementation
 // tries its best to mimic the implementation of libuv since it is the standard.
 // See: https://github.com/libuv/libuv/blob/90648ea3e55125a5a819b32106da6462da310da6/src/win/fs.c
@@ -315,6 +317,8 @@ impl Stats {
 }
 
 pub async fn stat_fn(ctx: Ctx<'_>, path: String) -> Result<Stats> {
+    ensure_access(&ctx, &path)?;
+
     let metadata = fs::metadata(&path)
         .await
         .or_throw_msg(&ctx, &["Can't stat \"", &path, "\""].concat())?;
@@ -325,6 +329,8 @@ pub async fn stat_fn(ctx: Ctx<'_>, path: String) -> Result<Stats> {
 }
 
 pub fn stat_fn_sync(ctx: Ctx<'_>, path: String) -> Result<Stats> {
+    ensure_access(&ctx, &path)?;
+
     let metadata =
         std::fs::metadata(&path).or_throw_msg(&ctx, &["Can't stat \"", &path, "\""].concat())?;
 
@@ -334,6 +340,8 @@ pub fn stat_fn_sync(ctx: Ctx<'_>, path: String) -> Result<Stats> {
 }
 
 pub async fn lstat_fn(ctx: Ctx<'_>, path: String) -> Result<Stats> {
+    ensure_access(&ctx, &path)?;
+
     let metadata = fs::symlink_metadata(&path)
         .await
         .or_throw_msg(&ctx, &["Can't lstat \"", &path, "\""].concat())?;
@@ -344,6 +352,8 @@ pub async fn lstat_fn(ctx: Ctx<'_>, path: String) -> Result<Stats> {
 }
 
 pub fn lstat_fn_sync(ctx: Ctx<'_>, path: String) -> Result<Stats> {
+    ensure_access(&ctx, &path)?;
+
     let metadata = std::fs::symlink_metadata(&path)
         .or_throw_msg(&ctx, &["Can't lstat \"", &path, "\""].concat())?;
 

--- a/modules/llrt_fs/src/symlink.rs
+++ b/modules/llrt_fs/src/symlink.rs
@@ -6,6 +6,8 @@ use std::io;
 use llrt_utils::result::ResultExt;
 use rquickjs::{function::Opt, Ctx, Result};
 
+use crate::security::ensure_access;
+
 fn symlink_blocking(target: &str, path: &str, type_value: Option<String>) -> io::Result<()> {
     #[cfg(unix)]
     {
@@ -41,6 +43,9 @@ pub async fn symlink<'js>(
     path: String,
     type_value: Opt<String>,
 ) -> Result<()> {
+    ensure_access(&ctx, &target)?;
+    ensure_access(&ctx, &path)?;
+
     let path_clone = path.clone();
 
     tokio::task::spawn_blocking(move || symlink_blocking(&target, &path_clone, type_value.0))
@@ -55,6 +60,9 @@ pub fn symlink_sync<'js>(
     path: String,
     type_value: Opt<String>,
 ) -> Result<()> {
+    ensure_access(&ctx, &target)?;
+    ensure_access(&ctx, &path)?;
+
     symlink_blocking(&target, &path, type_value.0)
         .or_throw_msg(&ctx, &["Can't create symlink \"", &path, "\""].concat())
 }

--- a/modules/llrt_fs/src/write_file.rs
+++ b/modules/llrt_fs/src/write_file.rs
@@ -7,12 +7,16 @@ use rquickjs::{function::Opt, Ctx, Error, FromJs, Result, Value};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
+use crate::security::ensure_access;
+
 pub async fn write_file<'js>(
     ctx: Ctx<'js>,
     path: String,
     data: Value<'js>,
     options: Opt<Either<String, WriteFileOptions>>,
 ) -> Result<()> {
+    ensure_access(&ctx, &path)?;
+
     let write_error_message = &["Can't write file \"", &path, "\""].concat();
 
     let mut file = fs::File::create(&path)
@@ -51,6 +55,8 @@ pub fn write_file_sync<'js>(
     bytes: ObjectBytes<'js>,
     options: Opt<Either<String, WriteFileOptions>>,
 ) -> Result<()> {
+    ensure_access(&ctx, &path)?;
+
     let write_error_message = &["Can't write file \"", &path, "\""].concat();
     std::fs::write(&path, bytes.as_bytes(&ctx)?).or_throw_msg(&ctx, write_error_message)?;
 


### PR DESCRIPTION
### Issue # (if available)

Closes #686

### Description of changes

Add LLRT_FS_ALLOW and LLRT_FS_DENY environment variables to control filesystem access, similar to existing network isolation (LLRT_NET_ALLOW/DENY).

- LLRT_FS_ALLOW: whitespace-separated list of allowed paths/patterns
- LLRT_FS_DENY: whitespace-separated list of denied paths/patterns

Supports exact paths (/tmp/file.txt), directory prefixes (/tmp/), and glob patterns (/tmp/*.txt).

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
