### PR TITLE
chore(deps): bump rquickjs from `5dcebf0` to `6083f92`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "rquickjs"
 version = "0.11.0"
-source = "git+https://github.com/DelSkayn/rquickjs#5dcebf0e1e4f242de4b98208c328bf69eb4ac1e6"
+source = "git+https://github.com/DelSkayn/rquickjs#6083f9287179e67fb939802d1fc084ff589faf3b"
 dependencies = [
  "either",
  "rquickjs-core",
@@ -2934,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "rquickjs-core"
 version = "0.11.0"
-source = "git+https://github.com/DelSkayn/rquickjs#5dcebf0e1e4f242de4b98208c328bf69eb4ac1e6"
+source = "git+https://github.com/DelSkayn/rquickjs#6083f9287179e67fb939802d1fc084ff589faf3b"
 dependencies = [
  "async-lock",
  "either",
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "rquickjs-macro"
 version = "0.11.0"
-source = "git+https://github.com/DelSkayn/rquickjs#5dcebf0e1e4f242de4b98208c328bf69eb4ac1e6"
+source = "git+https://github.com/DelSkayn/rquickjs#6083f9287179e67fb939802d1fc084ff589faf3b"
 dependencies = [
  "convert_case",
  "fnv",
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "rquickjs-sys"
 version = "0.11.0"
-source = "git+https://github.com/DelSkayn/rquickjs#5dcebf0e1e4f242de4b98208c328bf69eb4ac1e6"
+source = "git+https://github.com/DelSkayn/rquickjs#6083f9287179e67fb939802d1fc084ff589faf3b"
 dependencies = [
  "bindgen",
  "cc",

--- a/modules/llrt_stream_web/src/queuing_strategy/mod.rs
+++ b/modules/llrt_stream_web/src/queuing_strategy/mod.rs
@@ -177,8 +177,6 @@ pub(super) enum NativeSizeFunction {
 impl<'js> JsClass<'js> for NativeSizeFunction {
     const NAME: &'static str = "NativeSizeFunction";
 
-    const CALLABLE: bool = true;
-
     type Mutable = Readable;
 
     fn prototype(ctx: &Ctx<'js>) -> Result<Option<Object<'js>>> {


### PR DESCRIPTION
### Issue # (if available)

Fixed #1531 

### Description of changes

- Fixed inconsistencies occurring with cargo clippy.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
