### PR TITLE
fix(lambda): drop error type prefix from errorMessage to match Node.js shape (#1519)

### DIFF
--- a/llrt_core/src/runtime_client.rs
+++ b/llrt_core/src/runtime_client.rs
@@ -495,10 +495,12 @@ async fn post_error<'js>(
                 .unwrap_or(None)
                 .unwrap_or(String::from("Error"));
 
-            let mut str = String::with_capacity(100);
-            str.push_str(&error_name);
-            str.push_str(": ");
-            str.push_str(&ex.message().unwrap_or_default());
+            // Node's Lambda runtime exposes the error class as `errorType`
+            // and the bare message as `errorMessage`. Previously the message
+            // was prefixed with "{name}: " which broke parsers expecting the
+            // Node shape (#1519). Set errorType separately and use only the
+            // message text here.
+            let message = ex.message().unwrap_or_default();
 
             error_type = Some(error_name);
 
@@ -506,7 +508,7 @@ async fn post_error<'js>(
                 replace_newline_with_carriage_return(&mut stack);
                 error_stack = Some(stack);
             }
-            str
+            message
         },
         CaughtError::Value(value) => {
             let log_msg = format_values(ctx, Rest(vec![value.clone()]), false, true)

--- a/llrt_core/src/runtime_client.rs
+++ b/llrt_core/src/runtime_client.rs
@@ -495,11 +495,6 @@ async fn post_error<'js>(
                 .unwrap_or(None)
                 .unwrap_or(String::from("Error"));
 
-            // Node's Lambda runtime exposes the error class as `errorType`
-            // and the bare message as `errorMessage`. Previously the message
-            // was prefixed with "{name}: " which broke parsers expecting the
-            // Node shape (#1519). Set errorType separately and use only the
-            // message text here.
             let message = ex.message().unwrap_or_default();
 
             error_type = Some(error_name);


### PR DESCRIPTION
### Issue # (if available)

Closes #1519.

### Description of changes

`post_error` in `llrt_core/src/runtime_client.rs` was constructing the Lambda `errorMessage` as `"{className}: {message}"`. Node's Lambda runtime exposes the class as `errorType` separately and sends only the bare message in `errorMessage`, so parsers expecting the Node shape broke under LLRT.

Drops the prefix from the message: `errorType` continues to receive the class name and `errorMessage` is now `ex.message()`. The `Error`/`Value` arms already prefix `"Error: "` for value-style throws, left those untouched as they don't have a class name to redundantly include.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

No unit tests in this file today; the bug repro is the exact two snippets in the issue (one Node, one LLRT). Locally rust-syntax-checks cleanly; full `cargo check` is blocked by the compression-dictionary build script which is unrelated to this diff.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
