### PR TITLE
chore: Bump to rquickjs 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,8 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.10.0"
-source = "git+https://github.com/DelSkayn/rquickjs.git#111951b1a31075bdff46684e0ff29f37ff2a04b2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a"
 dependencies = [
  "either",
  "indexmap",
@@ -2762,8 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-core"
-version = "0.10.0"
-source = "git+https://github.com/DelSkayn/rquickjs.git#111951b1a31075bdff46684e0ff29f37ff2a04b2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1"
 dependencies = [
  "async-lock",
  "chrono",
@@ -2778,8 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-macro"
-version = "0.10.0"
-source = "git+https://github.com/DelSkayn/rquickjs.git#111951b1a31075bdff46684e0ff29f37ff2a04b2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7106215ff41a5677b104906a13e1a440b880f4b6362b5dc4f3978c267fad2b80"
 dependencies = [
  "convert_case",
  "fnv",
@@ -2796,8 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.10.0"
-source = "git+https://github.com/DelSkayn/rquickjs.git#111951b1a31075bdff46684e0ff29f37ff2a04b2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83"
 dependencies = [
  "bindgen",
  "cc",

--- a/libs/llrt_context/Cargo.toml
+++ b/libs/llrt_context/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/llrt"
 
 [dependencies]
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "futures",
 ], default-features = false }
 llrt_utils = { version = "0.7.0-beta", path = "../llrt_utils", default-features = false }

--- a/libs/llrt_hooking/Cargo.toml
+++ b/libs/llrt_hooking/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/lib.rs"
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
 once_cell = { version = "1", features = ["std"], default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }

--- a/libs/llrt_json/Cargo.toml
+++ b/libs/llrt_json/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 itoa = { version = "1", default-features = false }
 llrt_utils = { version = "0.7.0-beta", path = "../llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 ryu = { version = "1", default-features = false }
 simd-json = { version = "0.17", features = [
     "big-int-as-float",

--- a/libs/llrt_logging/Cargo.toml
+++ b/libs/llrt_logging/Cargo.toml
@@ -17,7 +17,7 @@ llrt_encoding = { version = "0.7.0-beta", path = "../llrt_encoding" }
 llrt_json = { version = "0.7.0-beta", path = "../llrt_json" }
 llrt_numbers = { version = "0.7.0-beta", path = "../llrt_numbers" }
 llrt_utils = { version = "0.7.0-beta", path = "../llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "macro",
 ], default-features = false }
 ryu = { version = "1", default-features = false }

--- a/libs/llrt_numbers/Cargo.toml
+++ b/libs/llrt_numbers/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 itoa = { version = "1", default-features = false }
 llrt_utils = { version = "0.7.0-beta", path = "../llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 ryu = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/libs/llrt_test/Cargo.toml
+++ b/libs/llrt_test/Cargo.toml
@@ -11,7 +11,7 @@ name = "llrt_test"
 path = "src/lib.rs"
 
 [dependencies]
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "futures",
   "loader",
   "parallel",

--- a/libs/llrt_utils/Cargo.toml
+++ b/libs/llrt_utils/Cargo.toml
@@ -14,7 +14,7 @@ fs = ["tokio/fs"]
 bytearray-buffer = ["tokio/sync"]
 
 [dependencies]
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "array-buffer",
   "macro",
 ], default-features = false }

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -37,7 +37,7 @@ rand = { version = "0.10.0-rc.5", features = [
   "thread_rng",
 ], default-features = false }
 ring = { version = "0.17", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "full-async",
   "parallel",
   "rust-alloc",
@@ -61,7 +61,7 @@ md-5 = { version = "0.11.0-rc.3", default-features = false }
 md-5 = { version = "0.11.0-rc.3", default-features = false }
 
 [build-dependencies]
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "full-async",
   "rust-alloc",
 ], default-features = false }

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -79,7 +79,7 @@ llrt_hooking = { path = "../libs/llrt_hooking" }
 llrt_json = { path = "../libs/llrt_json" }
 llrt_utils = { version = "0.7.0-beta", path = "../libs/llrt_utils" }
 once_cell = { version = "1", features = ["std"], default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "loader",
 ], default-features = false }
 simd-json = { version = "0.17", default-features = false }

--- a/llrt_modules/README.md
+++ b/llrt_modules/README.md
@@ -25,8 +25,7 @@ Check the [Compability matrix](#compatibility-matrix) for the full list.
 ```toml
 [dependencies]
 llrt_modules = { path = "llrt/llrt_modules", default-features = true } # load from local path
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
-"full-async"] }
+rquickjs = { version = "0.11", features = ["full-async"] }
 tokio = { version = "1", features = ["full"] }
 
 ```

--- a/modules/llrt_abort/Cargo.toml
+++ b/modules/llrt_abort/Cargo.toml
@@ -21,7 +21,7 @@ llrt_async_hooks = { version = "0.7.0-beta", path = "../llrt_async_hooks" }
 llrt_exceptions = { version = "0.7.0-beta", path = "../llrt_exceptions" }
 llrt_events = { version = "0.7.0-beta", path = "../llrt_events" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "macro",
 ], default-features = false }
 

--- a/modules/llrt_assert/Cargo.toml
+++ b/modules/llrt_assert/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }

