### PR TITLE
fix(perf_hooks,process): fix incompatibilities caused by the latest cargo fix

### DIFF
--- a/modules/llrt_perf_hooks/src/performance.rs
+++ b/modules/llrt_perf_hooks/src/performance.rs
@@ -58,7 +58,7 @@ impl<'js> Performance<'js> {
     fn now() -> f64 {
         let now = time::now_nanos();
         let started = time::origin_nanos();
-        let elapsed = now.checked_sub(started).unwrap_or_default();
+        let elapsed = now.saturating_sub(started);
 
         (elapsed as f64) / 1e6
     }

--- a/modules/llrt_process/src/lib.rs
+++ b/modules/llrt_process/src/lib.rs
@@ -36,7 +36,7 @@ fn hr_time_big_int(ctx: Ctx<'_>) -> Result<BigInt<'_>> {
     let now = time::now_nanos();
     let started = time::origin_nanos();
 
-    let elapsed = now.checked_sub(started).unwrap_or_default();
+    let elapsed = now.saturating_sub(started);
 
     BigInt::from_u64(ctx, elapsed)
 }
@@ -44,7 +44,7 @@ fn hr_time_big_int(ctx: Ctx<'_>) -> Result<BigInt<'_>> {
 fn hr_time(ctx: Ctx<'_>) -> Result<Array<'_>> {
     let now = time::now_nanos();
     let started = time::origin_nanos();
-    let elapsed = now.checked_sub(started).unwrap_or_default();
+    let elapsed = now.saturating_sub(started);
 
     let seconds = elapsed / 1_000_000_000;
     let remaining_nanos = elapsed % 1_000_000_000;


### PR DESCRIPTION
### Description of changes

After applying the latest rust toolchain, we found new incompatibilities and have fixed them.

```
% rustup update
   stable-aarch64-apple-darwin updated - rustc 1.94.0 (4a4ef493e 2026-03-02) (from rustc 1.93.0 (254b59607 2026-01-19))
  nightly-aarch64-apple-darwin updated - rustc 1.96.0-nightly (69370dc4a 2026-03-05) (from rustc 1.95.0-nightly (47611e160 2026-02-12))
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
