### PR TITLE
feat(temporal): Improved compatibility with Temporal.Duration

### DIFF
--- a/modules/llrt_temporal/src/duration.rs
+++ b/modules/llrt_temporal/src/duration.rs
@@ -2,16 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{cmp::Ordering, str::FromStr};
 
-use jiff::Span;
+use jiff::{Span, SpanCompare};
 use llrt_utils::result::ResultExt;
 use rquickjs::{
-    atom::PredefinedAtom, class::Trace, prelude::Rest, Class, Ctx, Exception, JsLifetime, Object,
-    Result, Value,
+    atom::PredefinedAtom,
+    class::Trace,
+    prelude::{Opt, Rest},
+    Class, Ctx, Exception, JsLifetime, Object, Result, Value,
 };
 
 use crate::utils::date::fill_duration_from_iter as fill_date_from_iter;
+use crate::utils::round::span::SpanRoundOption;
 use crate::utils::span::SpanExt;
 use crate::utils::time::fill_duration_from_iter as fill_time_from_iter;
+use crate::utils::total::span::SpanTotalOption;
 
 #[derive(Clone, JsLifetime, Trace)]
 #[rquickjs::class]
@@ -29,8 +33,9 @@ impl Duration {
     }
 
     #[qjs(static)]
-    fn compare(ctx: Ctx<'_>, duration1: Self, duration2: Self) -> Result<i8> {
-        match duration1.inner.compare(duration2.inner).or_throw(&ctx)? {
+    fn compare(ctx: Ctx<'_>, duration1: Self, duration2: Self, opt: Opt<Value<'_>>) -> Result<i8> {
+        let sc = Self::into_span_compare(&duration2.inner, &opt);
+        match duration1.inner.compare(sc).or_throw_range(&ctx, "")? {
             Ordering::Less => Ok(-1),
             Ordering::Equal => Ok(0),
             Ordering::Greater => Ok(1),
@@ -59,6 +64,13 @@ impl Duration {
         Self { inner: span }
     }
 
+    fn round(&self, ctx: Ctx<'_>, options: Value<'_>) -> Result<Self> {
+        let round = SpanRoundOption::from_value(&ctx, &options)?;
+        let round = round.into_inner();
+        let dt = self.inner.round(round).or_throw_range(&ctx, "")?;
+        Ok(Self { inner: dt })
+    }
+
     fn subtract(&self, ctx: Ctx<'_>, other: Value<'_>) -> Result<Self> {
         let duration = Self::from_value(&ctx, &other)?;
         let span = duration.into_inner();
@@ -76,6 +88,13 @@ impl Duration {
     #[qjs(rename = PredefinedAtom::ToString)]
     fn to_string(&self) -> String {
         self.inner.to_string()
+    }
+
+    fn total(&self, ctx: Ctx<'_>, options: Value<'_>) -> Result<f64> {
+        let total = SpanTotalOption::from_value(&ctx, &options)?;
+        let total = total.into_inner();
+        let num = self.inner.total(total).or_throw_range(&ctx, "")?;
+        Ok(num)
     }
 
     fn value_of(&self, ctx: Ctx<'_>) -> Result<()> {
@@ -189,6 +208,10 @@ impl Duration {
 
     pub(crate) fn into_inner(self) -> Span {
         self.inner
+    }
+
+    fn into_span_compare<'a>(span: &Span, value: &Opt<Value<'a>>) -> SpanCompare<'a> {
+        Span::into_span_compare(span, value)
     }
 
     pub(crate) fn new_object(span: Span) -> Self {

--- a/modules/llrt_temporal/src/now.rs
+++ b/modules/llrt_temporal/src/now.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use jiff::{Timestamp, Zoned};
+use jiff::{tz::TimeZone, Timestamp, Zoned};
 use rquickjs::{
     atom::PredefinedAtom,
     prelude::{Func, Opt},
@@ -19,6 +19,7 @@ pub(crate) fn define_object<'a>(ctx: &Ctx<'a>) -> Result<Object<'a>> {
     obj.set("plainDateISO", Func::from(plain_date_iso))?;
     obj.set("plainDateTimeISO", Func::from(plain_datetime_iso))?;
     obj.set("plainTimeISO", Func::from(plain_time_iso))?;
+    obj.set("timeZoneId", Func::from(time_zone_id))?;
     obj.set("zonedDateTimeISO", Func::from(zoned_datetime_iso))?;
     obj.set(PredefinedAtom::SymbolToStringTag, "Temporal.Now")?;
     Ok(obj)
@@ -37,6 +38,13 @@ fn plain_datetime_iso(ctx: Ctx<'_>, timezone: Opt<String>) -> Result<PlainDateTi
 fn plain_time_iso(ctx: Ctx<'_>, timezone: Opt<String>) -> Result<PlainTime> {
     let (ts, tz) = parts_of_zoned_now(timezone);
     PlainTime::from_ts_tz(&ctx, &ts, &tz)
+}
+
+fn time_zone_id() -> String {
+    let tz: TimeZone = TimeZone::system();
+    tz.iana_name()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "UTC".to_string())
 }
 
 fn zoned_datetime_iso(ctx: Ctx<'_>, timezone: Opt<String>) -> Result<ZonedDateTime> {

--- a/modules/llrt_temporal/src/plain_date.rs
+++ b/modules/llrt_temporal/src/plain_date.rs
@@ -203,6 +203,10 @@ impl PlainDate {
         Ok(zdt.to_plain_date())
     }
 
+    pub(crate) fn into_inner(self) -> Date {
+        self.inner
+    }
+
     pub(crate) fn new_object(date: Date) -> Self {
         Self { inner: date }
     }

--- a/modules/llrt_temporal/src/plain_date_time.rs
+++ b/modules/llrt_temporal/src/plain_date_time.rs
@@ -240,6 +240,10 @@ impl PlainDateTime {
         Ok(zdt.to_plain_date_time())
     }
 
+    pub(crate) fn into_inner(self) -> DateTime {
+        self.inner
+    }
+
     pub(crate) fn new_object(dt: DateTime) -> Self {
         Self { inner: dt }
     }

--- a/modules/llrt_temporal/src/utils/mod.rs
+++ b/modules/llrt_temporal/src/utils/mod.rs
@@ -5,4 +5,58 @@ pub mod date_time;
 pub mod round;
 pub mod span;
 pub mod time;
+pub mod total;
 pub mod zoned;
+
+use jiff::{RoundMode, Unit};
+use rquickjs::{Ctx, Exception, Result};
+
+pub(crate) fn get_unit(ctx: &Ctx, unit: &str) -> Result<Unit> {
+    let unit = match unit {
+        "day" => Unit::Day,
+        "hour" => Unit::Hour,
+        "minute" => Unit::Minute,
+        "second" => Unit::Second,
+        "millisecond" => Unit::Millisecond,
+        "microsecond" => Unit::Microsecond,
+        "nanosecond" => Unit::Nanosecond,
+        _ => return Err(Exception::throw_type(ctx, "Cannot convert to unit")),
+    };
+    Ok(unit)
+}
+
+pub(crate) fn get_duration_unit(ctx: &Ctx, unit: &Option<String>) -> Result<Option<Unit>> {
+    let Some(unit) = unit else {
+        return Ok(None);
+    };
+    let unit = match unit.as_str() {
+        "years" => Unit::Year,
+        "months" => Unit::Month,
+        "weeks" => Unit::Week,
+        "days" => Unit::Day,
+        "hours" => Unit::Hour,
+        "minutes" => Unit::Minute,
+        "seconds" => Unit::Second,
+        "milliseconds" => Unit::Millisecond,
+        "microseconds" => Unit::Microsecond,
+        "nanoseconds" => Unit::Nanosecond,
+        _ => return Err(Exception::throw_type(ctx, "Cannot convert to unit")),
+    };
+    Ok(Some(unit))
+}
+
+pub(crate) fn get_round_mode(ctx: &Ctx, mode: &Option<String>) -> Result<RoundMode> {
+    let mode = match mode.clone().unwrap_or_else(|| "halfExpand".into()).as_ref() {
+        "ceil" => RoundMode::Ceil,
+        "floor" => RoundMode::Floor,
+        "expand" => RoundMode::Expand,
+        "trunc" => RoundMode::Trunc,
+        "halfCeil" => RoundMode::HalfCeil,
+        "halfFloor" => RoundMode::HalfFloor,
+        "halfExpand" => RoundMode::HalfExpand,
+        "halfTrunc" => RoundMode::HalfTrunc,
+        "halfEven" => RoundMode::HalfEven,
+        _ => return Err(Exception::throw_type(ctx, "Cannot convert to RoundMode")),
+    };
+    Ok(mode)
+}

--- a/modules/llrt_temporal/src/utils/round/mod.rs
+++ b/modules/llrt_temporal/src/utils/round/mod.rs
@@ -1,13 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 pub mod date_time;
+pub mod span;
 pub mod time;
 pub mod timestamp;
 pub mod zoned;
 
 use jiff::{RoundMode, Unit};
 use llrt_utils::result::ResultExt;
-use rquickjs::{Ctx, Exception, Result, Value};
+use rquickjs::{Ctx, Result, Value};
+
+use crate::utils::{get_round_mode, get_unit};
 
 pub(crate) trait RoundBuilder: Sized {
     fn new() -> Self;
@@ -28,7 +31,7 @@ impl<T: RoundBuilder> RoundOption<T> {
                 .or_throw_range(ctx, "")?;
             let mode = obj.get::<_, String>("roundingMode").ok();
             let increment = obj.get::<_, i64>("roundingIncrement").ok();
-            let round = Self::from(ctx, &unit, mode, increment)?;
+            let round = Self::from(ctx, &unit, &mode, &increment)?;
             return Ok(Self { inner: round });
         }
 
@@ -36,7 +39,7 @@ impl<T: RoundBuilder> RoundOption<T> {
             .as_string()
             .and_then(|s| s.to_string().ok())
             .or_throw_type(ctx, "Cannot convert value to string")?;
-        let round = Self::from(ctx, &unit, None, None)?;
+        let round = Self::from(ctx, &unit, &None, &None)?;
         Ok(Self { inner: round })
     }
 
@@ -44,33 +47,10 @@ impl<T: RoundBuilder> RoundOption<T> {
         self.inner
     }
 
-    fn from(ctx: &Ctx, unit: &str, mode: Option<String>, increment: Option<i64>) -> Result<T> {
-        let unit = match unit {
-            "day" => Unit::Day,
-            "hour" => Unit::Hour,
-            "minute" => Unit::Minute,
-            "second" => Unit::Second,
-            "millisecond" => Unit::Millisecond,
-            "microsecond" => Unit::Microsecond,
-            "nanosecond" => Unit::Nanosecond,
-            _ => return Err(Exception::throw_type(ctx, "smallestUnit is invalid")),
-        };
-
-        let mode = match mode.unwrap_or_else(|| "halfExpand".into()).as_ref() {
-            "ceil" => RoundMode::Ceil,
-            "floor" => RoundMode::Floor,
-            "expand" => RoundMode::Expand,
-            "trunc" => RoundMode::Trunc,
-            "halfCeil" => RoundMode::HalfCeil,
-            "halfFloor" => RoundMode::HalfFloor,
-            "halfExpand" => RoundMode::HalfExpand,
-            "halfTrunc" => RoundMode::HalfTrunc,
-            "halfEven" => RoundMode::HalfEven,
-            _ => return Err(Exception::throw_type(ctx, "roundingMode is invalid")),
-        };
-
+    fn from(ctx: &Ctx, unit: &str, mode: &Option<String>, increment: &Option<i64>) -> Result<T> {
+        let unit = get_unit(ctx, unit).or_throw_range(ctx, "")?;
+        let mode = get_round_mode(ctx, mode)?;
         let increment = increment.unwrap_or(1);
-
         Ok(T::new().smallest(unit).mode(mode).increment(increment))
     }
 }

--- a/modules/llrt_temporal/src/utils/round/span.rs
+++ b/modules/llrt_temporal/src/utils/round/span.rs
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use jiff::{Span, SpanRound, Unit};
+use rquickjs::{Ctx, Result, Value};
+
+use crate::utils::span::SpanExt;
+use crate::utils::{get_duration_unit, get_round_mode};
+
+pub(crate) struct SpanRoundOption<'a> {
+    inner: SpanRound<'a>,
+}
+
+impl<'a> SpanRoundOption<'a> {
+    pub(crate) fn from_value(ctx: &Ctx<'_>, value: &Value<'a>) -> Result<Self> {
+        if let Some(obj) = value.as_object() {
+            let p1 = obj.get::<_, String>("largestUnit").ok();
+            let p2 = obj.get::<_, Value>("relativeTo").ok();
+            let p3 = obj.get::<_, i64>("roundingIncrement").ok();
+            let p4 = obj.get::<_, String>("roundingMode").ok();
+            let p5 = obj.get::<_, String>("smallestUnit").ok();
+            let round = Self::from(ctx, &p1, &p2, &p3, &p4, &p5)?;
+            return Ok(Self { inner: round });
+        }
+
+        let unit = value.as_string().and_then(|s| s.to_string().ok());
+        let round = Self::from(ctx, &None, &None, &None, &None, &unit)?;
+        Ok(Self { inner: round })
+    }
+
+    pub(crate) fn into_inner(self) -> SpanRound<'a> {
+        self.inner
+    }
+
+    fn from(
+        ctx: &Ctx,
+        largest_unit: &Option<String>,
+        relative_to: &Option<Value<'a>>,
+        increment: &Option<i64>,
+        mode: &Option<String>,
+        smallest_unit: &Option<String>,
+    ) -> Result<SpanRound<'a>> {
+        let largest_unit = get_duration_unit(ctx, largest_unit)?;
+        let relative_to = Span::into_span_relative_to(relative_to);
+        let increment = increment.unwrap_or(1);
+        let mode = get_round_mode(ctx, mode)?;
+        let smallest_unit = get_duration_unit(ctx, smallest_unit)?;
+
+        let mut span_round = SpanRound::new().mode(mode).increment(increment);
+        if let Some(largest_unit) = largest_unit {
+            span_round = span_round.largest(largest_unit);
+        }
+        if let Some(smallest_unit) = smallest_unit {
+            span_round = span_round.smallest(smallest_unit);
+        }
+        if let Some(relative_to) = relative_to {
+            span_round = span_round.relative(relative_to);
+        } else if largest_unit.is_some_and(|u| u < Unit::Day) {
+            span_round = span_round.days_are_24_hours();
+        }
+        Ok(span_round)
+    }
+}

--- a/modules/llrt_temporal/src/utils/span.rs
+++ b/modules/llrt_temporal/src/utils/span.rs
@@ -1,12 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use jiff::Span;
+use jiff::{Span, SpanCompare, SpanRelativeTo};
 use llrt_utils::result::ResultExt;
-use rquickjs::{Ctx, Object, Result, Value};
+use rquickjs::{prelude::Opt, Class, Ctx, Object, Result, Value};
+
+use crate::plain_date::PlainDate;
+use crate::plain_date_time::PlainDateTime;
+use crate::zoned_date_time::ZonedDateTime;
 
 pub trait SpanExt {
     fn from_object(ctx: &Ctx<'_>, obj: &Object<'_>) -> Result<Span>;
     fn span_with(self, ctx: &Ctx<'_>, value: &Value<'_>) -> Result<Span>;
+    fn into_span_compare<'a>(span: &Span, value: &Opt<Value<'a>>) -> SpanCompare<'a>;
+    fn into_span_relative_to<'a>(value: &Option<Value<'a>>) -> Option<SpanRelativeTo<'a>>;
 }
 
 impl SpanExt for Span {
@@ -20,6 +26,41 @@ impl SpanExt for Span {
             .or_throw_type(ctx, "Cannot convert value to object")?;
 
         into_span(ctx, Some(self), obj)
+    }
+
+    fn into_span_compare<'a>(span: &Span, value: &Opt<Value<'a>>) -> SpanCompare<'a> {
+        let Some(ref value) = value.0 else {
+            return span.into();
+        };
+        if let Some(object) = value.as_object() {
+            if let Ok(v) = object.get::<_, Value>("relativeTo") {
+                if let Some(relative) = Self::into_span_relative_to(&Some(v)) {
+                    return (span, relative).into();
+                }
+            }
+        }
+        span.into()
+    }
+
+    fn into_span_relative_to<'a>(value: &Option<Value<'a>>) -> Option<SpanRelativeTo<'a>> {
+        let Some(value) = value else {
+            return None;
+        };
+        if let Some(obj) = value.as_object() {
+            if let Some(cls) = Class::<PlainDate>::from_object(obj) {
+                let pd = cls.borrow().clone();
+                return Some(pd.into_inner().into());
+            }
+            if let Some(cls) = Class::<PlainDateTime>::from_object(obj) {
+                let pdt = cls.borrow().clone();
+                return Some(pdt.into_inner().into());
+            }
+            if let Some(cls) = Class::<ZonedDateTime>::from_object(obj) {
+                let zdt = cls.borrow().clone();
+                return Some(zdt.into_inner().datetime().into());
+            }
+        }
+        None
     }
 }
 

