### PR TITLE
Fix: use guaranteed-refused port in socket connection error test

### DIFF
--- a/tests/unit/socket.test.ts
+++ b/tests/unit/socket.test.ts
@@ -53,14 +53,20 @@ describe("createServer and connect", () => {
 
 describe("error handling", () => {
   it("should handle connection error", (done) => {
-    const nonExistentPort = 9999;
-    const client = net
-      .connect(nonExistentPort, "localhost")
-      .on("error", (error) => {
-        expect(error).toBeInstanceOf(Error);
-        client.end();
-        done(); // Test passes if an error event is emitted
+    // Bind and immediately close a server to get a guaranteed-refused port
+    const tmp = net.createServer();
+    tmp.listen(0, () => {
+      const port = (tmp.address() as any).port;
+      tmp.close(() => {
+        const client = net
+          .connect(port, "127.0.0.1")
+          .on("error", (error) => {
+            expect(error).toBeInstanceOf(Error);
+            client.destroy();
+            done();
+          });
       });
+    });
   });
 
   it("should handle server destroy", (done) => {


### PR DESCRIPTION
### Description of changes

use guaranteed-refused port in socket connection error test

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