--- a/modules/llrt_async_hooks/Cargo.toml
+++ b/modules/llrt_async_hooks/Cargo.toml
@@ -13,5 +13,5 @@ path = "src/lib.rs"
 [dependencies]
 llrt_hooking = { version = "0.7.0-beta", path = "../../libs/llrt_hooking" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/modules/llrt_buffer/Cargo.toml
+++ b/modules/llrt_buffer/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 itoa = { version = "1", default-features = false }
 llrt_encoding = { version = "0.7.0-beta", path = "../../libs/llrt_encoding" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "futures",
   "macro",
 ], default-features = false }

--- a/modules/llrt_child_process/Cargo.toml
+++ b/modules/llrt_child_process/Cargo.toml
@@ -17,7 +17,7 @@ llrt_context = { version = "0.7.0-beta", path = "../../libs/llrt_context" }
 llrt_events = { version = "0.7.0-beta", path = "../llrt_events" }
 llrt_stream = { version = "0.7.0-beta", path = "../llrt_stream" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "std",
 ], default-features = false }
 tokio = { version = "1", features = ["process"], default-features = false }

--- a/modules/llrt_console/Cargo.toml
+++ b/modules/llrt_console/Cargo.toml
@@ -13,6 +13,6 @@ path = "src/lib.rs"
 [dependencies]
 llrt_logging = { version = "0.7.0-beta", path = "../../libs/llrt_logging" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "macro",
 ], default-features = false }

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -48,7 +48,7 @@ rand = { version = "0.10.0-rc.5", features = [
   "thread_rng",
 ], default-features = false }
 ring = { version = "0.17", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "macro",
 ], default-features = false }
 

--- a/modules/llrt_dgram/Cargo.toml
+++ b/modules/llrt_dgram/Cargo.toml
@@ -17,7 +17,7 @@ llrt_buffer = { version = "0.7.0-beta", path = "../llrt_buffer" }
 llrt_context = { version = "0.7.0-beta", path = "../../libs/llrt_context" }
 llrt_events = { version = "0.7.0-beta", path = "../llrt_events" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 tokio = { version = "1", features = ["net", "macros"], default-features = false }
 tracing = { version = "0.1", default-features = false }
 

--- a/modules/llrt_dns/Cargo.toml
+++ b/modules/llrt_dns/Cargo.toml
@@ -16,7 +16,7 @@ either = { version = "1", default-features = false }
 llrt_context = { version = "0.7.0-beta", path = "../../libs/llrt_context" }
 llrt_hooking = { version = "0.7.0-beta", path = "../../libs/llrt_hooking" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "macro",
   "either",
 ], default-features = false }

