### PR TITLE
feat(fetch): add HTTP proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d2d54c4d9e7006f132f615a167865bff927a79ca63d8f637237575ce0a9795"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.0-rc.5",
  "inout",
 ]
 
@@ -201,6 +201,15 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
@@ -367,8 +376,8 @@ version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155e4a260750fa4f7754649f049748aacc31db238a358d85fd721002f230f92f"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.11.0",
+ "crypto-common 0.2.0-rc.5",
  "inout",
 ]
 
@@ -627,6 +636,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919bd05924682a5480aec713596b9e2aabed3a0a6022fab6847f85a99e5f190a"
@@ -723,13 +742,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea390c940e465846d64775e55e3115d5dc934acb953de6f6e6360bc232fe2bf7"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.11.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.0-rc.5",
  "subtle",
 ]
 
@@ -783,7 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e914ecb8e11a02f42cc05f6b43675d1e5aa4d446cd207f9f818903a1ab34f19f"
 dependencies = [
  "der",
- "digest",
+ "digest 0.11.0-rc.4",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -804,7 +833,7 @@ checksum = "39ecd2903524729de5d0cba7589121744513feadd56d71980cb480c48caceb11"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.11.0-rc.4",
  "hkdf",
  "hybrid-array",
  "pkcs8",
@@ -1001,6 +1030,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1128,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,7 +1182,7 @@ version = "0.13.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c597ac7d6cc8143e30e83ef70915e7f883b18d8bec2e2b2bce47f5bbb06d57"
 dependencies = [
- "digest",
+ "digest 0.11.0-rc.4",
 ]
 
 [[package]]
@@ -1208,6 +1271,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1841,16 +1921,20 @@ name = "llrt_http"
 version = "0.7.0-beta"
 dependencies = [
  "bytes",
+ "headers",
  "http-body-util",
  "hyper",
+ "hyper-http-proxy",
  "hyper-rustls",
  "hyper-util",
  "llrt_dns_cache",
  "llrt_tls",
  "llrt_utils",
  "once_cell",
+ "percent-encoding",
  "rquickjs",
  "rustls",
+ "tracing",
 ]
 
 [[package]]
@@ -2177,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64dd2c9099caf8e29b629305199dddb1c6d981562b62c089afea54b0b4b5c333"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.0-rc.4",
 ]
 
 [[package]]
@@ -2185,6 +2269,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -2770,7 +2860,7 @@ dependencies = [
  "const-oid",
  "crypto-bigint",
  "crypto-primes",
- "digest",
+ "digest 0.11.0-rc.4",
  "pkcs1",
  "pkcs8",
  "rand",
@@ -3018,6 +3108,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,7 +3126,7 @@ checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.0-rc.4",
 ]
 
 [[package]]
@@ -3070,7 +3171,7 @@ version = "3.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0251c9d6468f4ba853b6352b190fb7c1e405087779917c238445eb03993826"
 dependencies = [
- "digest",
+ "digest 0.11.0-rc.4",
  "rand_core",
 ]
 
@@ -3369,7 +3470,7 @@ version = "0.6.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ad6682ddb0189a4d3c2a5c54b8920ab6231ae911db53fc61a0709507bf1713b"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.0-rc.5",
  "subtle",
 ]
 
