### PR TITLE
fix(tls): get rustls-graviola from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,8 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 [[package]]
 name = "graviola"
 version = "0.3.4"
-source = "git+https://github.com/ctz/graviola.git#38a5e5ace4fd808ee49825b3bc2129d85a3542eb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4387e0458389da24c6fe732531e65595c7c4a32b027f98f4789e512e28224465"
 dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
@@ -3051,7 +3052,8 @@ dependencies = [
 [[package]]
 name = "rustls-graviola"
 version = "0.3.4"
-source = "git+https://github.com/ctz/graviola.git#38a5e5ace4fd808ee49825b3bc2129d85a3542eb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c712e50c59ceb2ba9ad4d79dcfd3e0046a082d61efa87fcdf8f59af04473c"
 dependencies = [
  "graviola",
  "rustls",

--- a/libs/llrt_test_tls/Cargo.toml
+++ b/libs/llrt_test_tls/Cargo.toml
@@ -26,7 +26,7 @@ hyper-util = { version = "0.1", features = [
 ], default-features = false }
 http = { version = "1", default-features = false }
 rustls = { version = "0.23", features = ["tls12"], default-features = false }
-rustls-graviola = { version = "0.3", git = "https://github.com/ctz/graviola.git", default-features = false, optional = true }
+rustls-graviola = { version = "0.3", default-features = false, optional = true }
 openssl = { version = "0.10", optional = true }
 tokio-openssl = { version = "0.6", optional = true }
 tokio = { version = "1", features = [

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -130,7 +130,7 @@ x25519-dalek = { version = "3.0.0-pre.6", features = [
 ring = { version = "0.17", default-features = false, optional = true }
 openssl-sys = { version = "0.9", optional = true }
 openssl = { version = "0.10", optional = true }
-graviola = { version = "0.3", git = "https://github.com/ctz/graviola.git", optional = true }
+graviola = { version = "0.3", optional = true }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }

--- a/modules/llrt_tls/Cargo.toml
+++ b/modules/llrt_tls/Cargo.toml
@@ -31,7 +31,7 @@ rustls = { version = "0.23", features = [
   "std",
   "tls12",
 ], default-features = false, optional = true }
-rustls-graviola = { version = "0.3", git = "https://github.com/ctz/graviola.git", default-features = false, optional = true }
+rustls-graviola = { version = "0.3", default-features = false, optional = true }
 openssl = { version = "0.10", optional = true }
 webpki-roots = { version = "1", default-features = false, optional = true }
 rustls-native-certs = { version = "0.8", default-features = false, optional = true }


### PR DESCRIPTION
### Issue # (if available)

Revert #1387

### Description of changes

A new version of `rustls-graviola` has been released, so it is no longer necessary to fetch assets directly from GitHub.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
