### PR TITLE
fix(core): remove zstd WriteBuf dependency for byte slice conversion

### DIFF
--- a/llrt_core/src/runtime_client.rs
+++ b/llrt_core/src/runtime_client.rs
@@ -22,7 +22,6 @@ use rquickjs::{
     CaughtError, Ctx, Exception, Function, IntoJs, Module, Object, Result, Value,
 };
 use tracing::info;
-use zstd::zstd_safe::WriteBuf;
 
 use crate::libs::{
     json::{
@@ -302,7 +301,7 @@ async fn next_invocation<'js, 'a>(
 
     if res.status() != StatusCode::OK {
         let res_bytes = res.collect().await.or_throw(ctx)?.to_bytes();
-        let res_str = String::from_utf8_lossy(res_bytes.as_slice());
+        let res_str = String::from_utf8_lossy(&res_bytes[..]);
         return Err(Exception::throw_message(
             ctx,
             &["Unexpected /invocation/next response: ", &res_str].concat(),
@@ -380,7 +379,7 @@ async fn invoke_response<'js>(
         StatusCode::ACCEPTED => Ok(()),
         _ => {
             let res_bytes = res.collect().await.or_throw(ctx)?.to_bytes();
-            let res_str = String::from_utf8_lossy(res_bytes.as_slice());
+            let res_str = String::from_utf8_lossy(&res_bytes[..]);
             Err(Exception::throw_message(
                 ctx,
                 &["Unexpected /invocation/response response: ", &res_str].concat(),
@@ -545,7 +544,7 @@ async fn post_error<'js>(
     let res = client.request(req).await.or_throw(ctx)?;
     if res.status() != StatusCode::ACCEPTED {
         let res_bytes = res.collect().await.or_throw(ctx)?.to_bytes();
-        let res_str = String::from_utf8_lossy(res_bytes.as_slice());
+        let res_str = String::from_utf8_lossy(&res_bytes[..]);
         return Err(Exception::throw_message(
             ctx,
             &["Unexpected ", path, " response: ", &res_str].concat(),


### PR DESCRIPTION
### Issue # (if available)

### Description of changes

Replace `res_bytes.as_slice()` with idiomatic `&res_bytes[..]` to avoid name collision with new [T]::as_slice() method added in Rust nightly (rust-lang/rust#145933, merged 2025-12-18).

Issue observed in nightly build checks for PR #1293.

The WriteBuf trait from zstd was only imported to provide as_slice() through its impl for [u8], which is unnecessary coupling. Using slice syntax is more idiomatic and doesn't require external trait imports.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