--- a/modules/llrt_temporal/src/utils/total/mod.rs
+++ b/modules/llrt_temporal/src/utils/total/mod.rs
@@ -1,0 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+pub mod span;

--- a/modules/llrt_temporal/src/utils/total/span.rs
+++ b/modules/llrt_temporal/src/utils/total/span.rs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use jiff::{Span, SpanTotal, Unit};
+use llrt_utils::result::ResultExt;
+use rquickjs::{Ctx, Result, Value};
+
+use crate::utils::get_duration_unit;
+use crate::utils::span::SpanExt;
+
+pub(crate) struct SpanTotalOption<'a> {
+    inner: SpanTotal<'a>,
+}
+
+impl<'a> SpanTotalOption<'a> {
+    pub(crate) fn from_value(ctx: &Ctx<'_>, value: &Value<'a>) -> Result<Self> {
+        if let Some(obj) = value.as_object() {
+            let relative_to = obj.get::<_, Value>("relativeTo").ok();
+            let unit = obj.get::<_, String>("unit").ok();
+            let total = Self::from(ctx, &relative_to, &unit)?;
+            return Ok(Self { inner: total });
+        }
+
+        let unit = value.as_string().and_then(|s| s.to_string().ok());
+        let total = Self::from(ctx, &None, &unit)?;
+        Ok(Self { inner: total })
+    }
+
+    pub(crate) fn into_inner(self) -> SpanTotal<'a> {
+        self.inner
+    }
+
+    fn from(
+        ctx: &Ctx,
+        relative_to: &Option<Value<'a>>,
+        unit: &Option<String>,
+    ) -> Result<SpanTotal<'a>> {
+        let relative_to = Span::into_span_relative_to(relative_to);
+        let unit = get_duration_unit(ctx, unit)?;
+        let unit = unit.or_throw_range(ctx, "Invalid unit")?;
+
+        if let Some(relative_to) = relative_to {
+            Ok((unit, relative_to).into())
+        } else if unit < Unit::Day {
+            let span_total: SpanTotal = unit.into();
+            Ok(span_total.days_are_24_hours())
+        } else {
+            Ok(unit.into())
+        }
+    }
+}

