### PR TITLE
ci: fail the release if the tag doesn't match the crate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,22 @@ on:
       - "v*.*.*"
 
 jobs:
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify tag matches crate version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          crate="$(grep -m1 '^version' llrt/Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
+          echo "Tag version:   $tag"
+          echo "Crate version: $crate"
+          if [ "$tag" != "$crate" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match crate version $crate in llrt/Cargo.toml. Bump the version before tagging the release."
+            exit 1
+          fi
   build:
+    needs: verify-version
     strategy:
       fail-fast: ${{ startsWith(github.ref, 'refs/tags/') }}
       matrix:


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/awslabs/llrt/issues/1614

### Description of changes

The `v0.8.1-beta` Linux x64 release assets reported `LLRT v0.8.0-beta` because the `v0.8.1-beta` tag was created on a commit whose `Cargo.toml` files still said `0.8.0-beta`. The version is baked in at compile time via `env!("CARGO_PKG_VERSION")`, so the binaries built from that tag carried the stale version. The current `main` already has the version bumped to `0.8.1-beta`, so there's nothing wrong in the source today — this change adds a guard so the mismatch can't ship again.

Adds a `verify-version` job to the release workflow that compares the pushed tag (e.g. `v0.8.1-beta`) against the version in `llrt/Cargo.toml` and fails the release before anything is built or published if they don't match. The `build` job now depends on it.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
