### PR TITLE
feat(tls): Support `rustls-rustcrypto` provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
+ "aes",
  "cipher",
  "ctr",
  "ghash",
@@ -336,8 +337,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher",
  "cpufeatures",
  "rand_core",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
 ]
 
 [[package]]
@@ -785,6 +799,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
  "zeroize",
 ]
 
@@ -834,6 +849,7 @@ dependencies = [
  "group",
  "hkdf",
  "hybrid-array",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -2264,6 +2280,7 @@ dependencies = [
  "openssl",
  "rustls",
  "rustls-graviola",
+ "rustls-rustcrypto",
  "tokio",
  "tokio-openssl",
  "tokio-rustls",
@@ -2291,6 +2308,7 @@ dependencies = [
  "rustls",
  "rustls-graviola",
  "rustls-native-certs",
+ "rustls-rustcrypto",
  "tracing",
  "webpki-roots",
 ]
@@ -2617,6 +2635,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pbkdf2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,6 +2767,16 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
+dependencies = [
+ "cpufeatures",
+ "universal-hash",
+]
 
 [[package]]
 name = "polyval"
@@ -3153,6 +3187,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-rustcrypto"
+version = "0.0.2-alpha"
+source = "git+https://github.com/RustCrypto/rustls-rustcrypto.git#7b44a2de957b6596d267a920d3aec0d4137defb1"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "crypto-common",
+ "der",
+ "digest",
+ "ecdsa",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "hmac",
+ "p256",
+ "p384",
+ "paste",
+ "pkcs8",
+ "rsa",
+ "rustls",
+ "rustls-pki-types",
+ "sec1",
+ "sha2",
+ "signature",
+ "x25519-dalek",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -346,10 +346,10 @@ deploy:
 	cd example/infrastructure && yarn deploy --require-approval never
 
 check:
-	cargo clippy --all-targets --no-default-features --features "lambda,macro,no-sdk,uncompressed,crypto-rust,tls-ring" -- -D warnings
+	cargo clippy --all-targets --no-default-features --features "lambda,macro,no-sdk,uncompressed,crypto-rust,tls-rust" -- -D warnings
 
 test-rs:
-	cargo test --all-targets --no-default-features --features "lambda,macro,no-sdk,uncompressed,crypto-rust,tls-ring"
+	cargo test --all-targets --no-default-features --features "lambda,macro,no-sdk,uncompressed,crypto-rust,tls-rust"
 
 check-crates:
 	cargo metadata --no-deps --format-version 1 --quiet | \

--- a/libs/llrt_test_tls/Cargo.toml
+++ b/libs/llrt_test_tls/Cargo.toml
@@ -11,7 +11,8 @@ name = "llrt_test_tls"
 path = "src/lib.rs"
 
 [features]
-default = ["tls-ring"]
+default = ["tls-rust"]
+tls-rust = ["dep:rustls-rustcrypto"]
 tls-ring = ["rustls/ring"]
 tls-aws-lc = ["rustls/aws_lc_rs"]
 tls-graviola = ["dep:rustls-graviola"]
@@ -27,6 +28,7 @@ hyper-util = { version = "0.1", features = [
 http = { version = "1", default-features = false }
 rustls = { version = "0.23", features = ["tls12"], default-features = false }
 rustls-graviola = { version = "0.4", default-features = false, optional = true }
+rustls-rustcrypto = { version = "0.0.2-alpha", git = "https://github.com/RustCrypto/rustls-rustcrypto.git", optional = true }
 openssl = { version = "0.10", optional = true }
 tokio-openssl = { version = "0.6", optional = true }
 tokio = { version = "1", features = [

--- a/libs/llrt_test_tls/src/lib.rs
+++ b/libs/llrt_test_tls/src/lib.rs
@@ -4,14 +4,35 @@
 // FIXME this library is only needed until TLS is natively supported in wiremock.
 // See https://github.com/LukeMathWalker/wiremock-rs/issues/58
 
+#[cfg(all(feature = "tls-rust", feature = "tls-ring"))]
+compile_error!("Features `tls-rust` and `tls-ring` are mutually exclusive");
+
+#[cfg(all(feature = "tls-rust", feature = "tls-aws-lc"))]
+compile_error!("Features `tls-rust` and `tls-aws-lc` are mutually exclusive");
+
+#[cfg(all(feature = "tls-rust", feature = "tls-graviola"))]
+compile_error!("Features `tls-rust` and `tls-graviola` are mutually exclusive");
+
+#[cfg(all(feature = "tls-rust", feature = "tls-openssl"))]
+compile_error!("Features `tls-rust` and `tls-openssl` are mutually exclusive");
+
 #[cfg(all(feature = "tls-ring", feature = "tls-aws-lc"))]
-compile_error!("Features 'tls-ring' and 'tls-aws-lc' are mutually exclusive");
+compile_error!("Features `tls-ring` and `tls-aws-lc` are mutually exclusive");
 
 #[cfg(all(feature = "tls-ring", feature = "tls-graviola"))]
-compile_error!("Features 'tls-ring' and 'tls-graviola' are mutually exclusive");
+compile_error!("Features `tls-ring` and `tls-graviola` are mutually exclusive");
+
+#[cfg(all(feature = "tls-ring", feature = "tls-openssl"))]
+compile_error!("Features `tls-ring` and `tls-openssl` are mutually exclusive");
 
 #[cfg(all(feature = "tls-aws-lc", feature = "tls-graviola"))]
-compile_error!("Features 'tls-aws-lc' and 'tls-graviola' are mutually exclusive");
+compile_error!("Features `tls-aws-lc` and `tls-graviola` are mutually exclusive");
+
+#[cfg(all(feature = "tls-aws-lc", feature = "tls-openssl"))]
+compile_error!("Features `tls-aws-lc` and `tls-openssl` are mutually exclusive");
+
+#[cfg(all(feature = "tls-graviola", feature = "tls-openssl"))]
+compile_error!("Features `tls-graviola` and `tls-openssl` are mutually exclusive");
 
 use std::net::{Ipv4Addr, SocketAddr};
 

--- a/libs/llrt_test_tls/src/server.rs
+++ b/libs/llrt_test_tls/src/server.rs
@@ -1,7 +1,13 @@
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 use std::sync::Arc;
 
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
@@ -9,6 +15,7 @@ use std::sync::Arc;
 ))]
 use hyper::service::service_fn;
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
@@ -16,6 +23,7 @@ use hyper::service::service_fn;
 ))]
 use hyper_util::rt::{TokioExecutor, TokioIo};
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
@@ -23,6 +31,7 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 ))]
 use hyper_util::server::conn::auto::Builder;
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
@@ -31,12 +40,18 @@ use hyper_util::server::conn::auto::Builder;
 use tokio::net::TcpListener;
 
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
     feature = "tls-openssl"
 ))]
 use crate::MockServerCerts;
