### PR TITLE
handle secret param in Hash constructors for SDK signing

### DIFF
--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -314,10 +314,13 @@ impl ModuleDef for CryptoModule {
                 let class_name: &str = algorithm.class_name();
                 let algo_name = String::from(algorithm.as_str());
 
-                let ctor =
-                    Constructor::new_class::<Hash, _, _>(ctx.clone(), move |ctx: Ctx<'_>| {
-                        Hash::new(ctx, algo_name.clone())
-                    })?;
+                let ctor = Constructor::new_class::<Hash, _, _>(
+                    ctx.clone(),
+                    move |ctx: Ctx<'js>, secret: Opt<ObjectBytes<'js>>| match secret.0 {
+                        Some(secret) => Hash::new_hmac(ctx, algo_name.clone(), secret),
+                        None => Hash::new(ctx, algo_name.clone()),
+                    },
+                )?;
 
                 default.set(class_name, ctor)?;
             }


### PR DESCRIPTION
### Description of changes

Support secret parameter in Hash class constructors for AWS SDK SigV4 signing

The Sha256/Sha1/etc. constructors exported from node:crypto ignored the secret parameter, always creating a plain hash. The AWS SDK passes a secret key via `new Sha256(secret)` to create HMAC instances for SigV4 signature calculation, resulting in InvalidSignatureException.

Hash now supports an optional secret parameter that switches to HMAC mode. Hmac delegates to Hash internally to avoid duplication.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
