### PR TITLE
feat(temporal): Improved compatibility with Temporal.ZonedDateTime

### DIFF
--- a/modules/llrt_temporal/src/utils/mod.rs
+++ b/modules/llrt_temporal/src/utils/mod.rs
@@ -10,6 +10,7 @@ pub mod time;
 pub mod time_round;
 pub mod timestamp_round;
 pub mod zoned;
+pub mod zoned_difference;
 pub mod zoned_round;
 
 use jiff::{RoundMode, Unit};

--- a/modules/llrt_temporal/src/utils/span_total.rs
+++ b/modules/llrt_temporal/src/utils/span_total.rs
@@ -19,8 +19,12 @@ impl<'a> SpanTotalExt<'a> for SpanTotal<'a> {
             return into_span_total(ctx, &relative_to, &unit);
         }
 
-        let unit = value.as_string().and_then(|s| s.to_string().ok());
-        into_span_total(ctx, &None, &unit)
+        let unit = value
+            .as_string()
+            .and_then(|s| s.to_string().ok())
+            .or_throw_type(ctx, "Cannot convert value to string")?;
+
+        into_span_total(ctx, &None, &Some(unit))
     }
 }
 

--- a/modules/llrt_temporal/src/utils/zoned_difference.rs
+++ b/modules/llrt_temporal/src/utils/zoned_difference.rs
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use jiff::{Unit, Zoned, ZonedDifference};
+use rquickjs::{Ctx, Result, Value};
+
+use crate::utils::{get_duration_unit, get_round_mode};
+
+pub trait ZonedDifferenceExt<'a> {
+    fn from_value(ctx: &Ctx<'_>, zoned: &'a Zoned, value: &Value) -> Result<ZonedDifference<'a>>;
+}
+
+impl<'a> ZonedDifferenceExt<'a> for ZonedDifference<'a> {
+    fn from_value(ctx: &Ctx<'_>, zoned: &'a Zoned, value: &Value) -> Result<ZonedDifference<'a>> {
+        if let Some(obj) = value.as_object() {
+            let largest_unit = obj.get::<_, String>("largestUnit").ok();
+            let increment = obj.get::<_, i64>("roundingIncrement").ok();
+            let mode = obj.get::<_, String>("roundingMode").ok();
+            let smallest_unit = obj.get::<_, String>("smallestUnit").ok();
+            return into_zoned_deffierence(
+                ctx.clone(),
+                zoned,
+                largest_unit,
+                increment,
+                mode,
+                smallest_unit,
+            );
+        }
+
+        let unit = value.as_string().and_then(|s| s.to_string().ok());
+        into_zoned_deffierence(ctx.clone(), zoned, None, None, None, unit)
+    }
+}
+
+fn into_zoned_deffierence<'a>(
+    ctx: Ctx,
+    zoned: &'a Zoned,
+    largest_unit: Option<String>,
+    increment: Option<i64>,
+    mode: Option<String>,
+    smallest_unit: Option<String>,
+) -> Result<ZonedDifference<'a>> {
+    let largest_unit = get_duration_unit(&ctx, &largest_unit)?.unwrap_or(Unit::Hour);
+    let increment = increment.unwrap_or(1);
+    let mode = get_round_mode(&ctx, &mode)?;
+    let smallest_unit = get_duration_unit(&ctx, &smallest_unit)?.unwrap_or(Unit::Nanosecond);
+
+    let zoned_deffierence = ZonedDifference::new(zoned)
+        .mode(mode)
+        .increment(increment)
+        .largest(largest_unit)
+        .smallest(smallest_unit);
+    Ok(zoned_deffierence)
+}

--- a/modules/llrt_temporal/src/utils/zoned_difference.rs
+++ b/modules/llrt_temporal/src/utils/zoned_difference.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use jiff::{Unit, Zoned, ZonedDifference};
+use llrt_utils::result::ResultExt;
 use rquickjs::{Ctx, Result, Value};
 
 use crate::utils::{get_duration_unit, get_round_mode};
