### PR TITLE
chore: Update and cleanup dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,15 +92,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -347,19 +338,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
 ]
 
 [[package]]
@@ -812,29 +790,6 @@ name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dlopen2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
-dependencies = [
- "dlopen2_derive",
- "libc",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "dlopen2_derive"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1473,30 +1428,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2852,7 +2783,6 @@ checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared",
- "serde",
 ]
 
 [[package]]
@@ -3270,7 +3200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a"
 dependencies = [
  "either",
- "indexmap",
  "rquickjs-core",
  "rquickjs-macro",
 ]
@@ -3282,12 +3211,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1"
 dependencies = [
  "async-lock",
- "chrono",
- "dlopen2",
  "either",
  "hashbrown 0.16.1",
- "indexmap",
- "phf",
  "relative-path",
  "rquickjs-sys",
 ]
@@ -3302,8 +3227,6 @@ dependencies = [
  "fnv",
  "ident_case",
  "indexmap",
- "phf_generator",
- "phf_shared",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -4015,11 +3938,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/libs/llrt_logging/Cargo.toml
+++ b/libs/llrt_logging/Cargo.toml
@@ -17,7 +17,5 @@ llrt_encoding = { version = "0.7.0-beta", path = "../llrt_encoding" }
 llrt_json = { version = "0.7.0-beta", path = "../llrt_json" }
 llrt_numbers = { version = "0.7.0-beta", path = "../llrt_numbers" }
 llrt_utils = { version = "0.7.0-beta", path = "../llrt_utils", default-features = false }
-rquickjs = { version = "0.11", features = [
-    "macro",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 ryu = { version = "1", default-features = false }

--- a/libs/llrt_utils/Cargo.toml
+++ b/libs/llrt_utils/Cargo.toml
@@ -15,7 +15,6 @@ bytearray-buffer = ["tokio/sync"]
 
 [dependencies]
 rquickjs = { version = "0.11", features = [
-  "array-buffer",
   "macro",
 ], default-features = false }
 tokio = { version = "1", features = ["sync"], default-features = false }

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -53,10 +53,9 @@ rand = { version = "0.10.0", features = [
   "thread_rng",
 ], default-features = false }
 rquickjs = { version = "0.11", features = [
-  "full-async",
+  "futures",
   "parallel",
   "rust-alloc",
-  "std",
 ], default-features = false }
 rustls = { version = "0.23", features = [
   "tls12",
@@ -76,10 +75,7 @@ md-5 = { version = "0.11.0-rc.5", default-features = false }
 md-5 = { version = "0.11.0-rc.5", default-features = false }
 
 [build-dependencies]
-rquickjs = { version = "0.11", features = [
-  "full-async",
-  "rust-alloc",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 phf_codegen = { version = "0.13", default-features = false }
 jwalk = { version = "0.8", default-features = false }
 llrt_build = { path = "../libs/llrt_build" }

--- a/modules/llrt_abort/Cargo.toml
+++ b/modules/llrt_abort/Cargo.toml
@@ -21,9 +21,7 @@ llrt_async_hooks = { version = "0.7.0-beta", path = "../llrt_async_hooks" }
 llrt_exceptions = { version = "0.7.0-beta", path = "../llrt_exceptions" }
 llrt_events = { version = "0.7.0-beta", path = "../llrt_events" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { version = "0.11", features = [
-    "macro",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 
 # Optional
 llrt_timers = { version = "0.7.0-beta", path = "../llrt_timers", optional = true }

--- a/modules/llrt_buffer/Cargo.toml
+++ b/modules/llrt_buffer/Cargo.toml
@@ -16,7 +16,6 @@ llrt_encoding = { version = "0.7.0-beta", path = "../../libs/llrt_encoding" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { version = "0.11", features = [
   "futures",
-  "macro",
 ], default-features = false }
 ryu = { version = "1", default-features = false }
 

--- a/modules/llrt_child_process/Cargo.toml
+++ b/modules/llrt_child_process/Cargo.toml
@@ -17,9 +17,7 @@ llrt_context = { version = "0.7.0-beta", path = "../../libs/llrt_context" }
 llrt_events = { version = "0.7.0-beta", path = "../llrt_events" }
 llrt_stream = { version = "0.7.0-beta", path = "../llrt_stream" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { version = "0.11", features = [
-    "std",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 tokio = { version = "1", features = ["process"], default-features = false }
 
 [target.'cfg(unix)'.dependencies]

--- a/modules/llrt_console/Cargo.toml
+++ b/modules/llrt_console/Cargo.toml
@@ -13,6 +13,4 @@ path = "src/lib.rs"
 [dependencies]
 llrt_logging = { version = "0.7.0-beta", path = "../../libs/llrt_logging" }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { version = "0.11", features = [
-    "macro",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -66,7 +66,7 @@ rand = { version = "0.10.0", features = [
   "std_rng",
   "thread_rng",
 ], default-features = false }
-rquickjs = { version = "0.11", features = ["macro"], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 
 
 # optional

--- a/modules/llrt_events/Cargo.toml
+++ b/modules/llrt_events/Cargo.toml
@@ -12,7 +12,5 @@ path = "src/lib.rs"
 
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { version = "0.11", features = [
-    "macro",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/modules/llrt_exceptions/Cargo.toml
+++ b/modules/llrt_exceptions/Cargo.toml
@@ -11,7 +11,5 @@ name = "llrt_exceptions"
 path = "src/lib.rs"
 
 [dependencies]
-rquickjs = { version = "0.11", features = [
-    "macro",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -12,7 +12,7 @@ name = "llrt_fetch"
 path = "src/lib.rs"
 
 [features]
-default = ["http1", "http2", "compression-c", "webpki-roots"]
+default = ["http1", "http2", "compression-c", "webpki-roots", "tls-ring"]
 
 http1 = ["hyper/http1", "llrt_http/http1"]
 http2 = ["hyper/http2", "llrt_http/http2"]
@@ -52,10 +52,7 @@ rand = { version = "0.10.0", features = [
   "std",
   "thread_rng",
 ], default-features = false }
-rquickjs = { version = "0.11", features = [
-  "either",
-  "std",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 tokio = { version = "1", features = [
   "macros",
   "sync",

--- a/modules/llrt_fs/Cargo.toml
+++ b/modules/llrt_fs/Cargo.toml
@@ -25,8 +25,6 @@ rand = { version = "0.10.0", features = [
 ], default-features = false }
 rquickjs = { version = "0.11", features = [
   "either",
-  "futures",
-  "macro",
 ], default-features = false }
 tokio = { version = "1", features = [
   "fs",

--- a/modules/llrt_url/Cargo.toml
+++ b/modules/llrt_url/Cargo.toml
@@ -13,9 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 llrt_utils = { version = "0.7.0-beta", path = "../../libs/llrt_utils", default-features = false }
-rquickjs = { version = "0.11", features = [
-    "macro",
-], default-features = false }
+rquickjs = { version = "0.11", default-features = false }
 url = { version = "2", features = ["std"], default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

- The following crates listed in Cargo.toml have become stable: `der v0.8.0`
- Reviewed rquickjs feature specification and removed unnecessary dependencies that were polluting Cargo.lock.
- And we've also updated the Cargo.lock dependency.

```
    Updating aws-lc-sys v0.37.0 -> v0.37.1
    Updating bitflags v2.10.0 -> v2.11.0
    Updating cc v1.2.55 -> v1.2.56
    Updating clap v4.5.57 -> v4.5.58
    Updating clap_builder v4.5.57 -> v4.5.58
    Updating clap_lex v0.7.7 -> v1.0.0
    Updating crypto-bigint v0.7.0-rc.25 -> v0.7.0-rc.27
    Updating crypto-primes v0.7.0-pre.8 -> v0.7.0-pre.9
    Updating der v0.8.0-rc.12 -> v0.8.0
    Updating digest v0.11.0-rc.11 -> v0.11.0
    Updating ghash v0.6.0-rc.5 -> v0.6.0-rc.6
    Updating jiff v0.2.19 -> v0.2.20
    Updating jiff-static v0.2.19 -> v0.2.20
    Updating jiff-tzdb v0.1.4 -> v0.1.5
    Updating libc v0.2.181 -> v0.2.182
    Updating ntapi v0.4.2 -> v0.4.3
    Updating polyval v0.7.0-rc.7 -> v0.7.0-rc.9
    Updating security-framework v3.5.1 -> v3.6.0
    Updating security-framework-sys v2.15.0 -> v2.16.0
    Updating syn v2.0.114 -> v2.0.115
    Updating toml_parser v1.0.6+spec-1.1.0 -> v1.0.8+spec-1.1.0
    Updating unicode-ident v1.0.22 -> v1.0.23
    Updating uuid v1.20.0 -> v1.21.0
    Updating zmij v1.0.19 -> v1.0.21
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