--- a/tests/unit/temporal.duration.test.ts
+++ b/tests/unit/temporal.duration.test.ts
@@ -1,112 +1,329 @@
-describe("Temporal.Duration", () => {
-  describe("creation and parsing", () => {
-    it("can be created from an object", () => {
-      const dur = Temporal.Duration.from({ hours: 3, minutes: 30 });
-      expect(dur.hours).toBe(3);
-      expect(dur.minutes).toBe(30);
-      expect(dur.toString()).toBe("PT3H30M");
+describe("Constructor", () => {
+  describe("Temporal.Duration()", () => {
+    it("Using Temporal.Duration()", () => {
+      const d = new Temporal.Duration(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+      expect(d.toString()).toBe("P1Y2M3W4DT5H6M7.00800901S");
+    });
+  });
+});
+
+describe("Static methods", () => {
+  describe("Temporal.Duration.compare()", () => {
+    it("Using Temporal.Instant.compare()", () => {
+      const d1 = Temporal.Duration.from({ hours: 1, minutes: 30 });
+      const d2 = Temporal.Duration.from({ minutes: 100 });
+      expect(Temporal.Duration.compare(d1, d2)).toBe(-1);
+
+      const d3 = Temporal.Duration.from({ hours: 2 });
+      const d4 = Temporal.Duration.from({ minutes: 110 });
+      expect(Temporal.Duration.compare(d3, d4)).toBe(1);
+
+      const d5 = Temporal.Duration.from({ hours: 1, minutes: 30 });
+      const d6 = Temporal.Duration.from({ seconds: 5400 });
+      expect(Temporal.Duration.compare(d5, d6)).toBe(0);
     });
 
-    it("can be parsed from an ISO 8601 string", () => {
-      const dur = Temporal.Duration.from("P1Y2M3DT4H5M6.007008009S");
-      expect(dur.years).toBe(1);
-      expect(dur.months).toBe(2);
-      expect(dur.days).toBe(3);
-      expect(dur.hours).toBe(4);
-      expect(dur.minutes).toBe(5);
-      expect(dur.seconds).toBe(6);
-      expect(dur.milliseconds).toBe(7);
-      expect(dur.microseconds).toBe(8);
-      expect(dur.nanoseconds).toBe(9);
-    });
+    it("Comparing calendar durations", () => {
+      const d1 = Temporal.Duration.from({ days: 31 });
+      const d2 = Temporal.Duration.from({ months: 1 });
 
-    it("can be created from an own object", () => {
-      const dur1 = Temporal.Duration.from("PT0S");
-      const dur2 = Temporal.Duration.from(dur1);
-      expect(dur1).toEqual(dur2);
-    });
+      expect(
+        Temporal.Duration.compare(d1, d2, {
+          relativeTo: Temporal.PlainDate.from("2021-01-01"), // ISO 8601 calendar
+        })
+      ).toBe(0);
 
-    it("has a blank property that detects zero durations", () => {
-      const zero = Temporal.Duration.from("PT0S");
-      expect(zero.blank).toBe(true);
-      const nonzero = Temporal.Duration.from({ seconds: 1 });
-      expect(nonzero.blank).toBe(false);
+      expect(
+        Temporal.Duration.compare(d1, d2, {
+          relativeTo: Temporal.PlainDate.from("2021-02-01"), // ISO 8601 calendar
+        })
+      ).toBe(1);
     });
   });
 
-  describe("arithmetic methods", () => {
-    const d1 = Temporal.Duration.from({ hours: 1, minutes: 30 });
-    const d2 = Temporal.Duration.from({ minutes: 45 });
+  describe("Temporal.Duration.from()", () => {
+    it("Creating a duration from an object", () => {
+      const d1 = Temporal.Duration.from({ hours: 1, minutes: 30 });
+      expect(d1.toString()).toBe("PT1H30M");
 
-    it("abs() and negated() returns durations correctly", () => {
-      const neg = d1.negated();
-      expect(neg.hours).toBe(-1);
-      expect(neg.abs().hours).toBe(1);
+      const d2 = Temporal.Duration.from({ months: 1, days: 2 });
+      expect(d2.toString()).toBe("P1M2D");
+
+      // Uncommon because unbalanced, but valid
+      const unbalanced = Temporal.Duration.from({
+        hours: 100,
+        minutes: 100,
+        seconds: 100,
+      });
+      expect(unbalanced.toString()).toBe("PT100H100M100S");
+
+      const neg = Temporal.Duration.from({ hours: -1, minutes: -30 });
+      expect(neg.toString()).toBe("-PT1H30M");
     });
 
-    it("add() return durations correctly", () => {
-      const sum = d1.add(d2);
-      expect(sum.hours).toBe(2);
-      expect(sum.minutes).toBe(15);
+    it("Creating a duration from a string", () => {
+      const d = Temporal.Duration.from("P1Y2M3W4DT5H6M7.00800901S");
+      expect(d.hours).toBe(5);
     });
 
-    it("compare() works correctly", () => {
-      expect(Temporal.Duration.compare(d1, d2)).toBe(1);
-      expect(Temporal.Duration.compare(d2, d1)).toBe(-1);
-      expect(Temporal.Duration.compare(d1, d1)).toBe(0);
+    it("Creating a duration from another duration", () => {
+      const d1 = Temporal.Duration.from({ hours: 1, minutes: 30 });
+      const d2 = Temporal.Duration.from(d1);
+      expect(d2.toString()).toBe("PT1H30M");
+    });
+  });
+});
+
+describe("Instance methods", () => {
+  describe("Temporal.Duration.prototype.abs()", () => {
+    it("Using abs()", () => {
+      const d1 = Temporal.Duration.from({ hours: 1, minutes: 30 });
+      const d2 = Temporal.Duration.from({ hours: -1, minutes: -30 });
+
+      expect(d1.abs().toString()).toBe("PT1H30M");
+      expect(d2.abs().toString()).toBe("PT1H30M");
+    });
+  });
+
+  describe("Temporal.Duration.prototype.add()", () => {
+    it("Using add()", () => {
+      const d1 = Temporal.Duration.from({ hours: 1, minutes: 30 });
+      const d2 = Temporal.Duration.from({ hours: -1, minutes: -20 });
+
+      const d3 = d1.add(d2);
+      expect(d3.toString()).toBe("PT10M");
     });
 
-    it("subtract() return durations correctly", () => {
-      const diff = d1.subtract(d2);
-      expect(diff.hours).toBe(0);
-      expect(diff.minutes).toBe(45);
-    });
+    it("Adding calendar durations", () => {
+      const d1 = Temporal.Duration.from({ days: 1 });
+      const d2 = Temporal.Duration.from({ months: 1 });
 
-    it("toJSON() returns the ISO string", () => {
-      const dur = Temporal.Duration.from({ days: 40 });
-      expect(JSON.stringify(dur)).toBe('"P40D"');
-    });
-
-    it("valueOf() throws a TypeError", () => {
-      const dur = Temporal.Duration.from({ seconds: 1 });
       expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        +dur;
+        d1.add(d2); // RangeError: for calendar duration arithmetic, use date arithmetic relative to a starting point
       }).toThrow();
-    });
 
-    it("with() returns a new duration with updated fields", () => {
-      const dur = Temporal.Duration.from({ hours: 1, minutes: 30 });
-      const updated = dur.with({ minutes: 45 });
-      expect(updated.hours).toBe(1);
-      expect(updated.minutes).toBe(45);
+      const start = Temporal.PlainDateTime.from("2022-01-01T00:00"); // ISO 8601 calendar
+      const result = start.add(d1).add(d2).since(start);
+      expect(result.toString()).toBe("P32D");
     });
   });
 
-  describe("properties", () => {
-    it("should have correct property values for weeks and all components", () => {
-      const dur = Temporal.Duration.from({ weeks: 2, days: 3, hours: 5 });
-      expect(dur.weeks).toBe(2);
-      expect(dur.days).toBe(3);
-      expect(dur.hours).toBe(5);
+  describe("Temporal.Duration.prototype.negated()", () => {
+    it("Using negated()", () => {
+      const d1 = Temporal.Duration.from({ hours: 1, minutes: 30 });
+      const d2 = Temporal.Duration.from({ hours: -1, minutes: -30 });
+
+      expect(d1.negated().toString()).toBe("-PT1H30M");
+      expect(d2.negated().toString()).toBe("PT1H30M");
+    });
+  });
+
+  describe("Temporal.Duration.prototype.round()", () => {
+    it("Rounding off small units", () => {
+      const duration = Temporal.Duration.from({
+        hours: 1,
+        minutes: 30,
+        seconds: 15,
+      });
+      const roundedDuration = duration.round("minutes");
+      expect(roundedDuration.toString()).toBe("PT1H30M");
     });
 
-    it("should report the correct sign for durations", () => {
-      const pos = Temporal.Duration.from({ hours: 5 });
-      expect(pos.sign).toBe(1);
-
-      const neg = pos.negated();
-      expect(neg.sign).toBe(-1);
-
-      const zero = Temporal.Duration.from("PT0S");
-      expect(zero.sign).toBe(0);
+    it("Avoiding larger units", () => {
+      const duration = Temporal.Duration.from({
+        days: 3,
+        hours: 1,
+        minutes: 41,
+        seconds: 5,
+      });
+      const roundedDuration = duration.round({ largestUnit: "hours" });
+      // expect(
+      //   `Time spent on this problem: ${roundedDuration.toLocaleString("en-US", { style: "digital" })}`,
+      // );
+      // Time spent on this problem: 73:41:05
+      expect(roundedDuration.toString()).toBe("PT73H41M5S");
     });
 
-    it("has correct toStringTag", () => {
-      const zdt = Temporal.Duration.from("PT0S");
-      expect(Object.prototype.toString.call(zdt)).toBe(
-        "[object Temporal.Duration]"
+    it("Rounding to a whole number of hours", () => {
+      const duration = Temporal.Duration.from({
+        days: 1,
+        hours: 1,
+        minutes: 30,
+      });
+      const roundedDuration = duration.round({
+        largestUnit: "hours",
+        smallestUnit: "hours",
+        roundingMode: "floor",
+      });
+      expect(roundedDuration.hours).toBe(25);
+    });
+
+    it("Rounding by 15-minute increments", () => {
+      const duration = Temporal.Duration.from({ hours: 1, minutes: 17 });
+      const roundedDuration = duration.round({
+        smallestUnit: "minutes",
+        roundingIncrement: 15,
+      });
+      // expect(
+      //   `The queue will take approximately ${roundedDuration.toLocaleString("en-US")}`,
+      // );
+      // The queue will take approximately 1 hr, 15 min
+      expect(roundedDuration.toString()).toBe("PT1H15M");
+    });
+
+    it("Resolving calendar durations", () => {
+      const duration = Temporal.Duration.from({ months: 1, days: 1, hours: 1 });
+      const roundedDuration = duration.round({
+        largestUnit: "days",
+        smallestUnit: "days",
+        relativeTo: Temporal.PlainDateTime.from("2022-01-01"),
+      });
+      expect(roundedDuration.toString()).toBe("P32D");
+    });
+  });
+
+  describe("Temporal.Duration.prototype.subtract()", () => {
+    it("Using subtract()", () => {
+      const d1 = Temporal.Duration.from({ hours: 1, minutes: 30 });
+      const d2 = Temporal.Duration.from({ hours: -1, minutes: -20 });
+
+      const d3 = d1.subtract(d2);
+      expect(d3.toString()).toBe("PT2H50M");
+    });
+  });
+
+  describe("Temporal.Duration.prototype.toJSON()", () => {
+    it("Using toJSON()", () => {
+      const duration = Temporal.Duration.from({
+        hours: 1,
+        minutes: 30,
+        seconds: 15,
+      });
+      const durationStr = duration.toJSON();
+      expect(durationStr).toBe("PT1H30M15S");
+      const d2 = Temporal.Duration.from(durationStr);
+    });
+
+    it("JSON serialization and parsing", () => {
+      const duration = Temporal.Duration.from({
+        hours: 1,
+        minutes: 30,
+        seconds: 15,
+      });
+      const jsonStr = JSON.stringify({ data: duration });
+      expect(jsonStr).toBe('{"data":"PT1H30M15S"}');
+      const obj = JSON.parse(jsonStr, (key, value) => {
+        if (key === "data") {
+          return Temporal.Duration.from(value);
+        }
+        return value;
+      });
+    });
+  });
+
+  describe("Temporal.Duration.prototype.toString()", () => {
+    it("Using toString()", () => {
+      const duration = Temporal.Duration.from({
+        hours: 1,
+        minutes: 30,
+        seconds: 15,
+      });
+      expect(duration.toString()).toBe("PT1H30M15S");
+
+      // Stringification implicitly calls toString()
+      expect(`${duration}`).toBe("PT1H30M15S");
+    });
+  });
+
+  describe("Temporal.Duration.prototype.total()", () => {
+    it("Using total()", () => {
+      const d = Temporal.Duration.from({ hours: 1, minutes: 30 });
+
+      expect(d.total("minutes")).toBe(90);
+      expect(d.total("hours")).toBe(1.5);
+    });
+
+    it("Total of a calendar duration", () => {
+      const d = Temporal.Duration.from({ months: 1 });
+
+      expect(
+        d.total({
+          unit: "days",
+          relativeTo: Temporal.PlainDate.from("2021-01-01"),
+        })
+      ).toBe(31);
+    });
+  });
+
+  describe("Temporal.Duration.prototype.valueOf()", () => {
+    it("Arithmetic and comparison operations on Temporal.Duration", () => {
+      const duration1 = Temporal.Duration.from({ seconds: 3 });
+      const duration2 = Temporal.Duration.from({ minutes: 1 });
+      expect(() => {
+        duration1 > duration2; // TypeError: can't convert Duration to primitive type
+      }).toThrow();
+      expect(duration1.total("seconds") > duration2.total("seconds")).toBe(
+        false
       );
+      expect(Temporal.Duration.compare(duration1, duration2)).toBe(-1);
+
+      expect(() => {
+        duration1 + duration2; // TypeError: can't convert Duration to primitive type
+      }).toThrow();
+      expect(duration1.total("seconds") + duration2.total("seconds")).toBe(63);
+      expect(duration1.add(duration2).toString()).toBe("PT1M3S");
     });
+  });
+
+  describe("Temporal.Duration.prototype.with()", () => {
+    it("Using with()", () => {
+      function balanceMinutes(duration) {
+        const { hours, minutes } = duration;
+        const totalMinutes = hours * 60 + minutes;
+        const balancedMinutes = totalMinutes % 60;
+        const balancedHours = (totalMinutes - balancedMinutes) / 60;
+        return duration.with({
+          hours: balancedHours,
+          minutes: balancedMinutes,
+        });
+      }
+
+      const d1 = Temporal.Duration.from({
+        hours: 100,
+        minutes: 100,
+        seconds: 100,
+      });
+      const d2 = balanceMinutes(d1);
+      expect(d2.hours).toBe(101);
+      expect(d2.minutes).toBe(40);
+      expect(d2.seconds).toBe(100);
+    });
+  });
+});
+
+describe("Instance properties", () => {
+  it("should have correct property values for weeks and all components", () => {
+    const dur = Temporal.Duration.from({ weeks: 2, days: 3, hours: 5 });
+    expect(dur.weeks).toBe(2);
+    expect(dur.days).toBe(3);
+    expect(dur.hours).toBe(5);
+  });
+
+  it("should report the correct sign for durations", () => {
+    const pos = Temporal.Duration.from({ hours: 5 });
+    expect(pos.sign).toBe(1);
+
+    const neg = pos.negated();
+    expect(neg.sign).toBe(-1);
+
+    const zero = Temporal.Duration.from("PT0S");
+    expect(zero.sign).toBe(0);
+  });
+
+  it("has correct toStringTag", () => {
+    const dur = Temporal.Duration.from("PT0S");
+    expect(Object.prototype.toString.call(dur)).toBe(
+      "[object Temporal.Duration]"
+    );
   });
 });

--- a/tests/unit/temporal.instant.test.ts
+++ b/tests/unit/temporal.instant.test.ts
@@ -12,7 +12,7 @@ describe("Constructor", () => {
 });
 
 describe("Static methods", () => {
-  describe("Temporal.Instant.prototype.compare()", () => {
+  describe("Temporal.Instant.compare()", () => {
     it("Using Temporal.Instant.compare()", () => {
       const instant1 = Temporal.Instant.from("2021-08-01T12:34:56Z");
       const instant2 = Temporal.Instant.from("2021-08-01T12:34:56Z");
@@ -22,9 +22,24 @@ describe("Static methods", () => {
       const instant3 = Temporal.Instant.from("2021-08-01T13:34:56Z");
       expect(Temporal.Instant.compare(instant1, instant3)).toBe(-1);
     });
+
+    it("Sorting an array of instants", () => {
+      const instants = [
+        Temporal.Instant.from("2021-08-01T12:34:56Z"),
+        Temporal.Instant.from("2021-08-01T12:34:56+01:00"),
+        Temporal.Instant.from("2021-08-01T12:34:56-01:00"),
+      ];
+
+      instants.sort(Temporal.Instant.compare);
+      expect(instants.map((instant) => instant.toString())).toStrictEqual([
+        "2021-08-01T11:34:56Z",
+        "2021-08-01T12:34:56Z",
+        "2021-08-01T13:34:56Z",
+      ]);
+    });
   });
 
-  describe("Temporal.Instant.prototype.from()", () => {
+  describe("Temporal.Instant.from()", () => {
     it("Creating an instant from a string", () => {
       const instant = Temporal.Instant.from("1970-01-01T00Z");
       expect(instant.toString()).toBe("1970-01-01T00:00:00Z");
@@ -37,6 +52,12 @@ describe("Static methods", () => {
         "1970-01-01T00+08:00[America/New_York]"
       );
       expect(instant3.toString()).toBe("1969-12-31T16:00:00Z");
+    });
+
+    it("Creating an instant from another instant", () => {
+      const instant = Temporal.Instant.from("1970-01-01T00Z");
+      const instant2 = Temporal.Instant.from(instant);
+      expect(instant2.toString()).toBe("1970-01-01T00:00:00Z");
     });
   });
 
@@ -125,6 +146,28 @@ describe("Instance methods", () => {
   });
 
   describe("Temporal.Instant.prototype.since()", () => {
+    it.skip("Using since()", () => {
+      const lastUpdated = Temporal.Instant.fromEpochMilliseconds(1735235418000);
+      const now = Temporal.Now.instant();
+      const duration = now.since(lastUpdated, { smallestUnit: "minute" });
+      console.log(`Last updated ${duration.toLocaleString("en-US")} ago`);
+    });
+
+    it.skip("Balancing the resulting duration", () => {
+      const lastUpdated = Temporal.Instant.fromEpochMilliseconds(1735235418000);
+      const now = Temporal.Now.instant();
+      const duration = now.since(lastUpdated, { smallestUnit: "minutes" });
+      const roundedDuration = duration.round({
+        largestUnit: "years",
+        // Use the ISO calendar; you can convert to another calendar using
+        // withCalendar()
+        relativeTo: now.toZonedDateTimeISO("UTC"),
+      });
+      console.log(
+        `Last updated ${roundedDuration.toLocaleString("en-US")} ago`
+      );
+    });
+
     it("since() returns correct duration", () => {
       const insta = Temporal.Instant.fromEpochMilliseconds(5000);
       const instb = Temporal.Instant.fromEpochMilliseconds(2000);
@@ -157,6 +200,7 @@ describe("Instance methods", () => {
       const instant = Temporal.Instant.fromEpochMilliseconds(1627821296000);
       const instantStr = instant.toJSON();
       expect(instantStr).toBe("2021-08-01T12:34:56Z");
+      const _ = Temporal.Instant.from(instantStr);
     });
   });
 
@@ -175,10 +219,24 @@ describe("Instance methods", () => {
       expect(zonedDateTime.toString()).toBe(
         "2021-08-01T08:34:56.123456789-04:00[America/New_York]"
       );
+
+      const localDateTime = instant.toZonedDateTimeISO(
+        Temporal.Now.timeZoneId()
+      );
+      console.log(localDateTime.toString()); // This instant in your timezone
     });
   });
 
   describe("Temporal.Instant.prototype.until()", () => {
+    it.skip("Using until()", () => {
+      const launch = Temporal.Instant.fromEpochMilliseconds(2051222400000);
+      const now = Temporal.Now.instant();
+      const duration = now.until(launch, { smallestUnit: "minutes" });
+      console.log(
+        `It will be ${duration.toLocaleString("en-US")} until the launch`
+      );
+    });
+
     it("until() returns correct duration", () => {
       const insta = Temporal.Instant.fromEpochMilliseconds(1000);
       const instb = Temporal.Instant.fromEpochMilliseconds(4000);
@@ -198,12 +256,19 @@ describe("Instance methods", () => {
   });
 
   describe("Temporal.Instant.prototype.valueOf()", () => {
-    it("valueOf() throws a TypeError", () => {
-      const inst = Temporal.Instant.fromEpochMilliseconds(0);
+    it("Arithmetic and comparison operations on Temporal.Instant", () => {
+      const instant1 = Temporal.Instant.fromEpochMilliseconds(0);
+      const instant2 = Temporal.Instant.fromEpochMilliseconds(1000);
       expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        +inst;
+        instant1 > instant2; // TypeError: can't convert Instant to primitive type
       }).toThrow();
+      expect(instant1.epochNanoseconds > instant2.epochNanoseconds).toBe(false);
+      expect(Temporal.Instant.compare(instant1, instant2)).toBe(-1);
+
+      expect(() => {
+        instant2 - instant1; // TypeError: can't convert Instant to primitive type
+      }).toThrow();
+      expect(instant2.since(instant1).toString()).toBe("PT1S");
     });
   });
 });

--- a/tests/unit/temporal.zoneddatetime.test.ts
+++ b/tests/unit/temporal.zoneddatetime.test.ts
@@ -1,3 +1,133 @@
+describe("Constructor", () => {
+  describe("Temporal.ZonedDateTime()", () => {
+    it("Using Temporal.ZonedDateTime()", () => {
+      const zdt = new Temporal.ZonedDateTime(0n, "America/New_York");
+      expect(zdt.toString()).toBe(
+        "1969-12-31T19:00:00-05:00[America/New_York]"
+      );
+    });
+  });
+});
+
+describe("Static methods", () => {
+  describe("Temporal.ZonedDateTime.compare()", () => {
+    it("Using Temporal.ZonedDateTime.compare()", () => {
+      const dt1 = Temporal.ZonedDateTime.from(
+        "2021-08-01T01:00:00[Europe/London]"
+      );
+      const dt2 = Temporal.ZonedDateTime.from(
+        "2021-08-02T00:00:00[Europe/London]"
+      );
+      expect(Temporal.ZonedDateTime.compare(dt1, dt2)).toBe(-1);
+
+      const dt3 = Temporal.ZonedDateTime.from(
+        "2021-08-01T00:00:00[Europe/London]"
+      );
+      expect(Temporal.ZonedDateTime.compare(dt1, dt3)).toBe(1);
+    });
+
+    it("Sorting an array of date-times #1", () => {
+      const dateTimes = [
+        Temporal.ZonedDateTime.from("2021-08-01T00:00:00[America/New_York]"),
+        Temporal.ZonedDateTime.from("2021-08-01T00:00:00[Asia/Hong_Kong]"),
+        Temporal.ZonedDateTime.from("2021-08-01T00:00:00[Europe/London]"),
+      ];
+
+      dateTimes.sort(Temporal.ZonedDateTime.compare);
+      expect(dateTimes.map((d) => d.toString())).toStrictEqual([
+        "2021-08-01T00:00:00+08:00[Asia/Hong_Kong]",
+        "2021-08-01T00:00:00+01:00[Europe/London]",
+        "2021-08-01T00:00:00-04:00[America/New_York]",
+      ]);
+    });
+
+    it("Sorting an array of date-times #2", () => {
+      const dateTimes = [
+        Temporal.ZonedDateTime.from("2021-08-01T00:00:00[America/New_York]"),
+        Temporal.ZonedDateTime.from("2021-08-01T00:00:00[Asia/Hong_Kong]"),
+        Temporal.ZonedDateTime.from("2021-08-01T00:00:00[Europe/London]"),
+      ];
+
+      dateTimes.sort((a, b) =>
+        Temporal.PlainDateTime.compare(a.toPlainDateTime(), b.toPlainDateTime())
+      );
+      expect(dateTimes.map((d) => d.toString())).toStrictEqual([
+        "2021-08-01T00:00:00-04:00[America/New_York]",
+        "2021-08-01T00:00:00+08:00[Asia/Hong_Kong]",
+        "2021-08-01T00:00:00+01:00[Europe/London]",
+      ]);
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.from()", () => {
+    it("Creating a ZonedDateTime from an object", () => {
+      // Year + month + day + hour + minute + second
+      const zdt = Temporal.ZonedDateTime.from({
+        timeZone: "America/New_York",
+        year: 2021,
+        month: 7,
+        day: 1,
+        hour: 12,
+        minute: 34,
+        second: 56,
+      });
+      expect(zdt.toString()).toBe(
+        "2021-07-01T12:34:56-04:00[America/New_York]"
+      );
+    });
+
+    it("Creating a ZonedDateTime from a string", () => {
+      // const zdt = Temporal.ZonedDateTime.from(
+      //   "2021-07-01T12:34:56-04:00[America/New_York]",
+      // );
+      // expect(zdt.toLocaleString()); // "7/1/2021, 12:34:56 PM EDT" (assuming en-US locale)
+
+      // Time given as UTC, and converted to local
+      const zdt2 = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56Z[America/New_York]"
+      );
+      expect(zdt2.toString()).toBe(
+        "2021-07-01T08:34:56-04:00[America/New_York]"
+      );
+    });
+
+    it("Creating a ZonedDateTime from an ISO 8601 / RFC 3339 string", () => {
+      const isoString = "2021-07-01T12:34:56+02:00";
+      const instant = Temporal.Instant.from(isoString);
+      const zdt = instant.toZonedDateTimeISO("America/New_York");
+      expect(zdt.toString()).toBe(
+        "2021-07-01T06:34:56-04:00[America/New_York]"
+      );
+    });
+
+    it("Local time disambiguation", () => {
+      const localTimeNotExist = "2024-03-10T02:05:00[America/New_York]";
+      // For non-existent times, "compatible" is equivalent to "later"
+      const zdt = Temporal.ZonedDateTime.from(localTimeNotExist);
+      expect(zdt.toString()).toBe(
+        "2024-03-10T03:05:00-04:00[America/New_York]"
+      );
+
+      // const zdt2 = Temporal.ZonedDateTime.from(localTimeNotExist, {
+      //   disambiguation: "earlier",
+      // });
+      // expect(zdt2.toString()).toBe("2024-03-10T01:05:00-05:00[America/New_York]");
+
+      const localTimeAmbiguous = "2024-11-03T01:05:00[America/New_York]";
+      // For ambiguous times, "compatible" is equivalent to "earlier"
+      const zdt3 = Temporal.ZonedDateTime.from(localTimeAmbiguous);
+      expect(zdt3.toString()).toBe(
+        "2024-11-03T01:05:00-04:00[America/New_York]"
+      );
+
+      // const zdt4 = Temporal.ZonedDateTime.from(localTimeAmbiguous, {
+      //   disambiguation: "later",
+      // });
+      // expect(zdt4.toString()).toBe("2024-11-03T01:05:00-05:00[America/New_York]");
+    });
+  });
+});
+
 describe("Temporal.ZonedDateTime", () => {
   describe("creation and parsing", () => {
     it("can be created from an RFC 9557 string", () => {


### PR DESCRIPTION
### Issue # (if available)

Related #1416

### Description of changes

By actively incorporating MDN (Temporal.Duration) use cases into our test cases, we identified several areas for improvement.

- This pull request will expose several methods: `Duration.round()`, `Duration.total()`, `Now.timeZoneId()`;
- We also made several other refactorings.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