+
+#[cfg(feature = "tls-rust")]
+fn get_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    Arc::new(rustls_rustcrypto::provider())
+}
 
 #[cfg(feature = "tls-ring")]
 fn get_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
@@ -53,7 +68,12 @@ fn get_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
     Arc::new(rustls_graviola::default_provider())
 }
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 pub(super) async fn run(
     listener: TcpListener,
     certs: MockServerCerts,

--- a/llrt/Cargo.toml
+++ b/llrt/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license-file = "LICENSE"
 
 [features]
-default = ["macro", "tls-ring", "crypto-rust"]
+default = ["macro", "tls-rust", "crypto-rust"]
 macro = ["llrt_core/macro"]
 lambda = ["llrt_core/lambda"]
 no-sdk = ["llrt_core/no-sdk"]
@@ -13,6 +13,7 @@ uncompressed = ["llrt_core/uncompressed"]
 bindgen = ["llrt_core/bindgen"]
 
 # TLS crypto backend features
+tls-rust = ["llrt_core/tls-rust"]
 tls-ring = ["llrt_core/tls-ring"]
 tls-aws-lc = ["llrt_core/tls-aws-lc"]
 tls-graviola = ["llrt_core/tls-graviola"]

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license-file = "LICENSE"
 
 [features]
-default = ["macro", "tls-ring", "crypto-rust"]
+default = ["macro", "tls-rust", "crypto-rust"]
 lambda = []
 no-sdk = []
 uncompressed = []
@@ -13,6 +13,7 @@ macro = ["rquickjs/macro"]
 bindgen = ["rquickjs/bindgen"]
 
 # TLS crypto backend features
+tls-rust = ["llrt_modules/tls-rust"]
 tls-ring = ["rustls/ring", "llrt_modules/tls-ring"]
 tls-aws-lc = ["rustls/aws_lc_rs", "llrt_modules/tls-aws-lc"]
 tls-graviola = ["llrt_modules/tls-graviola"]

--- a/llrt_core/src/http.rs
+++ b/llrt_core/src/http.rs
@@ -7,13 +7,28 @@ use tracing::warn;
 use crate::environment;
 use crate::modules::https::{set_http_version, set_pool_idle_timeout_seconds, HttpVersion};
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 use std::{fs::File, io};
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 use rustls::{pki_types::CertificateDer, version, SupportedProtocolVersion};
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 use crate::modules::tls::{set_extra_ca_certs, set_tls_versions};
 
 #[cfg(feature = "tls-openssl")]
@@ -24,7 +39,12 @@ pub fn init() -> StdResult<(), Box<dyn std::error::Error + Send + Sync>> {
         set_pool_idle_timeout_seconds(pool_idle_timeout);
     }
 
-    #[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+    #[cfg(any(
+        feature = "tls-rust",
+        feature = "tls-ring",
+        feature = "tls-aws-lc",
+        feature = "tls-graviola"
+    ))]
     {
         if let Some(extra_ca_certs) = build_extra_ca_certs()? {
             set_extra_ca_certs(extra_ca_certs);
@@ -59,7 +79,12 @@ fn build_pool_idle_timeout() -> Option<u64> {
     Some(pool_idle_timeout)
 }
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 fn build_extra_ca_certs() -> StdResult<Option<Vec<CertificateDer<'static>>>, io::Error> {
     if let Ok(extra_ca_certs) = env::var(environment::ENV_LLRT_EXTRA_CA_CERTS) {
         if !extra_ca_certs.is_empty() {
@@ -76,7 +101,12 @@ fn build_extra_ca_certs() -> StdResult<Option<Vec<CertificateDer<'static>>>, io:
     Ok(None)
 }
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 fn build_tls_versions() -> Vec<&'static SupportedProtocolVersion> {
     match env::var(environment::ENV_LLRT_TLS_VERSION).as_deref() {
         Ok("1.3") => vec![&version::TLS13, &version::TLS12],

--- a/llrt_modules/Cargo.toml
+++ b/llrt_modules/Cargo.toml
@@ -8,21 +8,14 @@ repository = "https://github.com/awslabs/llrt"
 readme = "README.md"
 
 [features]
-default = ["base", "console", "tls-ring", "crypto-rust"]
+default = ["base", "console", "tls-rust", "crypto-rust"]
 lambda = ["base"]
 
 # TLS crypto backend features
+tls-rust = ["llrt_http?/tls-rust", "llrt_tls?/tls-rust", "llrt_fetch?/tls-rust"]
 tls-ring = ["llrt_http?/tls-ring", "llrt_tls?/tls-ring", "llrt_fetch?/tls-ring"]
-tls-aws-lc = [
-  "llrt_http?/tls-aws-lc",
-  "llrt_tls?/tls-aws-lc",
-  "llrt_fetch?/tls-aws-lc",
-]
-tls-graviola = [
-  "llrt_http?/tls-graviola",
-  "llrt_tls?/tls-graviola",
-  "llrt_fetch?/tls-graviola",
-]
+tls-aws-lc = ["llrt_http?/tls-aws-lc", "llrt_tls?/tls-aws-lc", "llrt_fetch?/tls-aws-lc"]
+tls-graviola = ["llrt_http?/tls-graviola", "llrt_tls?/tls-graviola", "llrt_fetch?/tls-graviola"]
 tls-openssl = ["llrt_http?/tls-openssl", "llrt_tls?/tls-openssl"]
 
 # Crypto provider features

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -12,7 +12,7 @@ name = "llrt_fetch"
 path = "src/lib.rs"
 
 [features]
-default = ["http1", "http2", "compression-c", "webpki-roots", "tls-ring"]
+default = ["http1", "http2", "compression-c", "webpki-roots", "tls-rust"]
 
 http1 = ["hyper/http1", "llrt_http/http1"]
 http2 = ["hyper/http2", "llrt_http/http2"]
@@ -23,6 +23,7 @@ compression-rust = ["llrt_compression/all-rust"]
 webpki-roots = ["llrt_http/webpki-roots"]
 native-roots = ["llrt_http/native-roots"]
 
+tls-rust = ["llrt_http/tls-rust", "llrt_test_tls/tls-rust"]
 tls-ring = ["llrt_http/tls-ring", "llrt_test_tls/tls-ring"]
 tls-aws-lc = ["llrt_http/tls-aws-lc", "llrt_test_tls/tls-aws-lc"]
 tls-graviola = ["llrt_http/tls-graviola", "llrt_test_tls/tls-graviola"]

--- a/modules/llrt_http/Cargo.toml
+++ b/modules/llrt_http/Cargo.toml
@@ -12,7 +12,7 @@ name = "llrt_http"
 path = "src/lib.rs"
 
 [features]
-default = ["http1", "http2", "webpki-roots", "tls-ring"]
+default = ["http1", "http2", "webpki-roots", "tls-rust"]
 
 http1 = ["hyper/http1", "hyper-rustls?/http1", "hyper-util/http1"]
 http2 = ["hyper/http2", "hyper-rustls?/http2", "hyper-util/http2"]
@@ -21,34 +21,13 @@ webpki-roots = ["llrt_tls/webpki-roots"]
 native-roots = ["llrt_tls/native-roots"]
 
 # TLS crypto backend features (rustls-based)
-tls-ring = [
-  "http1",
-  "llrt_tls/tls-ring",
-  "dep:hyper-rustls",
-  "hyper-rustls/ring",
-  "dep:rustls",
-]
-tls-aws-lc = [
-  "http1",
-  "llrt_tls/tls-aws-lc",
-  "dep:hyper-rustls",
-  "hyper-rustls/aws-lc-rs",
-  "dep:rustls",
-]
-tls-graviola = [
-  "http1",
-  "llrt_tls/tls-graviola",
-  "dep:hyper-rustls",
-  "dep:rustls",
-]
+tls-rust = ["http1", "llrt_tls/tls-rust", "dep:hyper-rustls", "dep:rustls"]
+tls-ring = ["http1", "llrt_tls/tls-ring", "dep:hyper-rustls", "hyper-rustls/ring", "dep:rustls"]
+tls-aws-lc = ["http1", "llrt_tls/tls-aws-lc", "dep:hyper-rustls", "hyper-rustls/aws-lc-rs", "dep:rustls"]
+tls-graviola = ["http1", "llrt_tls/tls-graviola", "dep:hyper-rustls", "dep:rustls"]
 
 # OpenSSL TLS backend
-tls-openssl = [
-  "http1",
-  "llrt_tls/tls-openssl",
-  "dep:hyper-openssl",
-  "dep:openssl",
-]
+tls-openssl = ["http1", "llrt_tls/tls-openssl", "dep:hyper-openssl", "dep:openssl"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/modules/llrt_http/src/client.rs
+++ b/modules/llrt_http/src/client.rs
@@ -11,11 +11,21 @@ use once_cell::sync::Lazy;
 
 use crate::get_pool_idle_timeout;
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 use crate::get_http_version;
 
 // Rustls-based TLS backends
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 mod rustls_client {
     use super::*;
     use hyper_rustls::HttpsConnector;
@@ -121,7 +131,12 @@ mod openssl_client {
 }
 
 // Re-export based on feature
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 pub use rustls_client::*;
 
 #[cfg(feature = "tls-openssl")]

--- a/modules/llrt_http/src/lib.rs
+++ b/modules/llrt_http/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use llrt_utils::module::{export_default, ModuleInfo};
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
@@ -16,6 +17,7 @@ use rquickjs::{
 pub use self::config::*;
 
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
@@ -25,6 +27,7 @@ mod client;
 mod config;
 
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
@@ -33,6 +36,7 @@ mod config;
 mod agent;
 
 #[cfg(any(
+    feature = "tls-rust",
     feature = "tls-ring",
     feature = "tls-aws-lc",
     feature = "tls-graviola",
@@ -45,6 +49,7 @@ pub struct HttpsModule;
 impl ModuleDef for HttpsModule {
     fn declare(declare: &Declarations) -> Result<()> {
         #[cfg(any(
+            feature = "tls-rust",
             feature = "tls-ring",
             feature = "tls-aws-lc",
             feature = "tls-graviola",
@@ -58,6 +63,7 @@ impl ModuleDef for HttpsModule {
     fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
         export_default(ctx, exports, |default| {
             #[cfg(any(
+                feature = "tls-rust",
                 feature = "tls-ring",
                 feature = "tls-aws-lc",
                 feature = "tls-graviola",

--- a/modules/llrt_tls/Cargo.toml
+++ b/modules/llrt_tls/Cargo.toml
@@ -12,12 +12,13 @@ name = "llrt_tls"
 path = "src/lib.rs"
 
 [features]
-default = ["webpki-roots", "tls-ring"]
+default = ["webpki-roots", "tls-rust"]
 
 webpki-roots = ["dep:webpki-roots"]
 native-roots = ["dep:rustls-native-certs"]
 
 # TLS crypto backend features (rustls-based)
+tls-rust = ["dep:rustls", "dep:rustls-rustcrypto"]
 tls-ring = ["dep:rustls", "rustls/ring"]
 tls-aws-lc = ["dep:rustls", "rustls/aws_lc_rs"]
 tls-graviola = ["dep:rustls", "dep:rustls-graviola"]
@@ -32,6 +33,7 @@ rustls = { version = "0.23", features = [
   "tls12",
 ], default-features = false, optional = true }
 rustls-graviola = { version = "0.4", default-features = false, optional = true }
+rustls-rustcrypto = { version = "0.0.2-alpha", git = "https://github.com/RustCrypto/rustls-rustcrypto.git", optional = true }
 openssl = { version = "0.10", optional = true }
 webpki-roots = { version = "1", default-features = false, optional = true }
 rustls-native-certs = { version = "0.8", default-features = false, optional = true }

--- a/modules/llrt_tls/src/lib.rs
+++ b/modules/llrt_tls/src/lib.rs
@@ -2,6 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Ensure only one TLS backend is selected
+#[cfg(all(feature = "tls-rust", feature = "tls-ring"))]
+compile_error!("Features `tls-rust` and `tls-ring` are mutually exclusive");
+
+#[cfg(all(feature = "tls-rust", feature = "tls-aws-lc"))]
+compile_error!("Features `tls-rust` and `tls-aws-lc` are mutually exclusive");
+
+#[cfg(all(feature = "tls-rust", feature = "tls-graviola"))]
+compile_error!("Features `tls-rust` and `tls-graviola` are mutually exclusive");
+
+#[cfg(all(feature = "tls-rust", feature = "tls-openssl"))]
+compile_error!("Features `tls-rust` and `tls-openssl` are mutually exclusive");
+
 #[cfg(all(feature = "tls-ring", feature = "tls-aws-lc"))]
 compile_error!("Features `tls-ring` and `tls-aws-lc` are mutually exclusive");
 
@@ -20,13 +32,28 @@ compile_error!("Features `tls-aws-lc` and `tls-openssl` are mutually exclusive")
 #[cfg(all(feature = "tls-graviola", feature = "tls-openssl"))]
 compile_error!("Features `tls-graviola` and `tls-openssl` are mutually exclusive");
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 mod rustls_config;
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 pub use rustls_config::*;
 
-#[cfg(any(feature = "tls-ring", feature = "tls-aws-lc", feature = "tls-graviola"))]
+#[cfg(any(
+    feature = "tls-rust",
+    feature = "tls-ring",
+    feature = "tls-aws-lc",
+    feature = "tls-graviola"
+))]
 mod no_verification;
 
 #[cfg(feature = "tls-openssl")]

--- a/modules/llrt_tls/src/rustls_config.rs
+++ b/modules/llrt_tls/src/rustls_config.rs
@@ -14,6 +14,11 @@ use webpki_roots::TLS_SERVER_ROOTS;
 use crate::no_verification::NoCertificateVerification;
 
 // Select the crypto provider based on feature flags
+#[cfg(feature = "tls-rust")]
+fn get_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    Arc::new(rustls_rustcrypto::provider())
+}
+
 #[cfg(feature = "tls-ring")]
 fn get_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
     Arc::new(rustls::crypto::ring::default_provider())


### PR DESCRIPTION
### Issue # (if available)

Follow up #1343

### Description of changes

- RustCrypto is not yet stable, so this is a draft.
- Switching from `rustls-ring` to `rustls-rustcrypto` reduces the footprint slightly.

```
# crypto-rust, tls-ring (no-sdk):
% du -k target/aarch64-apple-darwin/release/llrt
9608    target/aarch64-apple-darwin/release/llrt

# crypto-rust, tls-rust (no-sdk):
% du -k target/aarch64-apple-darwin/release/llrt
9432    target/aarch64-apple-darwin/release/llrt
```
### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
