### PR TITLE
fix: Windows openssl test linking on windows-2025 runner

### DIFF
--- a/.github/workflows/build-modules.yml
+++ b/.github/workflows/build-modules.yml
@@ -52,6 +52,14 @@ jobs:
           echo "OPENSSL_DIR=D:/a/_temp/msys64/mingw64" >> $GITHUB_ENV
           echo "OPENSSL_LIB_DIR=D:/a/_temp/msys64/mingw64/lib" >> $GITHUB_ENV
           echo "OPENSSL_INCLUDE_DIR=D:/a/_temp/msys64/mingw64/include" >> $GITHUB_ENV
+          # Put the MSYS2 mingw64 toolchain first on PATH so the linker driver
+          # (x86_64-w64-mingw32-gcc), its crt2.o, and the openssl libs in
+          # OPENSSL_LIB_DIR all come from the same mingw-w64 runtime. Otherwise the
+          # cargo steps (run in Git Bash) pick up the runner's preinstalled
+          # C:\mingw64 gcc, whose crt2.o references _gnu_exception_handler /
+          # __mingw_oldexcpt_handler symbols that are absent from the MSYS2
+          # libmingw32/libmingwex pulled in via OPENSSL_LIB_DIR, breaking the link.
+          echo "D:/a/_temp/msys64/mingw64/bin" >> $GITHUB_PATH
       - name: Map crypto feature to TLS and crypto features
         id: features
         shell: bash


### PR DESCRIPTION
### Issue # (if available)

N/A

### Description of changes

It's a mingw-w64 toolchain mismatch surfaced by the new `windows-2025` runner image (the run also warns `windows-latest` is being redirected to `windows-2025-vs2026`):

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