--- a/modules/llrt_events/Cargo.toml
+++ b/modules/llrt_events/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "macro",
 ], default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/modules/llrt_exceptions/Cargo.toml
+++ b/modules/llrt_exceptions/Cargo.toml
@@ -11,7 +11,7 @@ name = "llrt_exceptions"
 path = "src/lib.rs"
 
 [dependencies]
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "macro",
 ], default-features = false }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -47,10 +47,10 @@ rand = { version = "0.10.0-rc.5", features = [
   "std",
   "thread_rng",
 ], default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", features = [
+rquickjs = { version = "0.11", features = [
   "either",
   "std",
-], version = "0.10.0", default-features = false }
+], default-features = false }
 tokio = { version = "1", features = [
   "macros",
   "sync",

--- a/modules/llrt_fs/Cargo.toml
+++ b/modules/llrt_fs/Cargo.toml
@@ -20,7 +20,7 @@ llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", features 
   "fs",
 ], default-features = false }
 ring = { version = "0.17", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "either",
   "futures",
   "macro",

--- a/modules/llrt_http/Cargo.toml
+++ b/modules/llrt_http/Cargo.toml
@@ -32,10 +32,10 @@ llrt_dns_cache = { version = "0.7.0-beta", path = "../../libs/llrt_dns_cache" }
 llrt_tls = { version = "0.7.0-beta", default-features = false, path = "../llrt_tls" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
 once_cell = { version = "1", features = ["std"], default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", features = [
+rquickjs = { version = "0.11", features = [
   "either",
   "std",
-], version = "0.10.0", default-features = false }
+], default-features = false }
 rustls = { version = "0.23", features = [
   "ring",
   "tls12",

--- a/modules/llrt_intl/Cargo.toml
+++ b/modules/llrt_intl/Cargo.toml
@@ -16,5 +16,5 @@ chrono = { version = "0.4", features = ["std", "clock"], default-features = fals
 chrono-tz = { version = "0.10", default-features = false }
 iana-time-zone = "0.1"
 itoa = "1.0"
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils" }

--- a/modules/llrt_navigator/Cargo.toml
+++ b/modules/llrt_navigator/Cargo.toml
@@ -12,4 +12,4 @@ name = "llrt_navigator"
 path = "src/lib.rs"
 
 [dependencies]
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }

--- a/modules/llrt_net/Cargo.toml
+++ b/modules/llrt_net/Cargo.toml
@@ -18,7 +18,7 @@ llrt_context = { version = "0.7.0-beta", path = "../../libs/llrt_context" }
 llrt_events = { version = "0.7.0-beta", path = "../llrt_events" }
 llrt_stream = { version = "0.7.0-beta", path = "../llrt_stream" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 tokio = { version = "1", features = ["net"], default-features = false }
 tracing = { version = "0.1", default-features = false }
 

--- a/modules/llrt_os/Cargo.toml
+++ b/modules/llrt_os/Cargo.toml
@@ -19,7 +19,7 @@ home = { version = "0.5", default-features = false }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
 num_cpus = { version = "1", default-features = false }
 once_cell = { version = "1", features = ["std"], default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "std",
 ], default-features = false }
 

--- a/modules/llrt_path/Cargo.toml
+++ b/modules/llrt_path/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "std",
 ], default-features = false }
 

--- a/modules/llrt_perf_hooks/Cargo.toml
+++ b/modules/llrt_perf_hooks/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 [dependencies]
 llrt_events = { version = "0.7.0-beta", path = "../llrt_events" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }

--- a/modules/llrt_process/Cargo.toml
+++ b/modules/llrt_process/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "std",
 ], default-features = false }
 

