### PR TITLE
chore(core): Eliminate use of `jwalk` for directory recursion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,56 +545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,16 +1538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-dependencies = [
- "crossbeam",
- "rayon",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,7 +1739,6 @@ dependencies = [
  "hyper",
  "itoa",
  "jiff",
- "jwalk",
  "libc",
  "llrt_build",
  "llrt_context",
@@ -1827,6 +1766,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "walkdir",
  "wiremock",
  "zstd",
 ]
@@ -2867,26 +2807,6 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "redox_syscall"

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -77,9 +77,9 @@ md-5 = { version = "0.11.0-rc.5", default-features = false }
 [build-dependencies]
 rquickjs = { version = "0.11", default-features = false }
 phf_codegen = { version = "0.13", default-features = false }
-jwalk = { version = "0.8", default-features = false }
 llrt_build = { path = "../libs/llrt_build" }
 uuid = { version = "1", features = ["v4"], default-features = false }
+walkdir = { version = "2", default-features = false }
 
 [dev-dependencies]
 wiremock = { version = "0.6", default-features = false }

--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -14,8 +14,8 @@ use std::{
     result::Result as StdResult,
 };
 
-use jwalk::WalkDir;
 use rquickjs::{CatchResultExt, CaughtError, Context, Module, Runtime, WriteOptions};
+use walkdir::WalkDir;
 
 const BUNDLE_JS_DIR: &str = "../bundle/js";
 


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

Using `jwalk` with `rayon` and `crossbeam` just for a single directory recursion is a bit extravagant.

```rust
// llrt_core/build.rs
for dir_ent in WalkDir::new(BUNDLE_JS_DIR).into_iter().flatten() {
```

These crates can be removed by replacing them with the simpler `walkdir`. Note that `walkdir` does not require any new injection into Cargo.lock, as `criterion` already depends on it.

 I was concerned about increased build times, but on my laptop it was minimal.

```
before:
% time make llrt-darwin-arm64-full-sdk.zip
make llrt-darwin-arm64-full-sdk.zip  309.10s user 31.86s system 297% cpu 1:54.46 total

% du -k target/aarch64-apple-darwin/release/llrt
12108   target/aarch64-apple-darwin/release/llrt

after:
% time make llrt-darwin-arm64-full-sdk.zip
make llrt-darwin-arm64-full-sdk.zip  307.04s user 31.62s system 300% cpu 1:52.66 total

% du -k target/aarch64-apple-darwin/release/llrt
12108   target/aarch64-apple-darwin/release/llrt
```


### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
