### PR TITLE
fix: CRC Blob string hasher

### DIFF
--- a/shims/string-hasher.js
+++ b/shims/string-hasher.js
@@ -4,7 +4,7 @@ export const stringHasher = async (checksumAlgorithmFn, body) => {
 
   if (body instanceof Blob) {
     const arrayBuffer = await body.arrayBuffer();
-    hash.update(arrayBuffer);
+    hash.update(new Uint8Array(arrayBuffer));
   } else {
     hash.update(toUint8Array(body || ""));
   }

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -227,3 +227,36 @@ describe("random", () => {
     );
   });
 });
+
+describe("string-hasher shim", () => {
+  // Mirrors shims/string-hasher.js
+  const stringHasher = async (checksumAlgorithmFn: any, body: any) => {
+    const hash = new checksumAlgorithmFn();
+    if (body instanceof Blob) {
+      hash.update(new Uint8Array(await body.arrayBuffer()));
+    } else {
+      hash.update(body);
+    }
+    return hash.digest();
+  };
+
+  class SumHasher {
+    sum = 0;
+    update(data: any) {
+      for (let i = 0; i < data.length; i++)
+        this.sum = (this.sum + data[i]) & 0xff;
+    }
+    digest() {
+      return this.sum;
+    }
+  }
+
+  it("hashes a Blob body to the same digest as the raw bytes", async () => {
+    const bytes = new TextEncoder().encode("hello world checksum test");
+    const expected = await stringHasher(SumHasher, bytes);
+    const fromBlob = await stringHasher(SumHasher, new Blob([bytes]));
+
+    expect(fromBlob).toEqual(expected);
+    expect(fromBlob).not.toEqual(0); // would be 0 with the old ArrayBuffer bug
+  });
+});


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/1511

### Description of changes

Missing Uint8Array wrap produces invalid checksums

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
