### PR TITLE
fix(dependabot): multiple definitions of the same ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,17 +37,11 @@ updates:
           - "minor"
           - "patch"
 
-  #
-  # Maintain direct RustCrypto dependencies
-  # - High-frequency (daily) updates
-  # - Grouped into a single PR for easier review
-  #
+  # Maintain dependencies for Rust
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: daily
-    allow:
-      - dependency-type: direct
     groups:
       rustcrypto:
         patterns:
@@ -67,57 +61,3 @@ updates:
           - "rsa"
           - "spki"
           - "x25519-dalek"
-    labels:
-      - dependencies
-      - rust
-      - rustcrypto
-    open-pull-requests-limit: 1
-
-  #
-  # Maintain other direct dependencies
-  # - Weekly updates to reduce review noise
-  # - RustCrypto crates are intentionally excluded
-  #
-  - package-ecosystem: cargo
-    directory: "/"
-    schedule:
-      interval: weekly
-    allow:
-      - dependency-type: direct
-    ignore:
-      - dependency-name: "aes*"
-      - dependency-name: "cbc"
-      - dependency-name: "const-oid"
-      - dependency-name: "ctr"
-      - dependency-name: "der"
-      - dependency-name: "ecdsa"
-      - dependency-name: "elliptic-curve"
-      - dependency-name: "md-5"
-      - dependency-name: "hmac"
-      - dependency-name: "p256"
-      - dependency-name: "p384"
-      - dependency-name: "p521"
-      - dependency-name: "pkcs8"
-      - dependency-name: "rsa"
-      - dependency-name: "spki"
-      - dependency-name: "x25519-dalek"
-    labels:
-      - dependencies
-      - rust
-      - direct
-
-  #
-  # Maintain indirect (transitive) dependencies
-  # - Lockfile-only updates
-  #
-  - package-ecosystem: cargo
-    directory: "/"
-    schedule:
-      interval: weekly
-    allow:
-      - dependency-type: indirect
-    labels:
-      - dependencies
-      - rust
-      - indirect
-    open-pull-requests-limit: 1


### PR DESCRIPTION
### Issue # (if available)

Fixed #1322 

### Description of changes

I'm sorry. It seems that the PR definition submitted in #1322 cannot run Dependabot, resulting in an error.

Since the PR wasn't appearing when it should have, I enabled it in my forked repository, and discovered that the following error was occurring.

```
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'cargo' has overlapping directories.
```

In cases like this where the directory and target branch are the same, it seems that there can only be one definition per ecosystem.

Therefore, we have changed the definition to enable more frequent checking for the RustCrypto group, which is our original purpose. Othe packages will also be affected, but we do not expect them to be updated frequently. After RustCrypto is updated from the RC to the official version, it may be a good idea to change the interval to weekly.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
