### PR TITLE
fix(headers): update keys and values methods to return iterable values

### DIFF
--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -192,13 +192,23 @@ impl Headers {
     }
 
     pub fn keys<'js>(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        Iterable::from(self.headers.iter().map(|(k, _)| k.to_string()).collect::<Vec<_>>())
-            .into_js(&ctx)
+        Iterable::from(
+            self.headers
+                .iter()
+                .map(|(k, _)| k.to_string())
+                .collect::<Vec<_>>(),
+        )
+        .into_js(&ctx)
     }
 
     pub fn values<'js>(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        Iterable::from(self.headers.iter().map(|(_, v)| v.to_string()).collect::<Vec<_>>())
-            .into_js(&ctx)
+        Iterable::from(
+            self.headers
+                .iter()
+                .map(|(_, v)| v.to_string())
+                .collect::<Vec<_>>(),
+        )
+        .into_js(&ctx)
     }
 
     pub fn entries<'js>(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {


### PR DESCRIPTION
### Issue # (if available)

Fixes: https://github.com/awslabs/llrt/issues/1303 and https://github.com/awslabs/llrt/issues/1247

### Description of changes

Use new rquickjs primitives for better spec compliance

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
