### PR TITLE
fix(fetch): reject connection failures with TypeError: Failed to fetch

### DIFF
--- a/modules/llrt_fetch/src/fetch.rs
+++ b/modules/llrt_fetch/src/fetch.rs
@@ -310,7 +310,10 @@ async fn dispatch<'js>(
             reason = abort_receiver.recv() => Err(ctx.throw(reason)),
         }
     } else {
-        client.request(req).await.map_err(|e| throw_fetch_failed(ctx, e))
+        client
+            .request(req)
+            .await
+            .map_err(|e| throw_fetch_failed(ctx, e))
     }
 }
 

--- a/modules/llrt_fetch/src/fetch.rs
+++ b/modules/llrt_fetch/src/fetch.rs
@@ -16,7 +16,13 @@ use llrt_encoding::bytes_from_b64;
 use llrt_http::Agent;
 use llrt_http::HyperClient;
 use llrt_stream_web::ReadableStream;
-use llrt_utils::{bytes::ObjectBytes, mc_oneshot, result::ResultExt, VERSION};
+use llrt_utils::{
+    bytes::ObjectBytes,
+    mc_oneshot,
+    primordials::{BasePrimordials, Primordial},
+    result::ResultExt,
+    VERSION,
+};
 use percent_encoding::percent_decode_str;
 use rquickjs::{
     atom::PredefinedAtom,
@@ -300,12 +306,32 @@ async fn dispatch<'js>(
 ) -> Result<hyper::Response<hyper::body::Incoming>> {
     if let Some(abort_receiver) = abort_receiver {
         select! {
-            res = client.request(req) => res.or_throw_type(ctx, "Fetch failed"),
+            res = client.request(req) => res.map_err(|e| throw_fetch_failed(ctx, e)),
             reason = abort_receiver.recv() => Err(ctx.throw(reason)),
         }
     } else {
-        client.request(req).await.or_throw_type(ctx, "Fetch failed")
+        client.request(req).await.map_err(|e| throw_fetch_failed(ctx, e))
     }
+}
+
+// Per WHATWG Fetch, a network/connection failure rejects with exactly
+// `TypeError: Failed to fetch`. The AWS SDK retry classifier
+// (@smithy/service-error-classification) only retries a TypeError whose
+// `message` matches that string exactly (and `instanceof TypeError`), so we
+// build a real TypeError and attach the hyper error as `cause` for diagnostics.
+fn throw_fetch_failed(ctx: &Ctx<'_>, err: impl std::fmt::Display) -> rquickjs::Error {
+    match new_type_error(ctx, err) {
+        Ok(value) => ctx.throw(value),
+        Err(_) => Exception::throw_type(ctx, "Failed to fetch"),
+    }
+}
+
+fn new_type_error<'js>(ctx: &Ctx<'js>, err: impl std::fmt::Display) -> Result<Value<'js>> {
+    let obj: Object = BasePrimordials::get(ctx)?
+        .constructor_type_error
+        .construct(("Failed to fetch",))?;
+    obj.set("cause", err.to_string())?;
+    Ok(obj.into_value())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/tests/unit/fetch.test.ts
+++ b/tests/unit/fetch.test.ts
@@ -152,6 +152,23 @@ describe("fetch", () => {
     await Promise.all(new Array(10).fill(0).map(() => fetch(url)));
   });
 
+  // Regression test for https://github.com/awslabs/llrt/issues/1482:
+  // a connection failure must reject with exactly `TypeError: Failed to fetch`
+  // so the AWS SDK retry middleware classifies it as a transient error.
+  it("should reject connection failures with TypeError: Failed to fetch", async () => {
+    // Port 65000 is unused, so the connection is refused immediately.
+    await expect(fetch("http://127.0.0.1:65000")).rejects.toThrow(
+      new TypeError("Failed to fetch")
+    );
+    try {
+      await fetch("http://127.0.0.1:65000");
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.message).toEqual("Failed to fetch");
+      expect(err.cause).toBeDefined(); // underlying error preserved for diagnostics
+    }
+  });
+
   it("is not allowed to fetch", async () => {
     const deniedUrl = new URL("https://www.amazon.com");
     const { stdout, stderr } = await spawnAndCollectOutput(deniedUrl, {


### PR DESCRIPTION
### Issue # (if available)

Fixes #1482

### Description of changes

Network/connection failures threw "Fetch failed" with the underlying hyper error appended. The AWS SDK retry classifier only treats a TypeError as a retryable transient error when its message is exactly "Failed to fetch", so SNS (and other SDK) calls were not retried (attempts: 1), ignoring the configured retry policy.

Throw exactly TypeError: Failed to fetch on connection failure, matching the WHATWG Fetch spec, so the SDK retries transient errors.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
