### PR TITLE
chore: bump phf and phf_codegen to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,9 +2621,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2631,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+checksum = "41b585a510fb76fdebead6897982ef2a03a21d8e6cbcca904999742a4afc6ffe"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2641,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -2651,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2664,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]

--- a/libs/llrt_encoding/Cargo.toml
+++ b/libs/llrt_encoding/Cargo.toml
@@ -11,7 +11,7 @@ base64-simd = { version = "0.8", features = [
     "alloc",
 ], default-features = false }
 hex-simd = { version = "0.8", features = ["alloc"], default-features = false }
-phf = { version = "0.13", features = ["macros"], default-features = false }
+phf = { version = "0.14", features = ["macros"], default-features = false }
 memchr = { version = "2", default-features = false }
 
 [build-dependencies]

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -49,7 +49,7 @@ llrt_modules = { path = "../llrt_modules", default-features = false, features = 
 llrt_numbers = { path = "../libs/llrt_numbers" }
 llrt_utils = { path = "../libs/llrt_utils", features = ["all"] }
 once_cell = { version = "1", features = ["std"], default-features = false }
-phf = { version = "0.13", default-features = false }
+phf = { version = "0.14", default-features = false }
 quick-xml = { version = "0.40", default-features = false }
 rand = { version = "0.10.1", features = [
   "alloc",
@@ -77,7 +77,7 @@ md-5 = { version = "0.11.0", default-features = false }
 
 [build-dependencies]
 rquickjs = { version = "0.12", default-features = false }
-phf_codegen = { version = "0.13", default-features = false }
+phf_codegen = { version = "0.14", default-features = false }
 llrt_build = { path = "../libs/llrt_build" }
 uuid = { version = "1", features = ["v4"], default-features = false }
 walkdir = { version = "2", default-features = false }


### PR DESCRIPTION
### Description of changes

BUMP dip

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
