### PR TITLE
chore: Support for next rust toolchain

### DIFF
--- a/libs/llrt_logging/src/lib.rs
+++ b/libs/llrt_logging/src/lib.rs
@@ -833,71 +833,56 @@ fn replace_invalid_utf8_and_utf16(bytes: &[u8]) -> String {
                 i += 1;
             },
             // 2-byte UTF-8 sequence
-            0xC0..=0xDF => {
-                if i + 1 < bytes.len() {
-                    let next = bytes[i + 1];
-                    if (next & 0xC0) == 0x80 {
-                        let code_point = ((current as u32 & 0x1F) << 6) | (next as u32 & 0x3F);
-                        if let Some(c) = char::from_u32(code_point) {
-                            result.push(c);
-                        } else {
-                            result.push('�');
-                        }
-                        i += 2;
+            0xC0..=0xDF if i + 1 < bytes.len() => {
+                let next = bytes[i + 1];
+                if (next & 0xC0) == 0x80 {
+                    let code_point = ((current as u32 & 0x1F) << 6) | (next as u32 & 0x3F);
+                    if let Some(c) = char::from_u32(code_point) {
+                        result.push(c);
                     } else {
                         result.push('�');
-                        i += 1;
                     }
+                    i += 2;
                 } else {
                     result.push('�');
                     i += 1;
                 }
             },
             // 3-byte UTF-8 sequence
-            0xE0..=0xEF => {
-                if i + 2 < bytes.len() {
-                    let next1 = bytes[i + 1];
-                    let next2 = bytes[i + 2];
-                    if (next1 & 0xC0) == 0x80 && (next2 & 0xC0) == 0x80 {
-                        let code_point = ((current as u32 & 0x0F) << 12)
-                            | ((next1 as u32 & 0x3F) << 6)
-                            | (next2 as u32 & 0x3F);
-                        if let Some(c) = char::from_u32(code_point) {
-                            result.push(c);
-                        } else {
-                            result.push('�');
-                        }
-                        i += 3;
+            0xE0..=0xEF if i + 2 < bytes.len() => {
+                let next1 = bytes[i + 1];
+                let next2 = bytes[i + 2];
+                if (next1 & 0xC0) == 0x80 && (next2 & 0xC0) == 0x80 {
+                    let code_point = ((current as u32 & 0x0F) << 12)
+                        | ((next1 as u32 & 0x3F) << 6)
+                        | (next2 as u32 & 0x3F);
+                    if let Some(c) = char::from_u32(code_point) {
+                        result.push(c);
                     } else {
                         result.push('�');
-                        i += 1;
                     }
+                    i += 3;
                 } else {
                     result.push('�');
                     i += 1;
                 }
             },
             // 4-byte UTF-8 sequence
-            0xF0..=0xF7 => {
-                if i + 3 < bytes.len() {
-                    let next1 = bytes[i + 1];
-                    let next2 = bytes[i + 2];
-                    let next3 = bytes[i + 3];
-                    if (next1 & 0xC0) == 0x80 && (next2 & 0xC0) == 0x80 && (next3 & 0xC0) == 0x80 {
-                        let code_point = ((current as u32 & 0x07) << 18)
-                            | ((next1 as u32 & 0x3F) << 12)
-                            | ((next2 as u32 & 0x3F) << 6)
-                            | (next3 as u32 & 0x3F);
-                        if let Some(c) = char::from_u32(code_point) {
-                            result.push(c);
-                        } else {
-                            result.push('�');
-                        }
-                        i += 4;
+            0xF0..=0xF7 if i + 3 < bytes.len() => {
+                let next1 = bytes[i + 1];
+                let next2 = bytes[i + 2];
+                let next3 = bytes[i + 3];
+                if (next1 & 0xC0) == 0x80 && (next2 & 0xC0) == 0x80 && (next3 & 0xC0) == 0x80 {
+                    let code_point = ((current as u32 & 0x07) << 18)
+                        | ((next1 as u32 & 0x3F) << 12)
+                        | ((next2 as u32 & 0x3F) << 6)
+                        | (next3 as u32 & 0x3F);
+                    if let Some(c) = char::from_u32(code_point) {
+                        result.push(c);
                     } else {
                         result.push('�');
-                        i += 1;
                     }
+                    i += 4;
                 } else {
                     result.push('�');
                     i += 1;

--- a/llrt/src/repl.rs
+++ b/llrt/src/repl.rs
@@ -165,13 +165,11 @@ pub(crate) async fn run_repl(ctx: &AsyncContext) {
                             added_input_chars = false;
                         }
                     },
-                    KeyCode::Up => {
-                        if !history.is_empty() && history_index > 0 {
-                            added_input_chars = false;
-                            history_index -= 1;
-                            current_input = history[history_index].clone();
-                            cursor_pos = current_input.len();
-                        }
+                    KeyCode::Up if !history.is_empty() && history_index > 0 => {
+                        added_input_chars = false;
+                        history_index -= 1;
+                        current_input = history[history_index].clone();
+                        cursor_pos = current_input.len();
                     },
                     KeyCode::Down => {
                         let history_len = history.len();
@@ -196,16 +194,12 @@ pub(crate) async fn run_repl(ctx: &AsyncContext) {
                     KeyCode::Left => {
                         cursor_pos = cursor_pos.saturating_sub(1);
                     },
-                    KeyCode::Right => {
-                        if cursor_pos < current_input.len() {
-                            cursor_pos += 1;
-                        }
+                    KeyCode::Right if cursor_pos < current_input.len() => {
+                        cursor_pos += 1;
                     },
-                    KeyCode::Backspace => {
-                        if cursor_pos > 0 {
-                            current_input.remove(cursor_pos - 1);
-                            cursor_pos -= 1;
-                        }
+                    KeyCode::Backspace if cursor_pos > 0 => {
+                        current_input.remove(cursor_pos - 1);
+                        cursor_pos -= 1;
                     },
                     KeyCode::Char(c) => {
                         if modifiers == KeyModifiers::CONTROL && (c == 'c' || c == 'd') {

--- a/llrt_modules/src/package/resolver.rs
+++ b/llrt_modules/src/package/resolver.rs
@@ -478,10 +478,7 @@ fn load_node_modules<'a>(
         let str_dir = dir.to_string_lossy();
         if let Some(dirs) = cache.get(str_dir.as_ref()) {
             if let Some(dirs) = dirs {
-                results
-                    .0
-                    .borrow_mut()
-                    .extend(dirs.0.borrow().clone().into_iter());
+                results.0.borrow_mut().extend(dirs.0.borrow().clone());
             }
             last_found_index = i;
 

--- a/modules/llrt_assert/src/lib.rs
+++ b/modules/llrt_assert/src/lib.rs
@@ -9,20 +9,14 @@ use rquickjs::{
 
 fn ok(ctx: Ctx, value: Value, message: Opt<Value>) -> Result<()> {
     match value.type_of() {
-        Type::Bool => {
-            if value.as_bool().unwrap() {
-                return Ok(());
-            }
+        Type::Bool if value.as_bool().unwrap() => {
+            return Ok(());
         },
-        Type::Float | Type::Int => {
-            if value.as_number().unwrap() != 0.0 {
-                return Ok(());
-            }
+        Type::Float | Type::Int if value.as_number().unwrap() != 0.0 => {
+            return Ok(());
         },
-        Type::String => {
-            if !value.as_string().unwrap().to_string().unwrap().is_empty() {
-                return Ok(());
-            }
+        Type::String if !value.as_string().unwrap().to_string().unwrap().is_empty() => {
+            return Ok(());
         },
         Type::Array
         | Type::BigInt

--- a/modules/llrt_dns/src/lookup.rs
+++ b/modules/llrt_dns/src/lookup.rs
@@ -95,11 +95,11 @@ async fn lookup_host(
     match order {
         LookupOrder::Verbatim => Ok(addrs),
         LookupOrder::Ipv4First => {
-            addrs.sort_by(|a, b| a.family.cmp(&b.family));
+            addrs.sort_by_key(|a| a.family);
             Ok(addrs)
         },
         LookupOrder::Ipv6First => {
-            addrs.sort_by(|a, b| b.family.cmp(&a.family));
+            addrs.sort_by_key(|b| std::cmp::Reverse(b.family));
             Ok(addrs)
         },
     }


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

- This update fixes code that causes build errors when updating to a new toolchain (including automatically updated code).

```
% rustup update
   stable-aarch64-apple-darwin updated - rustc 1.95.0 (59807616e 2026-04-14) (from rustc 1.94.0 (4a4ef493e 2026-03-02))
  nightly-aarch64-apple-darwin updated - rustc 1.97.0-nightly (7af3402cd 2026-04-16) (from rustc 1.96.0-nightly (69370dc4a 2026-03-05))
```

### Note

- `llrt/src/repl.rs` has been unintentionally detected as a full-line difference file. This is due to a change in line endings from CRLF to LF.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