@@ -3426,6 +3527,12 @@ dependencies = [
  "itoa",
  "ryu",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"

--- a/README.md
+++ b/README.md
@@ -630,6 +630,40 @@ Initializes TLS connections in parallel during function init which significantly
 
 Set the TLS version to be used for network connections. By default only TLS 1.2 is enabled. TLS 1.3 can also be enabled by setting this variable to `1.3`
 
+### `HTTP_PROXY=url` / `HTTPS_PROXY=url`
+
+Configure HTTP/HTTPS proxy servers for outgoing `fetch` requests. The URL can include authentication credentials.
+
+- `HTTP_PROXY` - Proxy for HTTP requests
+- `HTTPS_PROXY` - Proxy for HTTPS requests
+- `ALL_PROXY` - Fallback proxy for both HTTP and HTTPS if specific proxy is not set
+
+Examples:
+
+```shell
+HTTP_PROXY=http://proxy.example.com:8080
+HTTPS_PROXY=http://user:password@proxy.example.com:8080
+ALL_PROXY=http://proxy.example.com:3128
+```
+
+### `NO_PROXY=hosts`
+
+Comma-separated list of hosts that should bypass the proxy. Supports:
+
+- `*` - Bypass all hosts
+- `.example.com` - Bypass subdomains only (e.g., `sub.example.com` but not `example.com`)
+- `example.com` - Bypass domain and all subdomains
+- `example.com:8080` - Bypass only when port matches (pattern without port matches any port)
+- `[::1]:8080` - IPv6 with port (use brackets)
+
+Default bypass hosts: `localhost`, `127.0.0.1`, `::1`
+
+Example:
+
+```shell
+NO_PROXY=localhost:3000,.internal.corp,api.example.com:443
+```
+
 ## Benchmark Methodology
 
 Although Init Duration [reported by Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) is commonly used to understand cold start impact on overall request latency, this metric does not include the time needed to copy code into the Lambda sandbox.

--- a/modules/llrt_http/Cargo.toml
+++ b/modules/llrt_http/Cargo.toml
@@ -23,11 +23,15 @@ native-roots = ["llrt_tls/native-roots"]
 [dependencies]
 bytes = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
+headers = { version = "0.4", default-features = false }
 hyper = { version = "1", features = ["client"], default-features = false }
 hyper-util = { version = "0.1", default-features = false }
 hyper-rustls = { version = "0.27", features = [
   "ring",
 ], default-features = false }
+hyper-http-proxy = { version = "1", default-features = false }
+percent-encoding = { version = "2", default-features = false, features = ["std"] }
+tracing = { version = "0.1", default-features = false }
 llrt_dns_cache = { version = "0.7.0-beta", path = "../../libs/llrt_dns_cache" }
 llrt_tls = { version = "0.7.0-beta", default-features = false, path = "../llrt_tls" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }

--- a/modules/llrt_http/src/agent.rs
+++ b/modules/llrt_http/src/agent.rs
@@ -1,27 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::convert::Infallible;
-
-use bytes::Bytes;
-use http_body_util::combinators::BoxBody;
-use hyper_rustls::HttpsConnector;
-use hyper_util::client::legacy::{connect::HttpConnector, Client};
-use llrt_dns_cache::CachedDnsResolver;
 use llrt_utils::result::ResultExt;
 use llrt_utils::{any_of::AnyOf4, bytes::ObjectBytes, object::ObjectExt};
 use rquickjs::{prelude::Opt, Ctx, Error, FromJs, Result, Value};
+
+use crate::{
+    proxy::{ProxyConfig, PROXY_CONFIG},
+    HyperClient,
+};
 
 #[rquickjs::class]
 #[derive(rquickjs::JsLifetime, rquickjs::class::Trace)]
 pub struct Agent {
     #[qjs(skip_trace)]
-    client: Client<HttpsConnector<HttpConnector<CachedDnsResolver>>, BoxBody<Bytes, Infallible>>,
+    client: HyperClient,
 }
 
 impl Agent {
-    pub fn client(
-        &self,
-    ) -> Client<HttpsConnector<HttpConnector<CachedDnsResolver>>, BoxBody<Bytes, Infallible>> {
+    pub fn client(&self) -> HyperClient {
         self.client.clone()
     }
 }
@@ -47,8 +43,15 @@ impl Agent {
             ca,
         })
         .or_throw_msg(&ctx, "Failed to build TLS config")?;
-        let client =
-            crate::build_client(Some(config)).or_throw_msg(&ctx, "Failed to build HTTP client")?;
+
+        // Use global proxy config for the Agent's client
+        let proxy_config: Option<&ProxyConfig> = if PROXY_CONFIG.is_enabled() {
+            Some(&*PROXY_CONFIG)
+        } else {
+            None
+        };
+        let client = crate::build_client(Some(config), proxy_config)
+            .or_throw_msg(&ctx, "Failed to build HTTP client")?;
 
         Ok(Self { client })
     }

