### PR TITLE
fix: Support for Proxy objects in JSON serialization and logging

### DIFF
--- a/libs/llrt_utils/src/clone.rs
+++ b/libs/llrt_utils/src/clone.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use rquickjs::{
     atom::PredefinedAtom,
     function::{Constructor, Opt, This},
-    Array, ArrayBuffer, Ctx, Function, IntoJs, Null, Object, Result, Type, Value,
+    Array, ArrayBuffer, Ctx, Exception, Function, IntoJs, Null, Object, Result, Type, Value,
 };
 
 use super::{
@@ -79,6 +79,12 @@ pub fn structured_clone<'js>(
                     }
                 }
                 match value.type_of() {
+                    Type::Proxy => {
+                        return Err(Exception::throw_type(
+                            ctx,
+                            "A Proxy value could not be cloned",
+                        ));
+                    },
                     Type::Object => {
                         if check_circular(
                             &mut tape,

--- a/modules/llrt_assert/src/lib.rs
+++ b/modules/llrt_assert/src/lib.rs
@@ -29,6 +29,7 @@ fn ok(ctx: Ctx, value: Value, message: Opt<Value>) -> Result<()> {
         | Type::Constructor
         | Type::Exception
         | Type::Function
+        | Type::Proxy
         | Type::Symbol
         | Type::Object => {
             return Ok(());

--- a/tests/unit/console.test.ts
+++ b/tests/unit/console.test.ts
@@ -166,6 +166,17 @@ it("should log complex object", () => {
   );
 });
 
+it("should log Proxy object", () => {
+  const target = { a: 1, b: "foo" };
+  const proxy = new Proxy(target, {
+    set(t, p, v) {
+      t[p] = v;
+      return true;
+    },
+  });
+  expect(util.format(proxy)).toEqual(`{\n  a: 1,\n  b: 'foo'\n}`);
+});
+
 it("should log Headers", () => {
   const headers = new Headers();
   headers.append("foo", "bar");


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/1399

### Description of changes

New types in quickjs-ng + rquickjs stored proxy objects as a desecrate type. This was missing in console and json modules.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
