### PR TITLE
fix(dns): Allow IPv6 in dns.lookup() results in cargo test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,10 @@ deploy:
 	cd example/infrastructure && yarn deploy --require-approval never
 
 check:
-	cargo clippy --all-targets --features "lambda,macro,no-sdk,uncompressed,crypto-rust,tls-ring" -- -D warnings
+	cargo clippy --all-targets --no-default-features --features "lambda,macro,no-sdk,uncompressed,crypto-rust,tls-ring" -- -D warnings
+
+test-rs:
+	cargo test --all-targets --no-default-features --features "lambda,macro,no-sdk,uncompressed,crypto-rust,tls-ring"
 
 check-crates:
 	cargo metadata --no-deps --format-version 1 --quiet | \

--- a/modules/llrt_dns/src/lookup.rs
+++ b/modules/llrt_dns/src/lookup.rs
@@ -239,7 +239,7 @@ mod tests {
 
                 let result = call_test::<String, _>(&ctx, &module, ("www.amazon.com",)).await;
 
-                assert!(result.ends_with(":4"));
+                assert!(result.ends_with(":4") || result.ends_with(":6"));
             })
         })
         .await


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

Some test environments may return IPv6 addresses, so we accept this.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