--- a/modules/llrt_http/src/lib.rs
+++ b/modules/llrt_http/src/lib.rs
@@ -9,10 +9,12 @@ use rquickjs::{
 pub use self::agent::Agent;
 pub use self::client::*;
 pub use self::config::*;
+pub use self::proxy::*;
 
 mod agent;
 mod client;
 mod config;
+pub mod proxy;
 
 // Here we should also add the http module.
 

--- a/modules/llrt_http/src/proxy.rs
+++ b/modules/llrt_http/src/proxy.rs
@@ -1,0 +1,532 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+use std::sync::Arc;
+
+use headers::{authorization::Basic, Authorization};
+use hyper::Uri;
+use hyper_http_proxy::{Intercept, Proxy, ProxyConnector};
+use once_cell::sync::Lazy;
+use percent_encoding::percent_decode_str;
+use tracing::debug;
+
+/// Global proxy configuration read from environment variables at startup
+pub static PROXY_CONFIG: Lazy<ProxyConfig> = Lazy::new(ProxyConfig::from_env);
+
+/// Default hosts that should bypass the proxy
+const DEFAULT_BYPASS_HOSTS: &[&str] = &["localhost", "127.0.0.1", "::1"];
+
+/// Proxy configuration parsed from environment variables
+#[derive(Debug, Clone)]
+pub struct ProxyConfig {
+    pub http_proxy: Option<Uri>,
+    pub https_proxy: Option<Uri>,
+    /// Pre-processed NO_PROXY patterns for efficient matching
+    no_proxy_patterns: Vec<NoProxyPattern>,
+}
+
+/// A pre-processed NO_PROXY pattern for efficient matching
+#[derive(Debug, Clone)]
+enum NoProxyPattern {
+    /// Matches all hosts
+    Wildcard,
+    /// Exact host match (lowercase), with optional port
+    Exact(String, Option<u16>),
+    /// Suffix match - pattern starts with dot (e.g., ".example.com"), with optional port
+    Suffix(String, Option<u16>),
+    /// Domain match - matches domain and all subdomains, with optional port
+    Domain {
+        exact: String,
+        suffix: String,
+        port: Option<u16>,
+    },
+}
+
+/// Check if a request port matches a pattern port.
+///
+/// - If pattern has no port (None), it matches any request port
+/// - If pattern has a port, request must have the same port
+#[inline]
+fn port_matches(request_port: Option<u16>, pattern_port: Option<u16>) -> bool {
+    match pattern_port {
+        None => true, // Pattern without port matches any port
+        Some(p) => request_port == Some(p),
+    }
+}
+
+/// Parse a NO_PROXY pattern into host and optional port.
+///
+/// Handles IPv6 addresses in brackets: `[::1]:8080`
+fn parse_host_port(pattern: &str) -> (&str, Option<u16>) {
+    // Handle IPv6 in brackets: [::1]:8080
+    if pattern.starts_with('[') {
+        if let Some(bracket_end) = pattern.find(']') {
+            let host = &pattern[1..bracket_end];
+            let remainder = &pattern[bracket_end + 1..];
+            if let Some(port_str) = remainder.strip_prefix(':') {
+                if let Ok(port) = port_str.parse::<u16>() {
+                    return (host, Some(port));
+                }
+            }
+            return (host, None);
+        }
+    }
+
+    // Handle regular host:port (but not IPv6 without brackets)
+    // Count colons - if more than one, it's likely IPv6 without port
+    let colon_count = pattern.chars().filter(|&c| c == ':').count();
+    if colon_count == 1 {
+        if let Some(colon_pos) = pattern.rfind(':') {
+            let host = &pattern[..colon_pos];
+            let port_str = &pattern[colon_pos + 1..];
+            if let Ok(port) = port_str.parse::<u16>() {
+                return (host, Some(port));
+            }
+        }
+    }
+
+    (pattern, None)
+}
+
+impl ProxyConfig {
+    /// Read proxy configuration from environment variables.
+    ///
+    /// Supports:
+    /// - `HTTP_PROXY` / `http_proxy` - Proxy URL for HTTP requests
+    /// - `HTTPS_PROXY` / `https_proxy` - Proxy URL for HTTPS requests
+    /// - `ALL_PROXY` / `all_proxy` - Fallback proxy for both HTTP and HTTPS
+    /// - `NO_PROXY` / `no_proxy` - Comma-separated list of hosts to bypass
+    ///
+    /// The proxy URL can include credentials: `http://user:pass@proxy:8080`
+    ///
+    /// Default bypass hosts (localhost, 127.0.0.1, ::1) are always included.
+    pub fn from_env() -> Self {
+        // Try specific proxy first, then fall back to ALL_PROXY
+        let all_proxy = env::var("ALL_PROXY")
+            .or_else(|_| env::var("all_proxy"))
+            .ok()
+            .and_then(|s| s.parse::<Uri>().ok());
+
+        // Clone all_proxy for http since we need it again for https
+        let http_proxy = env::var("HTTP_PROXY")
+            .or_else(|_| env::var("http_proxy"))
+            .ok()
+            .and_then(|s| s.parse::<Uri>().ok())
+            .or_else(|| all_proxy.clone());
+
+        // Consume all_proxy here (no clone needed)
+        let https_proxy = env::var("HTTPS_PROXY")
+            .or_else(|_| env::var("https_proxy"))
+            .ok()
+            .and_then(|s| s.parse::<Uri>().ok())
+            .or(all_proxy);
+
+        // Parse NO_PROXY patterns
+        let no_proxy_str = env::var("NO_PROXY")
+            .or_else(|_| env::var("no_proxy"))
+            .unwrap_or_default();
+
+        // Default bypass hosts match any port
+        let mut no_proxy_patterns: Vec<NoProxyPattern> = DEFAULT_BYPASS_HOSTS
+            .iter()
+            .map(|h| NoProxyPattern::Exact(h.to_lowercase(), None))
+            .collect();
+
+        for pattern in no_proxy_str.split(',').map(|s| s.trim().to_lowercase()) {
+            if pattern.is_empty() {
+                continue;
+            }
+            let parsed = if pattern == "*" {
+                NoProxyPattern::Wildcard
+            } else if pattern.starts_with('.') {
+                // Suffix pattern like ".example.com" or ".example.com:8080"
+                let (host, port) = parse_host_port(&pattern);
+                NoProxyPattern::Suffix(host.to_string(), port)
+            } else {
+                // Domain pattern like "example.com" or "example.com:8080"
+                let (host, port) = parse_host_port(&pattern);
+                NoProxyPattern::Domain {
+                    exact: host.to_string(),
+                    suffix: format!(".{}", host),
+                    port,
+                }
+            };
+            no_proxy_patterns.push(parsed);
+        }
+
+        let config = Self {
+            http_proxy,
+            https_proxy,
+            no_proxy_patterns,
+        };
+
+        // Log proxy configuration for debugging
+        if config.is_enabled() {
+            debug!(
+                http_proxy = ?config.http_proxy.as_ref().and_then(strip_userinfo),
+                https_proxy = ?config.https_proxy.as_ref().and_then(strip_userinfo),
+                no_proxy_count = config.no_proxy_patterns.len(),
+                "Proxy configuration loaded from environment"
+            );
+        }
+
+        config
+    }
+
+    /// Check if a host should bypass the proxy based on NO_PROXY rules.
+    ///
+    /// Matching rules:
+    /// - `*` matches all hosts
+    /// - `.example.com` matches `foo.example.com` but not `example.com`
+    /// - `example.com` matches `example.com` and `foo.example.com`
+    /// - `example.com:8080` matches only when port is 8080
+    /// - `localhost`, `127.0.0.1`, `::1` are always bypassed
+    pub fn should_bypass(&self, host: &str, port: Option<u16>) -> bool {
+        let host_lower = host.to_lowercase();
+        self.no_proxy_patterns.iter().any(|pattern| match pattern {
+            NoProxyPattern::Wildcard => true,
+            NoProxyPattern::Exact(exact, pattern_port) => {
+                host_lower == *exact && port_matches(port, *pattern_port)
+            },
+            NoProxyPattern::Suffix(suffix, pattern_port) => {
+                host_lower.ends_with(suffix) && port_matches(port, *pattern_port)
+            },
+            NoProxyPattern::Domain {
+                exact,
+                suffix,
+                port: pattern_port,
+            } => {
+                (host_lower == *exact || host_lower.ends_with(suffix))
+                    && port_matches(port, *pattern_port)
+            },
+        })
+    }
+
+    /// Check if any proxy is configured
+    pub fn is_enabled(&self) -> bool {
+        self.http_proxy.is_some() || self.https_proxy.is_some()
+    }
+}
+
+/// Extract basic auth credentials from a proxy URI.
+///
+/// Parses URIs like `http://user:password@proxy:8080` and returns
+/// an Authorization header. Properly handles URL-encoded credentials.
+pub fn extract_basic_auth(uri: &Uri) -> Option<Authorization<Basic>> {
+    let authority = uri.authority()?;
+    let authority_str = authority.as_str();
+
+    // Find the @ separator
+    let at_pos = authority_str.find('@')?;
+    let userinfo = &authority_str[..at_pos];
+
+    // Split into username and password
+    let colon_pos = userinfo.find(':')?;
+    let username = &userinfo[..colon_pos];
+    let password = &userinfo[colon_pos + 1..];
+
+    // URL decode the credentials (handles UTF-8 properly)
+    let username = percent_decode_str(username).decode_utf8().ok()?.to_string();
+    let password = percent_decode_str(password).decode_utf8().ok()?.to_string();
+
+    Some(Authorization::basic(&username, &password))
+}
+
+/// Create a proxy URI without credentials (for the actual proxy connection).
+///
+/// Strips the userinfo from URIs like `http://user:password@proxy:8080`
+/// to produce `http://proxy:8080`.
+pub fn strip_userinfo(uri: &Uri) -> Option<Uri> {
+    let authority = uri.authority()?;
+    let authority_str = authority.as_str();
+
+    // Check if there's userinfo to strip
+    if let Some(at_pos) = authority_str.find('@') {
+        let host_port = &authority_str[at_pos + 1..];
+        let scheme = uri.scheme_str().unwrap_or("http");
+        let path = uri.path();
+
+        format!("{}://{}{}", scheme, host_port, path)
+            .parse::<Uri>()
+            .ok()
+    } else {
+        Some(uri.clone())
+    }
+}
+
+/// Create an Intercept that respects NO_PROXY for HTTP requests.
+fn create_http_intercept(config: Arc<ProxyConfig>) -> Intercept {
+    let custom: hyper_http_proxy::Custom =
+        (move |scheme: Option<&str>, host: Option<&str>, port: Option<u16>| {
+            // Only intercept HTTP requests (not HTTPS)
+            if scheme != Some("http") {
+                return false;
+            }
+            if let Some(host) = host {
+                !config.should_bypass(host, port)
+            } else {
+                false
+            }
+        })
+        .into();
+    Intercept::Custom(custom)
+}
+
+/// Create an Intercept that respects NO_PROXY for HTTPS requests.
+fn create_https_intercept(config: Arc<ProxyConfig>) -> Intercept {
+    let custom: hyper_http_proxy::Custom =
+        (move |scheme: Option<&str>, host: Option<&str>, port: Option<u16>| {
+            // Only intercept HTTPS requests
+            if scheme != Some("https") {
+                return false;
+            }
+            if let Some(host) = host {
+                !config.should_bypass(host, port)
+            } else {
+                false
+            }
+        })
+        .into();
+    Intercept::Custom(custom)
+}
+
+/// Configure proxies on a ProxyConnector based on the given ProxyConfig.
+pub fn configure_proxies<C>(connector: &mut ProxyConnector<C>, config: &ProxyConfig) {
+    let config_arc = Arc::new(config.clone());
+
+    if let Some(http_uri) = &config.http_proxy {
+        let proxy_uri = strip_userinfo(http_uri).unwrap_or_else(|| http_uri.clone());
+        let intercept = create_http_intercept(Arc::clone(&config_arc));
+        let mut proxy = Proxy::new(intercept, proxy_uri);
+
+        if let Some(auth) = extract_basic_auth(http_uri) {
+            proxy.set_authorization(auth);
+        }
+
+        connector.add_proxy(proxy);
+    }
+
+    if let Some(https_uri) = &config.https_proxy {
+        let proxy_uri = strip_userinfo(https_uri).unwrap_or_else(|| https_uri.clone());
+        let intercept = create_https_intercept(Arc::clone(&config_arc));
+        let mut proxy = Proxy::new(intercept, proxy_uri);
+
+        if let Some(auth) = extract_basic_auth(https_uri) {
+            proxy.set_authorization(auth);
+        }
+
+        connector.add_proxy(proxy);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_bypass_exact_match() {
+        let config = ProxyConfig {
+            http_proxy: None,
+            https_proxy: None,
+            no_proxy_patterns: vec![
+                NoProxyPattern::Exact("localhost".to_string(), None),
+                NoProxyPattern::Domain {
+                    exact: "example.com".to_string(),
+                    suffix: ".example.com".to_string(),
+                    port: None,
+                },
+            ],
+        };
+
+        assert!(config.should_bypass("localhost", None));
+        assert!(config.should_bypass("example.com", None));
+        assert!(config.should_bypass("LOCALHOST", None));
+        assert!(config.should_bypass("sub.example.com", None));
+        assert!(!config.should_bypass("other.com", None));
+    }
+
+    #[test]
+    fn test_should_bypass_dot_prefix() {
+        let config = ProxyConfig {
+            http_proxy: None,
+            https_proxy: None,
+            no_proxy_patterns: vec![NoProxyPattern::Suffix(".internal.com".to_string(), None)],
+        };
+
+        assert!(config.should_bypass("host.internal.com", None));
+        assert!(config.should_bypass("deep.host.internal.com", None));
+        assert!(!config.should_bypass("internal.com", None));
+    }
+
+    #[test]
+    fn test_should_bypass_wildcard() {
+        let config = ProxyConfig {
+            http_proxy: None,
+            https_proxy: None,
+            no_proxy_patterns: vec![NoProxyPattern::Wildcard],
+        };
+
+        assert!(config.should_bypass("anything.com", None));
+        assert!(config.should_bypass("localhost", Some(8080)));
+    }
+
+    #[test]
+    fn test_default_bypass_hosts() {
+        let config = ProxyConfig::from_env();
+
+        // These should always be bypassed (any port)
+        assert!(config.should_bypass("localhost", None));
+        assert!(config.should_bypass("localhost", Some(3000)));
+        assert!(config.should_bypass("127.0.0.1", Some(8080)));
+        assert!(config.should_bypass("::1", None));
+        assert!(config.should_bypass("LOCALHOST", Some(443)));
+    }
+
+    #[test]
+    fn test_should_bypass_with_port() {
+        let config = ProxyConfig {
+            http_proxy: None,
+            https_proxy: None,
+            no_proxy_patterns: vec![
+                // localhost:3000 - only matches port 3000
+                NoProxyPattern::Exact("localhost".to_string(), Some(3000)),
+                // example.com:8080 - domain with specific port
+                NoProxyPattern::Domain {
+                    exact: "example.com".to_string(),
+                    suffix: ".example.com".to_string(),
+                    port: Some(8080),
+                },
+                // .internal.com:443 - suffix with specific port
+                NoProxyPattern::Suffix(".internal.com".to_string(), Some(443)),
+            ],
+        };
+
+        // localhost:3000 matches
+        assert!(config.should_bypass("localhost", Some(3000)));
+        // localhost:8080 does NOT match (wrong port)
+        assert!(!config.should_bypass("localhost", Some(8080)));
+        // localhost without port does NOT match
+        assert!(!config.should_bypass("localhost", None));
+
+        // example.com:8080 matches
+        assert!(config.should_bypass("example.com", Some(8080)));
+        // sub.example.com:8080 matches
+        assert!(config.should_bypass("sub.example.com", Some(8080)));
+        // example.com:443 does NOT match (wrong port)
+        assert!(!config.should_bypass("example.com", Some(443)));
+
+        // host.internal.com:443 matches
+        assert!(config.should_bypass("host.internal.com", Some(443)));
+        // host.internal.com:8080 does NOT match (wrong port)
+        assert!(!config.should_bypass("host.internal.com", Some(8080)));
+    }
+
+    #[test]
+    fn test_should_bypass_pattern_without_port_matches_any() {
+        let config = ProxyConfig {
+            http_proxy: None,
+            https_proxy: None,
+            no_proxy_patterns: vec![
+                // localhost without port - matches any port
+                NoProxyPattern::Exact("localhost".to_string(), None),
+            ],
+        };
+
+        assert!(config.should_bypass("localhost", None));
+        assert!(config.should_bypass("localhost", Some(80)));
+        assert!(config.should_bypass("localhost", Some(443)));
+        assert!(config.should_bypass("localhost", Some(8080)));
+    }
+
+    #[test]
+    fn test_parse_host_port() {
+        // Regular host without port
+        assert_eq!(parse_host_port("example.com"), ("example.com", None));
+
+        // Host with port
+        assert_eq!(
+            parse_host_port("example.com:8080"),
+            ("example.com", Some(8080))
+        );
+
+        // Suffix with port
+        assert_eq!(
+            parse_host_port(".example.com:443"),
+            (".example.com", Some(443))
+        );
+
+        // IPv6 without brackets (no port)
+        assert_eq!(parse_host_port("::1"), ("::1", None));
+
+        // IPv6 in brackets without port
+        assert_eq!(parse_host_port("[::1]"), ("::1", None));
+
+        // IPv6 in brackets with port
+        assert_eq!(parse_host_port("[::1]:8080"), ("::1", Some(8080)));
+
+        // IPv6 in brackets with port
+        assert_eq!(
+            parse_host_port("[2001:db8::1]:443"),
+            ("2001:db8::1", Some(443))
+        );
+    }
+
+    #[test]
+    fn test_extract_basic_auth() {
+        let uri: Uri = "http://user:pass@proxy.example.com:8080".parse().unwrap();
+        let auth = extract_basic_auth(&uri);
+        assert!(auth.is_some());
+    }
+
+    #[test]
+    fn test_extract_basic_auth_encoded() {
+        // Test URL-encoded credentials with special characters
+        let uri: Uri = "http://user%40domain:p%40ss%3Aword@proxy.example.com:8080"
+            .parse()
+            .unwrap();
+        let auth = extract_basic_auth(&uri);
+        assert!(auth.is_some());
+    }
+
+    #[test]
+    fn test_extract_basic_auth_no_credentials() {
+        let uri: Uri = "http://proxy.example.com:8080".parse().unwrap();
+        let auth = extract_basic_auth(&uri);
+        assert!(auth.is_none());
+    }
+
+    #[test]
+    fn test_strip_userinfo() {
+        let uri: Uri = "http://user:pass@proxy.example.com:8080/path"
+            .parse()
+            .unwrap();
+        let stripped = strip_userinfo(&uri).unwrap();
+        assert_eq!(stripped.to_string(), "http://proxy.example.com:8080/path");
+    }
+
+    #[test]
+    fn test_strip_userinfo_no_credentials() {
+        let uri: Uri = "http://proxy.example.com:8080".parse().unwrap();
+        let stripped = strip_userinfo(&uri).unwrap();
+        // When no credentials are present, returns the original URI
+        assert_eq!(stripped.to_string(), uri.to_string());
+    }
+
+    #[test]
+    fn test_is_enabled() {
+        let config = ProxyConfig {
+            http_proxy: Some("http://proxy:8080".parse().unwrap()),
+            https_proxy: None,
+            no_proxy_patterns: vec![],
+        };
+        assert!(config.is_enabled());
+
+        let config = ProxyConfig {
+            http_proxy: None,
+            https_proxy: None,
+            no_proxy_patterns: vec![],
+        };
+        assert!(!config.is_enabled());
+    }
+}


### PR DESCRIPTION
### Issue # (if available)

Closes #273 

### Description of changes

- Support HTTP_PROXY, HTTPS_PROXY, ALL_PROXY environment variables
- Support NO_PROXY for bypassing specific hosts with port matching
- Support proxy authentication via URL credentials
- Default bypass for localhost, 127.0.0.1, ::1

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
