### PR TITLE
fix: JSON import() fails for escaped characters

### DIFF
--- a/llrt_modules/src/package/loader.rs
+++ b/llrt_modules/src/package/loader.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{fs::File, io::Read};
 
+use llrt_json::escape::escape_json_string;
 use rquickjs::{loader::Loader, Ctx, Function, Module, Object, Result, Value};
 use tracing::trace;
 
@@ -82,13 +83,12 @@ impl PackageLoader {
         if !from_cjs_import {
             if normalized_name.ends_with(".json") {
                 let mut file = File::open(path)?;
-                let prefix = "export default JSON.parse(`";
-                let suffix = "`);";
-                let mut json = String::with_capacity(prefix.len() + suffix.len());
-                json.push_str(prefix);
-                file.read_to_string(&mut json)?;
-                json.push_str(suffix);
-
+                let mut contents = Vec::new();
+                file.read_to_end(&mut contents)?;
+                let mut json = String::with_capacity(contents.len() + 40);
+                json.push_str("export default JSON.parse(\"");
+                escape_json_string(&mut json, &contents);
+                json.push_str("\");");
                 return Ok((Module::declare(ctx, path, json)?, None));
             }
             if is_cjs || normalized_name.ends_with(".cjs") {

--- a/tests/unit/fixtures/escaped.json
+++ b/tests/unit/fixtures/escaped.json
@@ -1,0 +1,8 @@
+{
+  "quote": "\"hello\"",
+  "backslash": "a\\b",
+  "tab": "a\tb",
+  "newline": "a\nb",
+  "mixed": "\"it\\s\\nalive\"",
+  "nested": { "key": "val\"ue" }
+}

--- a/tests/unit/json.test.ts
+++ b/tests/unit/json.test.ts
@@ -1,3 +1,17 @@
+describe("JSON import()", () => {
+  it("should parse escaped characters via import()", async () => {
+    const mod = await import("./fixtures/escaped.json");
+    expect(mod.default).toStrictEqual({
+      quote: '"hello"',
+      backslash: "a\\b",
+      tab: "a\tb",
+      newline: "a\nb",
+      mixed: '"it\\s\\nalive"',
+      nested: { key: 'val"ue' },
+    });
+  });
+});
+
 describe("JSON Parsing", () => {
   it("should parse valid JSON", () => {
     const parsedData = JSON.parse('{"key": "value"}');


### PR DESCRIPTION
### Issue # (if available)

Fixes #1470

### Description of changes

JSON files loaded via `import()` were embedded in a JS template literal `export default JSON.parse(``...``)`. Template literals interpret `\` as an escape character, so `\"` in the JSON became `"` before `JSON.parse` saw it, producing invalid JSON.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