--- a/modules/llrt_stream/Cargo.toml
+++ b/modules/llrt_stream/Cargo.toml
@@ -17,7 +17,7 @@ llrt_events = { version = "0.7.0-beta", path = "../llrt_events" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", features = [
   "bytearray-buffer",
 ], default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "std",
 ], default-features = false }
 tokio = { version = "1", features = [

--- a/modules/llrt_stream_web/Cargo.toml
+++ b/modules/llrt_stream_web/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 llrt_abort = { version = "0.7.0-beta", path = "../llrt_abort" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }

--- a/modules/llrt_string_decoder/Cargo.toml
+++ b/modules/llrt_string_decoder/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 llrt_buffer = { version = "0.7.0-beta", path = "../llrt_buffer" }
 llrt_encoding = { version = "0.7.0-beta", path = "../../libs/llrt_encoding" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }

--- a/modules/llrt_timers/Cargo.toml
+++ b/modules/llrt_timers/Cargo.toml
@@ -15,7 +15,7 @@ llrt_context = { version = "0.7.0-beta", path = "../../libs/llrt_context" }
 llrt_hooking = { version = "0.7.0-beta", path = "../../libs/llrt_hooking" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
 once_cell = { version = "1", features = ["std"], default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 tokio = { version = "1", features = [
   "macros",
   "sync",

--- a/modules/llrt_tty/Cargo.toml
+++ b/modules/llrt_tty/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 libc = { version = "0.2", default-features = false }
 
 [dev-dependencies]

--- a/modules/llrt_url/Cargo.toml
+++ b/modules/llrt_url/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
     "macro",
 ], default-features = false }
 url = { version = "2", features = ["std"], default-features = false }

--- a/modules/llrt_util/Cargo.toml
+++ b/modules/llrt_util/Cargo.toml
@@ -16,4 +16,4 @@ llrt_context = { version = "0.7.0-beta", path = "../../libs/llrt_context" }
 llrt_encoding = { version = "0.7.0-beta", path = "../../libs/llrt_encoding" }
 llrt_logging = { version = "0.7.0-beta", path = "../../libs/llrt_logging" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", default-features = false }
+rquickjs = { version = "0.11", default-features = false }

--- a/modules/llrt_zlib/Cargo.toml
+++ b/modules/llrt_zlib/Cargo.toml
@@ -31,7 +31,7 @@ llrt_buffer = { version = "0.7.0-beta", path = "../llrt_buffer" }
 llrt_compression = { version = "0.7.0-beta", path = "../../libs/llrt_compression", default-features = false }
 llrt_context = { version = "0.7.0-beta", path = "../../libs/llrt_context" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { git = "https://github.com/DelSkayn/rquickjs.git", version = "0.10.0", features = [
+rquickjs = { version = "0.11", features = [
   "std",
 ], default-features = false }
 

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -25,7 +25,7 @@ WebCryptoAPI > should pass getPublicKey.tentative.https.any.js tests
 Error: [getPublicKey works for ECDH] promise_test: Unhandled rejection with value: object "TypeError: not a function"
 
 WebCryptoAPI > should pass historical.any.js tests
-Error: [Non-secure context window does not have access to crypto.subtle] assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+Error: [Non-secure context window does not have access to crypto.subtle] assert_equals: expected (undefined) undefined but got (object) object "[object SubtleCrypto]"
 
 WebCryptoAPI > should pass supports.tentative.https.any.js tests
 Error: [SubtleCrypto.supports method exists] assert_true: SubtleCrypto.supports should be a function expected true got false
@@ -292,7 +292,7 @@ TypeError: Error converting from js 'object' into type 'AbortSignal'
 
 
 Error: Test did not exit within 1s. It does not properly clean up created resources (servers, timeouts etc)
-    at <anonymous> (llrt:test/index:437:27)
+    at <anonymous> (llrt:test/index:448:27)
 
 
 🧪/wpt/streams.readable-byte-streams.test.js 


### PR DESCRIPTION
### Description of changes

- Upgrading Rquickjs from 0.10 -> 0.11.
- We have also removed the Git URL specification, which may cause inconsistencies when LLRT is released as a crate in the future. This specification is probably a relic from the time when no new versions were released for a long time, and is no longer necessary. @richarddavison and @Sytten  will surely bump it at the appropriate time. :)

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
