### PR TITLE
fix: throw when constructing a Request with an empty-string URL

### DIFF
--- a/modules/llrt_fetch/src/request.rs
+++ b/modules/llrt_fetch/src/request.rs
@@ -134,14 +134,15 @@ impl<'js> Request<'js> {
         if input.is_string() {
             let s: String = input.get()?;
             // Validate as a URL; accept relative URLs against a generic base.
-            if !s.is_empty() {
-                let base = url::Url::parse("http://llrt.local/").expect("static base URL");
-                let parsed = base
-                    .join(&s)
-                    .map_err(|_| Exception::throw_type(&ctx, "Invalid URL"))?;
-                if !parsed.username().is_empty() || parsed.password().is_some() {
-                    return Err(Exception::throw_type(&ctx, "URL must not have credentials"));
-                }
+            if s.is_empty() {
+                return Err(Exception::throw_type(&ctx, "Invalid URL"));
+            }
+            let base = url::Url::parse("http://llrt.local/").expect("static base URL");
+            let parsed = base
+                .join(&s)
+                .map_err(|_| Exception::throw_type(&ctx, "Invalid URL"))?;
+            if !parsed.username().is_empty() || parsed.password().is_some() {
+                return Err(Exception::throw_type(&ctx, "URL must not have credentials"));
             }
             request.url = s;
         } else if let Ok(url) = URL::from_js(&ctx, input.clone()) {

--- a/tests/unit/fetch.request.test.ts
+++ b/tests/unit/fetch.request.test.ts
@@ -170,6 +170,12 @@ describe("Request class", () => {
     expect(request instanceof Request).toBeTruthy();
   });
 
+  it("should throw when constructed with an empty-string URL", () => {
+    expect(() => {
+      new Request("");
+    }).toThrow();
+  });
+
   // ── Body with GET/HEAD should throw ──
 
   it("should throw when body is set with GET method", () => {


### PR DESCRIPTION
### Issue # (if available)

Fixes #1621

### Description of changes

`new Request("")` was silently accepted instead of throwing. The string branch of the `Request` constructor skipped URL validation whenever the input was empty (`if !s.is_empty()`), so an empty string fell straight through into `request.url`. Node, Bun, and Deno all reject an empty-string URL with a `TypeError`.

Removing the guard alone wouldn't fix it: `Url::join("")` resolves to the base URL rather than failing, so an empty input would still pass. This change instead rejects an empty string explicitly with a `TypeError` ("Invalid URL") before attempting to parse, and always runs the existing URL/credentials validation for non-empty inputs.

Added a unit test in `tests/unit/fetch.request.test.ts` covering `new Request("")` throwing.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