@@ -26,8 +27,12 @@ impl<'a> ZonedDifferenceExt<'a> for ZonedDifference<'a> {
             );
         }
 
-        let unit = value.as_string().and_then(|s| s.to_string().ok());
-        into_zoned_deffierence(ctx.clone(), zoned, None, None, None, unit)
+        let unit = value
+            .as_string()
+            .and_then(|s| s.to_string().ok())
+            .or_throw_type(ctx, "Cannot convert value to string")?;
+
+        into_zoned_deffierence(ctx.clone(), zoned, None, None, None, Some(unit))
     }
 }
 

--- a/modules/llrt_temporal/src/zoned_date_time.rs
+++ b/modules/llrt_temporal/src/zoned_date_time.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{cmp::Ordering, str::FromStr};
 
-use jiff::{Timestamp, Zoned};
+use jiff::{Timestamp, Zoned, ZonedDifference};
 use llrt_utils::result::ResultExt;
 use rquickjs::Object;
 use rquickjs::{
@@ -16,6 +16,7 @@ use crate::plain_date::PlainDate;
 use crate::plain_date_time::PlainDateTime;
 use crate::plain_time::PlainTime;
 use crate::utils::zoned::ZonedExt;
+use crate::utils::zoned_difference::ZonedDifferenceExt;
 use crate::utils::zoned_round::ZonedRoundOption;
 
 use super::extract_bigint_or_number;
@@ -68,7 +69,7 @@ impl ZonedDateTime {
     }
 
     fn equals(&self, other: Self) -> bool {
-        self.inner == other.inner
+        self.inner == other.inner && self.inner.time_zone() == other.inner.time_zone()
     }
 
     #[qjs(rename = "getTimeZoneTransition")]
@@ -92,8 +93,14 @@ impl ZonedDateTime {
         Ok(Self { inner: zoned })
     }
 
-    fn since(&self, other: Self) -> Duration {
-        Duration::new_object(self.inner.clone() - other.inner)
+    fn since(&self, ctx: Ctx<'_>, other: &Self, opt: Opt<Value<'_>>) -> Result<Duration> {
+        let span = if let Some(ref opt) = opt.0 {
+            let diff = ZonedDifference::from_value(&ctx, &other.inner, opt)?;
+            self.inner.since(diff).or_throw_range(&ctx, "")?
+        } else {
+            self.inner.clone() - other.inner.clone()
+        };
+        Ok(Duration::new_object(span))
     }
 
     fn subtract(&self, ctx: Ctx<'_>, duration: Value<'_>) -> Result<Self> {
@@ -134,8 +141,14 @@ impl ZonedDateTime {
         self.inner.to_string()
     }
 
-    fn until(&self, other: Self) -> Duration {
-        Duration::new_object(other.inner - self.inner.clone())
+    fn until(&self, ctx: Ctx<'_>, other: &Self, opt: Opt<Value<'_>>) -> Result<Duration> {
+        let span = if let Some(ref opt) = opt.0 {
+            let diff = ZonedDifference::from_value(&ctx, &other.inner, opt)?;
+            self.inner.until(diff).or_throw_range(&ctx, "")?
+        } else {
+            other.inner.clone() - self.inner.clone()
+        };
+        Ok(Duration::new_object(span))
     }
 
     fn value_of(&self, ctx: Ctx<'_>) -> Result<()> {

--- a/tests/unit/temporal.zoneddatetime.test.ts
+++ b/tests/unit/temporal.zoneddatetime.test.ts
@@ -77,9 +77,9 @@ describe("Static methods", () => {
     });
 
     it("Creating a ZonedDateTime from a string", () => {
-      // const zdt = Temporal.ZonedDateTime.from(
-      //   "2021-07-01T12:34:56-04:00[America/New_York]",
-      // );
+      const zdt = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56-04:00[America/New_York]"
+      );
       // expect(zdt.toLocaleString()); // "7/1/2021, 12:34:56 PM EDT" (assuming en-US locale)
 
       // Time given as UTC, and converted to local
@@ -128,65 +128,77 @@ describe("Static methods", () => {
   });
 });
 
-describe("Temporal.ZonedDateTime", () => {
-  describe("creation and parsing", () => {
-    it("can be created from an RFC 9557 string", () => {
-      const zdt1 = Temporal.ZonedDateTime.from(
-        "2021-08-19T17:01:00+01:00[Europe/London]"
-      );
-      expect(zdt1.toString()).toContain(
-        "2021-08-19T17:01:00+01:00[Europe/London]"
-      );
-    });
+describe("Instance methods", () => {
+  const zdt1 = Temporal.ZonedDateTime.from("2020-01-01T12:00:00+00:00[UTC]");
+  const zdt2 = Temporal.ZonedDateTime.from("2020-01-02T12:00:00+00:00[UTC]");
 
-    it("can be created from an own object", () => {
-      const zdt1 = Temporal.ZonedDateTime.from(
-        "2021-08-19T17:01:00+01:00[Europe/London]"
+  describe("Temporal.ZonedDateTime.prototype.add()", () => {
+    it("Adding a duration", () => {
+      const start = Temporal.ZonedDateTime.from(
+        "2021-11-01T12:34:56-04:00[America/New_York]"
       );
-      const zdt2 = Temporal.ZonedDateTime.from(zdt1);
-      expect(zdt1).toEqual(zdt2);
-    });
-
-    it("can be created from an object containing properties", () => {
-      const zdt1 = Temporal.ZonedDateTime.from({
-        timeZone: "America/Los_Angeles",
-        year: 1995,
-        month: 12,
-        day: 7,
-        hour: 3,
-        minute: 24,
-        second: 30,
-        millisecond: 0,
-        microsecond: 3,
-        nanosecond: 500,
+      const end = start.add({
+        years: 1,
+        months: 2,
+        weeks: 3,
+        days: 4,
+        hours: 5,
+        minutes: 6,
+        seconds: 7,
+        milliseconds: 8,
       });
-      expect(zdt1.toString()).toEqual(
-        "1995-12-07T03:24:30.0000035-08:00[America/Los_Angeles]"
+      expect(end.toString()).toBe(
+        "2023-01-26T17:41:03.008-05:00[America/New_York]"
       );
     });
   });
 
-  describe("arithmetic methods", () => {
-    const zdt1 = Temporal.ZonedDateTime.from("2020-01-01T12:00:00+00:00[UTC]");
-    const zdt2 = Temporal.ZonedDateTime.from("2020-01-02T12:00:00+00:00[UTC]");
+  describe("Temporal.ZonedDateTime.prototype.equals()", () => {
+    it("Using equals()", () => {
+      // Asia/Kolkata and Asia/Calcutta are aliases of each other
+      const dt1 = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56+05:30[Asia/Kolkata]"
+      );
+      const dt2 = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56+05:30[Asia/Calcutta]"
+      );
+      // expect(dt1.equals(dt2)).toBe(true);
 
-    it("add() advances the date/time", () => {
-      const later = zdt1.add({ days: 1 });
-      expect(later.day).toBe(2);
+      const dt3 = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56+05:30[+05:30]"
+      );
+      expect(dt1.equals(dt3)).toBe(false);
+
+      const dt4 = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56+05:30[Asia/Kolkata][u-ca=buddhist]"
+      );
+      // expect(dt1.equals(dt4)).toBe(false);
     });
 
-    it("compare() method works for two ZonedDateTime objects", () => {
-      expect(Temporal.ZonedDateTime.compare(zdt1, zdt2)).toBe(-1);
-      expect(Temporal.ZonedDateTime.compare(zdt2, zdt1)).toBe(1);
-      expect(Temporal.ZonedDateTime.compare(zdt1, zdt1)).toBe(0);
-    });
+    it("Testing if two time zone identifiers are equivalent", () => {
+      function sameTimeZone(timeZone1, timeZone2) {
+        const dt1 = Temporal.ZonedDateTime.from({
+          year: 2021,
+          month: 7,
+          day: 1,
+          timeZone: timeZone1,
+        });
+        const dt2 = Temporal.ZonedDateTime.from({
+          year: 2021,
+          month: 7,
+          day: 1,
+          timeZone: timeZone2,
+        });
+        return dt1.equals(dt2);
+      }
 
-    it("equals() verifies if two ZonedDateTime are equal", () => {
-      const same = Temporal.ZonedDateTime.from("2020-01-01T12:00:00[UTC]");
-      expect(zdt1.equals(same)).toBe(true);
+      // expect(sameTimeZone("Asia/Kolkata", "Asia/Calcutta")).toBe(true);
+      expect(sameTimeZone("Asia/Shanghai", "Asia/Taipei")).toBe(false);
     });
+  });
 
-    it("getTimeZoneTransition() returns the next and previous timezone offset transitions", () => {
+  describe("Temporal.ZonedDateTime.prototype.getTimeZoneTransition()", () => {
+    it("Finding the next time zone transition", () => {
       const dt = Temporal.ZonedDateTime.from(
         "2024-01-01T00-05:00[America/New_York]"
       );
@@ -208,149 +220,349 @@ describe("Temporal.ZonedDateTime", () => {
       const dt2 = Temporal.ZonedDateTime.from("2024-01-01T00Z[UTC]");
       expect(dt2.getTimeZoneTransition("next")).toBe(null);
     });
+  });
 
-    it("round() supports various forms, roundingMode, and roundingIncrement", () => {
-      const zFrac = zdt1.add({ milliseconds: 500 });
-      const rounded = zFrac.round({ smallestUnit: "second" });
-      expect(rounded.second).toBe(1);
-      expect(rounded.offset).toBe("+00:00");
-      expect(rounded.timeZoneId).toBe("UTC");
+  describe("Temporal.ZonedDateTime.prototype.round()", () => {
+    it("Rounding off small units", () => {
+      const zdt = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56.123456789[America/New_York]"
+      );
+      const nearestMillisecond = zdt.round("millisecond");
+      expect(nearestMillisecond.toString()).toBe(
+        "2021-07-01T12:34:56.123-04:00[America/New_York]"
+      );
 
-      const truncated = zFrac.round({
-        smallestUnit: "second",
-        roundingMode: "trunc",
-      });
-      expect(truncated.second).toBe(0);
-
-      const zMulti = zdt1.add({ minutes: 7, seconds: 15 });
-      const str = zMulti.round("minute");
-      expect(str.minute).toBe(7);
-      expect(str.second).toBe(0);
-
-      const inc = zMulti.round({
+      const nearestHalfHour = zdt.round({
         smallestUnit: "minute",
-        roundingIncrement: 15,
+        roundingIncrement: 30,
       });
-      expect(inc.minute).toBe(0);
+      expect(nearestHalfHour.toString()).toBe(
+        "2021-07-01T12:30:00-04:00[America/New_York]"
+      );
 
-      const incHour = zMulti.round({
-        smallestUnit: "hour",
-        roundingIncrement: 2,
-      });
-      expect(incHour.hour).toBe(12);
+      const nextDay = zdt.round({ smallestUnit: "day", roundingMode: "ceil" });
+      expect(nextDay.toString()).toBe(
+        "2021-07-02T00:00:00-04:00[America/New_York]"
+      );
     });
 
-    it("since() returns correct duration", () => {
-      const d = zdt2.since(zdt1);
-
-      expect(d.sign).toBe(1);
-      expect(d.years).toBe(0);
-      expect(d.months).toBe(0);
-      expect(d.days).toBe(0);
-      expect(d.hours).toBe(24);
-      expect(d.minutes).toBe(0);
-      expect(d.seconds).toBe(0);
-      expect(d.milliseconds).toBe(0);
-      expect(d.microseconds).toBe(0);
-      expect(d.nanoseconds).toBe(0);
-    });
-
-    it("subtract() decrements by a duration", () => {
-      const earlier = zdt1.subtract({ hours: 1 });
-      expect(earlier.hour).toBeLessThan(zdt1.hour);
-    });
-
-    it("toInstant() returns a Temporal.Instant", () => {
-      const inst = zdt1.toInstant();
-      expect(inst).toBeInstanceOf(Temporal.Instant);
-    });
-
-    it("toPlainDate() returns a Temporal.PlainDate", () => {
-      const pd1 = zdt1.toPlainDate();
-      expect(pd1).toBeInstanceOf(Temporal.PlainDate);
-      expect(pd1.toString()).toBe("2020-01-01");
-    });
-
-    it("toPlainDateTime() returns a Temporal.PlainDateTime", () => {
-      const pdt1 = zdt1.toPlainDateTime();
-      expect(pdt1).toBeInstanceOf(Temporal.PlainDateTime);
-      expect(pdt1.toString()).toBe("2020-01-01T12:00:00");
-    });
-
-    it("toPlainTime() returns a Temporal.PlainTime", () => {
-      const pt1 = zdt1.toPlainTime();
-      expect(pt1).toBeInstanceOf(Temporal.PlainTime);
-      expect(pt1.toString()).toBe("12:00:00");
-    });
-
-    it("toString() returns an ISO string representation", () => {
-      const str = zdt1.toString();
-      expect(typeof str).toBe("string");
-      expect(str).toBe("2020-01-01T12:00:00+00:00[UTC]");
-    });
-
-    it("until() returns correct duration", () => {
-      const d = zdt1.until(zdt2);
-
-      expect(d.sign).toBe(1);
-      expect(d.years).toBe(0);
-      expect(d.months).toBe(0);
-      expect(d.days).toBe(0);
-      expect(d.hours).toBe(24);
-      expect(d.minutes).toBe(0);
-      expect(d.seconds).toBe(0);
-      expect(d.milliseconds).toBe(0);
-      expect(d.microseconds).toBe(0);
-      expect(d.nanoseconds).toBe(0);
-    });
-
-    it("valueOf() throws a TypeError", () => {
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        +zdt1;
-      }).toThrow();
-    });
-
-    it("with() method returns a new ZonedDateTime with updated fields", () => {
-      const updated = zdt1.with({ day: 15 });
-      expect(updated.day).toBe(15);
-      expect(updated.month).toBe(zdt1.month);
-    });
-
-    it("withTimeZone() method returns a new ZonedDateTime with replaceing timezone", () => {
-      const updated = zdt1.withTimeZone("Asia/Tokyo");
-      expect(updated.toString()).toBe("2020-01-01T21:00:00+09:00[Asia/Tokyo]");
+    it("Ambiguity after rounding", () => {
+      const zdt = Temporal.ZonedDateTime.from(
+        "2024-03-10T01:00:00-05:00[America/New_York]"
+      );
+      const rounded = zdt.round({ smallestUnit: "hour", roundingIncrement: 2 });
+      // The result is supposed to be 2024-03-10T02:00:00-05:00[America/New_York],
+      // but this time does not exist. `disambiguation: "compatible"` tells us to move
+      // forward by 1 hour.
+      expect(rounded.toString()).toBe(
+        "2024-03-10T03:00:00-04:00[America/New_York]"
+      );
     });
   });
 
-  describe("properties", () => {
-    const zdt = Temporal.ZonedDateTime.from("2020-01-01T12:00:00[UTC]");
+  describe("Temporal.ZonedDateTime.prototype.since()", () => {
+    it("Offset transitions", () => {
+      const start = Temporal.ZonedDateTime.from(
+        "2024-11-03T01:00:00-04:00[America/New_York]"
+      );
+      const end = Temporal.ZonedDateTime.from(
+        "2024-11-04T01:00:00-05:00[America/New_York]"
+      );
+      expect(end.since(start).toString()).toBe("PT25H");
+      expect(end.since(start, { largestUnit: "days" }).toString()).toBe("P1D"); // WebMDN's prediction of "PT1D" is probably wrong.
 
-    it("should have correct date and time properties", () => {
-      expect(zdt.year).toBe(2020);
-      expect(zdt.month).toBe(1);
-      expect(zdt.day).toBe(1);
-      expect(zdt.hour).toBe(12);
-      expect(zdt.minute).toBe(0);
-      expect(zdt.second).toBe(0);
-      expect(zdt.millisecond).toBe(0);
-      expect(zdt.offset).toBe("+00:00");
-
-      expect(typeof zdt.epochMilliseconds).toBe("number");
-      expect(zdt.epochMilliseconds).toBeGreaterThan(0);
-      expect(typeof zdt.epochNanoseconds).toBe("bigint");
-      expect(zdt.epochNanoseconds).toBeGreaterThan(0n);
-
-      expect(zdt.dayOfYear).toBe(1);
-      expect(zdt.daysInMonth).toBe(31);
-      expect(zdt.daysInYear).toBe(366);
-      expect(zdt.inLeapYear).toBe(true);
+      const start2 = Temporal.ZonedDateTime.from(
+        "2024-03-10T01:00:00-05:00[America/New_York]"
+      );
+      const end2 = Temporal.ZonedDateTime.from(
+        "2024-03-11T01:00:00-04:00[America/New_York]"
+      );
+      expect(end2.since(start2).toString()).toBe("PT23H");
+      expect(end2.since(start2, { largestUnit: "days" }).toString()).toBe(
+        "P1D"
+      ); // WebMDN's prediction of "PT1D" is probably wrong.
     });
 
-    it("has correct toStringTag", () => {
-      expect(Object.prototype.toString.call(zdt)).toBe(
-        "[object Temporal.ZonedDateTime]"
+    it("Different time zones", () => {
+      const start = Temporal.ZonedDateTime.from(
+        "2024-11-03T01:00:00-04:00[America/New_York]"
+      );
+      // Peru does not use DST so its offset remains -05:00 year-round
+      const end = Temporal.ZonedDateTime.from(
+        "2024-11-04T01:00:00-05:00[America/Lima]"
+      );
+
+      expect(end.since(start).toString()).toBe("PT25H");
+      expect(() => {
+        end.since(start, { largestUnit: "days" }); // RangeError: time zones "America/Lima" and "America/New_York" aren't compatible
+      }).toThrow();
+
+      expect(
+        end
+          .withTimeZone("America/New_York")
+          .since(start, { largestUnit: "days" })
+          .toString()
+      ).toBe("P1D");
+      expect(
+        end
+          .since(start.withTimeZone("America/Lima"), { largestUnit: "days" })
+          .toString()
+      ).toBe("P1DT1H"); // WebMDN's prediction of "P1D1H" is probably wrong.
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.subtract()", () => {
+    it("Subtracting a duration", () => {
+      const start = Temporal.ZonedDateTime.from(
+        "2021-01-01T12:34:56-05:00[America/New_York]"
+      );
+      const end = start.subtract({
+        years: 1,
+        months: 2,
+        weeks: 3,
+        days: 4,
+        hours: 5,
+        minutes: 6,
+        seconds: 7,
+        milliseconds: 8,
+      });
+      expect(end.toString()).toBe(
+        "2019-10-07T07:28:48.992-04:00[America/New_York]"
       );
     });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.toInstant()", () => {
+    it("Using toInstant()", () => {
+      const zdt = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56.987654321-04:00[America/New_York]"
+      );
+      const instant = zdt.toInstant();
+      expect(instant.toString()).toBe("2021-07-01T16:34:56.987654321Z");
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.toJSON()", () => {
+    it("Using toJSON()", () => {
+      const zdt = Temporal.ZonedDateTime.from({
+        year: 2021,
+        month: 8,
+        day: 1,
+        timeZone: "America/New_York",
+      });
+      const zdtStr = zdt.toJSON();
+      expect(zdtStr.toString()).toBe(
+        "2021-08-01T00:00:00-04:00[America/New_York]"
+      );
+      const zdt2 = Temporal.ZonedDateTime.from(zdtStr);
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.toPlainDate()", () => {
+    it("Using toPlainDate()", () => {
+      const zdt = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56.987654321-04:00[America/New_York]"
+      );
+      const plainDate = zdt.toPlainDate();
+      expect(plainDate.toString()).toBe("2021-07-01");
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.toPlainDateTime()", () => {
+    it("Using toPlainDateTime()", () => {
+      const zdt = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56.987654321-04:00[America/New_York]"
+      );
+      const plainDateTime = zdt.toPlainDateTime();
+      expect(plainDateTime.toString()).toBe("2021-07-01T12:34:56.987654321");
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.toPlainTime()", () => {
+    it("Using toPlainTime()", () => {
+      const zdt = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56.987654321-04:00[America/New_York]"
+      );
+      const plainTime = zdt.toPlainTime();
+      expect(plainTime.toString()).toBe("12:34:56.987654321");
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.toString()", () => {
+    it("Using toString()", () => {
+      const zdt = Temporal.ZonedDateTime.from(
+        "2021-08-01T12:34:56[America/New_York]"
+      );
+      expect(zdt.toString()).toBe(
+        "2021-08-01T12:34:56-04:00[America/New_York]"
+      );
+    });
+
+    it("Even for the UTC time zone, the offset is +00:00, not Z", () => {
+      const zdt = Temporal.ZonedDateTime.from("2021-08-01T12:34:56[UTC]");
+      expect(zdt.toString()).toBe("2021-08-01T12:34:56+00:00[UTC]");
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.until()", () => {
+    it("until() returns correct duration", () => {
+      const flight = Temporal.ZonedDateTime.from(
+        "2024-12-21T13:31:00-05:00[America/New_York]"
+      );
+      const now =
+        Temporal.Now.zonedDateTimeISO("America/New_York").round("second");
+      if (Temporal.ZonedDateTime.compare(flight, now) < 0) {
+        console.error(
+          "The flight is already in the past. The result may not make sense."
+        );
+      }
+      const duration = now.until(flight, { largestUnit: "days" });
+      expect(`The flight is in ${duration.toLocaleString("en-US")}`);
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.valueOf()", () => {
+    it("valueOf() throws a TypeError", () => {
+      const zdt1 = Temporal.ZonedDateTime.from(
+        "2022-01-01T00:00:00[America/New_York]"
+      );
+      const zdt2 = Temporal.ZonedDateTime.from(
+        "2022-07-01T00:00:00[America/New_York]"
+      );
+      expect(() => {
+        zdt1 > zdt2; // TypeError: can't convert ZonedDateTime to primitive type
+      }).toThrow();
+      expect(Temporal.ZonedDateTime.compare(zdt1, zdt2)).toBe(-1);
+
+      expect(() => {
+        zdt2 - zdt1; // TypeError: can't convert ZonedDateTime to primitive type
+      }).toThrow();
+      expect(zdt2.since(zdt1).toString()).toBe("PT4343H");
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.with()", () => {
+    it("Using with()", () => {
+      const zdt = Temporal.ZonedDateTime.from(
+        "2021-07-01T12:34:56[America/New_York]"
+      );
+      const newZDT = zdt.with({ hour: 13 });
+      expect(newZDT.toString()).toBe(
+        "2021-07-01T13:34:56-04:00[America/New_York]"
+      );
+    });
+
+    describe("Offset during date changes", () => {
+      it("By default", () => {
+        const zdt = Temporal.ZonedDateTime.from(
+          "2021-07-01T12:00:00-04:00[America/New_York]"
+        );
+        const newZDT = zdt.with({ month: 12 });
+        // The offset is recalculated to -05:00
+        expect(newZDT.toString()).toBe(
+          "2021-12-01T12:00:00-05:00[America/New_York]"
+        );
+      });
+
+      it("And if you set the time to within the DST transition, the offset is used to resolve the ambiguity", () => {
+        const zdt = Temporal.ZonedDateTime.from(
+          "2024-11-02T01:05:00-04:00[America/New_York]"
+        );
+        const newZDT = zdt.with({ day: 3 });
+        expect(newZDT.toString()).toBe(
+          "2024-11-03T01:05:00-04:00[America/New_York]"
+        );
+
+        const zdt2 = Temporal.ZonedDateTime.from(
+          "2024-11-04T01:05:00-05:00[America/New_York]"
+        );
+        const newZDT2 = zdt2.with({ day: 3 });
+        expect(newZDT2.toString()).toBe(
+          "2024-11-03T01:05:00-05:00[America/New_York]"
+        );
+      });
+
+      it.skip("If you use offset: `use`, then the offset will be used as-is to obtain the exact time first, and then recalculate the offset", () => {
+        const zdt = Temporal.ZonedDateTime.from(
+          "2021-07-01T12:00:00-04:00[America/New_York]"
+        );
+        const newZDT = zdt.with({ month: 12 }, { offset: "use" });
+        // The offset is recalculated to -05:00, but the wall-clock time changes
+        expect(newZDT.toString()).toBe(
+          "2021-12-01T11:00:00-05:00[America/New_York]"
+        );
+      });
+
+      it.skip("You can also set offset: `reject` to throw an error if the original offset is invalid, forcing an explicit new offset to be specified", () => {
+        const zdt = Temporal.ZonedDateTime.from(
+          "2021-07-01T12:00:00-04:00[America/New_York]"
+        );
+
+        expect(() => {
+          zdt.with({ month: 12 }, { offset: "reject" });
+          // RangeError: date-time can't be represented in the given time zone
+        }).toThrow();
+        expect(
+          zdt
+            .with({ month: 12, offset: "-05:00" }, { offset: "reject" })
+            .toString()
+        ).toBe("2021-12-01T12:00:00-05:00[America/New_York]");
+      });
+    });
+  });
+
+  describe("Temporal.ZonedDateTime.prototype.withTimeZone()", () => {
+    it("Using withTimeZone()", () => {
+      const meetingTime = Temporal.ZonedDateTime.from(
+        "2021-08-01T12:00[America/New_York]"
+      );
+      const meetingTimeInParis = meetingTime.withTimeZone("Europe/Paris");
+      expect(meetingTimeInParis.toString()).toBe(
+        "2021-08-01T18:00:00+02:00[Europe/Paris]"
+      );
+    });
+
+    it("Replacing the time zone while keeping the same wall-clock time", () => {
+      const meetingTime = Temporal.ZonedDateTime.from(
+        "2021-08-01T12:00[America/New_York]"
+      );
+      const meetingTimeInParis = meetingTime
+        .toPlainDateTime()
+        .toZonedDateTime("Europe/Paris");
+      expect(meetingTimeInParis.toString()).toBe(
+        "2021-08-01T12:00:00+02:00[Europe/Paris]"
+      );
+    });
+  });
+});
+
+describe("Instance properties", () => {
+  const zdt = Temporal.ZonedDateTime.from("2020-01-01T12:00:00[UTC]");
+
+  it("should have correct date and time properties", () => {
+    expect(zdt.year).toBe(2020);
+    expect(zdt.month).toBe(1);
+    expect(zdt.day).toBe(1);
+    expect(zdt.hour).toBe(12);
+    expect(zdt.minute).toBe(0);
+    expect(zdt.second).toBe(0);
+    expect(zdt.millisecond).toBe(0);
+    expect(zdt.offset).toBe("+00:00");
+
+    expect(typeof zdt.epochMilliseconds).toBe("number");
+    expect(zdt.epochMilliseconds).toBeGreaterThan(0);
+    expect(typeof zdt.epochNanoseconds).toBe("bigint");
+    expect(zdt.epochNanoseconds).toBeGreaterThan(0n);
+
+    expect(zdt.dayOfYear).toBe(1);
+    expect(zdt.daysInMonth).toBe(31);
+    expect(zdt.daysInYear).toBe(366);
+    expect(zdt.inLeapYear).toBe(true);
+  });
+
+  it("has correct toStringTag", () => {
+    expect(Object.prototype.toString.call(zdt)).toBe(
+      "[object Temporal.ZonedDateTime]"
+    );
   });
 });


### PR DESCRIPTION
### Issue # (if available)

Related #1416 

### Description of changes

We made several improvements, including actively incorporating MDN (Temporal.Instant) use cases into our test cases.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime

- equals(): Time zone detection was missing.
- since(), until(): Added support for options.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
