### PR TITLE
feat(fetch): Add WPT tests and improve FormData compatibility

### DIFF
--- a/libs/llrt_utils/src/class.rs
+++ b/libs/llrt_utils/src/class.rs
@@ -13,18 +13,65 @@ use super::{
 
 pub static CUSTOM_INSPECT_SYMBOL_DESCRIPTION: &str = "llrt.inspect.custom";
 
-pub trait IteratorDef<'js>
-where
-    Self: 'js + JsClass<'js> + Sized,
-{
-    fn js_entries(&self, ctx: Ctx<'js>) -> Result<Array<'js>>;
+/// Which view an iterator yields: `keys()`, `values()`, or `entries()`.
+#[derive(Clone, Copy)]
+pub enum IterKind {
+    Keys,
+    Values,
+    Entries,
+}
 
-    fn js_iterator(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        let value = self.js_entries(ctx)?;
-        let obj = value.as_object();
-        let values_fn: Function = obj.get(PredefinedAtom::Values)?;
-        values_fn.call((This(value),))
+/// Wrap an entry into a `{ value, done }` iterator result. `None` means done.
+pub fn iterator_result<'js>(
+    ctx: &Ctx<'js>,
+    kind: IterKind,
+    entry: Option<(Value<'js>, Value<'js>)>,
+) -> Result<Object<'js>> {
+    let obj = Object::new(ctx.clone())?;
+    match entry {
+        Some((key, value)) => {
+            obj.set(PredefinedAtom::Done, false)?;
+            match kind {
+                IterKind::Keys => obj.set(PredefinedAtom::Value, key)?,
+                IterKind::Values => obj.set(PredefinedAtom::Value, value)?,
+                IterKind::Entries => {
+                    let entry = Array::new(ctx.clone())?;
+                    entry.set(0, key)?;
+                    entry.set(1, value)?;
+                    obj.set(PredefinedAtom::Value, entry)?;
+                },
+            }
+        },
+        None => obj.set(PredefinedAtom::Done, true)?,
     }
+    Ok(obj)
+}
+
+/// Create a WebIDL iterator instance, wiring its prototype the first time:
+/// the prototype inherits `%IteratorPrototype%` (so it's tagged
+/// `[object Iterator]`) and `next` becomes enumerable. Idempotent — later
+/// calls skip the setup — so callers just build iterators and never register
+/// anything separately.
+pub fn live_iterator<'js, C>(ctx: &Ctx<'js>, iter: C) -> Result<Class<'js, C>>
+where
+    C: JsClass<'js> + 'js,
+{
+    let instance = Class::<C>::instance(ctx.clone(), iter)?;
+    if let Some(proto) = Class::<C>::prototype(ctx)? {
+        let iterator_proto = &BasePrimordials::get(ctx)?.prototype_iterator;
+        if proto.get_prototype().as_ref() != Some(iterator_proto) {
+            proto.set_prototype(Some(iterator_proto))?;
+            let next_fn: Function = proto.get("next")?;
+            proto.prop(
+                "next",
+                Property::from(next_fn)
+                    .writable()
+                    .enumerable()
+                    .configurable(),
+            )?;
+        }
+    }
+    Ok(instance)
 }
 
 pub fn get_class_name(value: &Value) -> Result<Option<String>> {
@@ -71,42 +118,6 @@ where
             proto.prop(
                 custom_inspect_symbol,
                 Accessor::from(|this: This<Class<'js, C>>, ctx| this.borrow().custom_inspect(ctx)),
-            )?;
-        }
-        Ok(())
-    }
-}
-
-/// Register a class as a WebIDL pair iterator: registers it on the globals,
-/// removes the constructor (it's not exposed to JS), wires its prototype to
-/// inherit from `%IteratorPrototype%` (so it's iterable and stringifies as
-/// `[object Iterator]`), and re-defines `next` as enumerable per WebIDL.
-///
-/// The class must declare a `next(&mut self, ctx) -> Result<Object>` method
-/// via `#[rquickjs::methods]`.
-pub trait WebIdlIteratorExtension<'js> {
-    fn define_as_webidl_iterator(globals: &Object<'js>, name: &str) -> Result<()>;
-}
-
-impl<'js, C> WebIdlIteratorExtension<'js> for Class<'js, C>
-where
-    C: JsClass<'js> + 'js,
-{
-    fn define_as_webidl_iterator(globals: &Object<'js>, name: &str) -> Result<()> {
-        let ctx = globals.ctx();
-        Self::define(globals)?;
-        // Iterator class is not exposed to JS.
-        globals.remove(name)?;
-        if let Some(proto) = Class::<C>::prototype(ctx)? {
-            let iterator_proto = BasePrimordials::get(ctx)?.prototype_iterator.clone();
-            proto.set_prototype(Some(&iterator_proto))?;
-            let next_fn: Function = proto.get("next")?;
-            proto.prop(
-                "next",
-                Property::from(next_fn)
-                    .writable()
-                    .enumerable()
-                    .configurable(),
             )?;
         }
         Ok(())

--- a/libs/llrt_utils/src/object.rs
+++ b/libs/llrt_utils/src/object.rs
@@ -123,23 +123,6 @@ impl<'js> Proxy<'js> {
     }
 }
 
-pub fn map_to_entries<'js, K, V, M>(ctx: &Ctx<'js>, map: M) -> Result<Array<'js>>
-where
-    M: IntoIterator<Item = (K, V)>,
-    K: IntoJs<'js>,
-    V: IntoJs<'js>,
-{
-    let array = Array::new(ctx.clone())?;
-    for (idx, (key, value)) in map.into_iter().enumerate() {
-        let entry = Array::new(ctx.clone())?;
-        entry.set(0, key)?;
-        entry.set(1, value)?;
-        array.set(idx, entry)?;
-    }
-
-    Ok(array)
-}
-
 pub fn array_to_btree_map<'js>(
     ctx: &Ctx<'js>,
     array: Array<'js>,

--- a/modules/llrt_buffer/src/file.rs
+++ b/modules/llrt_buffer/src/file.rs
@@ -106,13 +106,7 @@ impl<'js> File<'js> {
     ) -> Result<Self> {
         let options = Opt(Some({
             let obj = Object::new(ctx.clone())?;
-            obj.set(
-                "type",
-                mime_type
-                    .clone()
-                    .unwrap_or("application/octet-stream".into())
-                    .into_js(ctx)?,
-            )?;
+            obj.set("type", mime_type.clone().unwrap_or("".into()).into_js(ctx)?)?;
             obj.into_js(ctx)?
         }));
         let blob = Blob::new(ctx.clone(), Opt(Some(data.into_js(ctx)?)), options)?;
@@ -126,5 +120,9 @@ impl<'js> File<'js> {
 
     pub fn get_blob(&self) -> Blob<'js> {
         self.blob.clone()
+    }
+
+    pub fn set_filename(&mut self, filename: String) {
+        self.filename = filename;
     }
 }

--- a/modules/llrt_fetch/src/form_data.rs
+++ b/modules/llrt_fetch/src/form_data.rs
@@ -4,17 +4,15 @@ use std::{cell::RefCell, io::Write, rc::Rc};
 
 use hyper::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use llrt_buffer::{Blob, File};
-use llrt_utils::{class::CustomInspect, result::ResultExt};
+use llrt_utils::{class::CustomInspect, object::map_to_entries, result::ResultExt};
 use rand::RngExt;
 use rquickjs::{
     atom::PredefinedAtom,
     class::{Trace, Tracer},
     prelude::{Opt, This},
-    Array, Class, Coerced, Ctx, Exception, FromJs, Function, IntoJs, JsLifetime, Object, Result,
+    Class, Coerced, Ctx, Exception, FromJs, Function, IntoJs, Iterable, JsLifetime, Object, Result,
     Type, Value,
 };
-
-use crate::IteratorKind;
 
 #[derive(Clone, Trace, JsLifetime)]
 enum FormValue<'js> {
@@ -145,33 +143,42 @@ impl<'js> FormData<'js> {
         self.entries.borrow_mut().retain(|(k, _)| *k != name);
         Ok(())
     }
-    pub fn keys(
-        this: This<Class<'js, FormData<'js>>>,
-        ctx: Ctx<'js>,
-    ) -> Result<Class<'js, FormDataIter<'js>>> {
-        FormDataIter::create(&ctx, this.0, IteratorKind::Keys)
+
+    pub fn keys(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        let keys: Vec<String> = self
+            .entries
+            .borrow()
+            .iter()
+            .map(|(k, _)| k.clone())
+            .collect();
+
+        Iterable::from(keys).into_js(&ctx)
     }
 
-    pub fn values(
-        this: This<Class<'js, FormData<'js>>>,
-        ctx: Ctx<'js>,
-    ) -> Result<Class<'js, FormDataIter<'js>>> {
-        FormDataIter::create(&ctx, this.0, IteratorKind::Values)
+    pub fn values(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        let values: Vec<FormValue<'js>> = self
+            .entries
+            .borrow()
+            .iter()
+            .map(|(_, v)| v.clone())
+            .collect();
+
+        Iterable::from(values).into_js(&ctx)
     }
 
-    pub fn entries(
-        this: This<Class<'js, FormData<'js>>>,
-        ctx: Ctx<'js>,
-    ) -> Result<Class<'js, FormDataIter<'js>>> {
-        FormDataIter::create(&ctx, this.0, IteratorKind::Entries)
+    pub fn entries(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        let entries = self.entries.borrow();
+        let array = map_to_entries(&ctx, entries.0.clone())?;
+
+        Iterable::from(array).into_js(&ctx)
     }
 
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
-    pub fn iterator(
-        this: This<Class<'js, FormData<'js>>>,
-        ctx: Ctx<'js>,
-    ) -> Result<Class<'js, FormDataIter<'js>>> {
-        FormDataIter::create(&ctx, this.0, IteratorKind::Entries)
+    pub fn iterator(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
+        let entries = self.entries.borrow();
+        let array = map_to_entries(&ctx, entries.0.clone())?;
+
+        Iterable::from(array).into_js(&ctx)
     }
 
     pub fn for_each(this: This<Class<'js, FormData<'js>>>, callback: Function<'js>) -> Result<()> {
@@ -371,55 +378,6 @@ fn generate_boundary() -> String {
 fn starts_with_ignore_case(haystack: &str, needle: &str) -> bool {
     haystack.len() >= needle.len()
         && haystack.as_bytes()[..needle.len()].eq_ignore_ascii_case(needle.as_bytes())
-}
-
-#[derive(Trace, JsLifetime)]
-#[rquickjs::class]
-pub struct FormDataIter<'js> {
-    fd: Class<'js, FormData<'js>>,
-    #[qjs(skip_trace)]
-    index: usize,
-    #[qjs(skip_trace)]
-    kind: IteratorKind,
-}
-
-#[rquickjs::methods]
-impl<'js> FormDataIter<'js> {
-    fn next(&mut self, ctx: Ctx<'js>) -> Result<Object<'js>> {
-        let obj = Object::new(ctx.clone())?;
-        // Re-read on every next() — WPT expects the iterator to observe
-        // mutations made during iteration (insertions, deletions).
-        let sorted = self.fd.borrow().iter();
-
-        if self.index < sorted.len() {
-            let (k, v) = &sorted[self.index];
-            self.index += 1;
-            obj.set("done", false)?;
-            match self.kind {
-                IteratorKind::Keys => obj.set("value", k)?,
-                IteratorKind::Values => obj.set("value", v.clone().into_js(&ctx)?)?,
-                IteratorKind::Entries => {
-                    let entry = Array::new(ctx.clone())?;
-                    entry.set(0, k)?;
-                    entry.set(1, v.clone().into_js(&ctx)?)?;
-                    obj.set("value", entry)?;
-                },
-            }
-        } else {
-            obj.set("done", true)?;
-        }
-        Ok(obj)
-    }
-}
-
-impl<'js> FormDataIter<'js> {
-    fn create(
-        ctx: &Ctx<'js>,
-        fd: Class<'js, FormData<'js>>,
-        kind: IteratorKind,
-    ) -> Result<Class<'js, Self>> {
-        Class::instance(ctx.clone(), Self { fd, index: 0, kind })
-    }
 }
 
 impl<'js> CustomInspect<'js> for FormData<'js> {

--- a/modules/llrt_fetch/src/form_data.rs
+++ b/modules/llrt_fetch/src/form_data.rs
@@ -4,20 +4,22 @@ use std::{cell::RefCell, io::Write, rc::Rc};
 
 use hyper::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use llrt_buffer::{Blob, File};
-use llrt_utils::{class::IteratorDef, object::map_to_entries, result::ResultExt};
+use llrt_utils::{class::CustomInspect, result::ResultExt};
 use rand::RngExt;
 use rquickjs::{
     atom::PredefinedAtom,
     class::{Trace, Tracer},
-    prelude::Opt,
-    Array, Class, Ctx, Exception, Function, IntoJs, JsLifetime, Result, Value,
+    prelude::{Opt, This},
+    Array, Class, Coerced, Ctx, Exception, FromJs, Function, IntoJs, JsLifetime, Object, Result,
+    Type, Value,
 };
+
+use crate::IteratorKind;
 
 #[derive(Clone, Trace, JsLifetime)]
 enum FormValue<'js> {
     Text(String),
-    File(File<'js>),
-    Blob(Blob<'js>),
+    File(Value<'js>),
 }
 
 impl<'js> IntoJs<'js> for FormValue<'js> {
@@ -25,7 +27,6 @@ impl<'js> IntoJs<'js> for FormValue<'js> {
         match self {
             FormValue::Text(s) => s.into_js(ctx),
             FormValue::File(f) => f.into_js(ctx),
-            FormValue::Blob(b) => b.into_js(ctx),
         }
     }
 }
@@ -70,37 +71,40 @@ impl<'js> Trace<'js> for FormData<'js> {
     }
 }
 
-impl<'js> IteratorDef<'js> for FormData<'js> {
-    fn js_entries(&self, ctx: Ctx<'js>) -> Result<Array<'js>> {
-        let entries = self.entries.borrow();
-        map_to_entries(&ctx, entries.0.clone())
-    }
-}
-
 #[rquickjs::methods(rename_all = "camelCase")]
 impl<'js> FormData<'js> {
     #[qjs(constructor)]
-    pub fn new(_form: Opt<Value<'js>>, _submitter: Opt<Value<'js>>) -> Self {
-        Self::default()
+    pub fn new(ctx: Ctx<'js>, form: Opt<Value<'js>>, _submitter: Opt<Value<'js>>) -> Result<Self> {
+        if let Some(obj) = form.0 {
+            if matches!(obj.type_of(), Type::Null | Type::String) {
+                return Err(Exception::throw_type(&ctx, "Invalid type"));
+            };
+        }
+        Ok(Self::default())
     }
 
-    pub fn append(&self, ctx: Ctx<'js>, name: String, value: Value<'js>) -> Result<()> {
-        let entry = value_to_form_entry(&ctx, name, value)?;
+    pub fn append(
+        &self,
+        ctx: Ctx<'js>,
+        name: String,
+        value: Value<'js>,
+        filename: Opt<String>,
+    ) -> Result<()> {
+        let entry = value_to_form_entry(&ctx, name, value, filename)?;
         self.entries.borrow_mut().push(entry);
         Ok(())
     }
 
-    pub fn get(&self, ctx: Ctx<'js>, name: String) -> Result<Option<Value<'js>>> {
+    pub fn get(&self, ctx: Ctx<'js>, name: String) -> Result<Value<'js>> {
         let value = self
             .entries
             .borrow()
             .iter()
-            .rev()
             .find(|(k, _)| *k == name)
             .map(|(_, v)| v.clone());
         match value {
-            Some(v) => Ok(v.into_js(&ctx).ok()),
-            None => Ok(None),
+            Some(v) => v.into_js(&ctx),
+            None => Ok(Value::new_null(ctx)),
         }
     }
 
@@ -123,8 +127,14 @@ impl<'js> FormData<'js> {
         Ok(entries.iter().any(|(n, _)| n == &name))
     }
 
-    pub fn set(&self, ctx: Ctx<'js>, name: String, value: Value<'js>) -> Result<()> {
-        let entry = value_to_form_entry(&ctx, name, value)?;
+    pub fn set(
+        &self,
+        ctx: Ctx<'js>,
+        name: String,
+        value: Value<'js>,
+        filename: Opt<String>,
+    ) -> Result<()> {
+        let entry = value_to_form_entry(&ctx, name, value, filename)?;
         let mut entries = self.entries.borrow_mut();
         entries.retain(|(k, _)| *k != entry.0);
         entries.push(entry);
@@ -135,43 +145,39 @@ impl<'js> FormData<'js> {
         self.entries.borrow_mut().retain(|(k, _)| *k != name);
         Ok(())
     }
-
-    pub fn keys(&self, _ctx: Ctx<'js>) -> Result<Vec<String>> {
-        Ok(self
-            .entries
-            .borrow()
-            .iter()
-            .map(|(k, _)| k.clone())
-            .collect())
+    pub fn keys(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, FormDataIter<'js>>> {
+        FormDataIter::create(&ctx, this.0, IteratorKind::Keys)
     }
 
-    pub fn values(&self, ctx: Ctx<'js>) -> Result<Vec<Value<'js>>> {
-        let values: Vec<FormValue<'js>> = self
-            .entries
-            .borrow()
-            .iter()
-            .map(|(_, v)| v.clone())
-            .collect();
-        Ok(values
-            .into_iter()
-            .filter_map(|v| v.into_js(&ctx).ok())
-            .collect())
+    pub fn values(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, FormDataIter<'js>>> {
+        FormDataIter::create(&ctx, this.0, IteratorKind::Values)
     }
 
-    pub fn entries(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        self.js_iterator(ctx)
+    pub fn entries(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, FormDataIter<'js>>> {
+        FormDataIter::create(&ctx, this.0, IteratorKind::Entries)
     }
 
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
-    pub fn iterator(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        self.js_iterator(ctx)
+    pub fn iterator(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, FormDataIter<'js>>> {
+        FormDataIter::create(&ctx, this.0, IteratorKind::Entries)
     }
 
-    pub fn for_each(&self, ctx: Ctx<'js>, callback: Function<'js>) -> Result<()> {
-        let entries = self.entries.borrow().0.clone();
-        for (name, value) in entries.into_iter() {
-            let val = value.into_js(&ctx)?;
-            () = callback.call((val, name))?;
+    pub fn for_each(this: This<Class<'js, FormData<'js>>>, callback: Function<'js>) -> Result<()> {
+        let sorted = this.0.borrow().iter();
+        for (k, v) in &sorted {
+            () = callback.call((v.clone(), k.clone(), this.0.clone()))?;
         }
         Ok(())
     }
@@ -219,7 +225,10 @@ impl<'js> FormData<'js> {
                     let data = std::mem::take(&mut current_data);
                     if let Some(filename) = filename.take() {
                         let file = File::from_bytes(ctx, data, filename, mime_type)?;
-                        entries.push((name.take().or_throw(ctx)?, FormValue::File(file)));
+                        entries.push((
+                            name.take().or_throw(ctx)?,
+                            FormValue::File(file.into_js(ctx)?),
+                        ));
                     } else {
                         let text = String::from_utf8_lossy(&data).into_owned();
                         entries.push((name.take().or_throw(ctx)?, FormValue::Text(text)));
@@ -266,7 +275,7 @@ impl<'js> FormData<'js> {
         })
     }
 
-    pub fn to_multipart_bytes(&self, _ctx: &Ctx<'js>) -> Result<(Vec<u8>, String)> {
+    pub fn to_multipart_bytes(&self, ctx: &Ctx<'js>) -> Result<(Vec<u8>, String)> {
         let boundary = generate_boundary();
         let mut body = Vec::new();
         let entries = self.entries.borrow();
@@ -284,6 +293,7 @@ impl<'js> FormData<'js> {
                     )?;
                 },
                 FormValue::File(file) => {
+                    let file = File::from_js(ctx, file.clone())?;
                     let filename = file.name().clone();
                     let content_type = file.mime_type().clone();
                     let blob = file.get_blob();
@@ -291,16 +301,6 @@ impl<'js> FormData<'js> {
                     write!(
                         body,
                         "--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"; filename=\"{filename}\"\r\nContent-Type: {content_type}\r\n\r\n"
-                    )?;
-                    body.extend_from_slice(bytes);
-                    body.extend_from_slice(b"\r\n");
-                },
-                FormValue::Blob(blob) => {
-                    let bytes = blob.as_bytes();
-                    let content_type = blob.mime_type();
-                    write!(
-                        body,
-                        "--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"; filename=\"blob\"\r\nContent-Type: {content_type}\r\n\r\n"
                     )?;
                     body.extend_from_slice(bytes);
                     body.extend_from_slice(b"\r\n");
@@ -318,17 +318,30 @@ fn value_to_form_entry<'js>(
     ctx: &Ctx<'js>,
     name: String,
     value: Value<'js>,
+    filename: Opt<String>,
 ) -> Result<(String, FormValue<'js>)> {
     if let Some(obj) = value.as_object() {
-        if let Some(f) = Class::<File>::from_object(obj) {
-            return Ok((name, FormValue::File(f.borrow().clone())));
+        if Class::<File>::from_object(obj).is_some() {
+            if let Some(filename) = filename.0 {
+                let mut file = File::from_js(ctx, value)?;
+                file.set_filename(filename);
+                return Ok((name, FormValue::File(file.into_js(ctx)?)));
+            } else {
+                return Ok((name, FormValue::File(value)));
+            }
         }
         if let Some(b) = Class::<Blob>::from_object(obj) {
-            return Ok((name, FormValue::Blob(b.borrow().clone())));
+            let blob = b.borrow().clone();
+            let filename = filename.0.unwrap_or("blob".into());
+            let file = File::from_bytes(ctx, blob.get_bytes(), filename, Some(blob.mime_type()))?;
+            return Ok((name, FormValue::File(file.into_js(ctx)?)));
         }
     }
     if let Some(s) = value.as_string() {
         return Ok((name, FormValue::Text(s.to_string().or_throw(ctx)?)));
+    }
+    if let Ok(Coerced(s)) = Coerced::<String>::from_js(ctx, value.clone()) {
+        return Ok((name, FormValue::Text(s)));
     }
     Err(Exception::throw_type(ctx, "Invalid FormData value type"))
 }
@@ -358,4 +371,64 @@ fn generate_boundary() -> String {
 fn starts_with_ignore_case(haystack: &str, needle: &str) -> bool {
     haystack.len() >= needle.len()
         && haystack.as_bytes()[..needle.len()].eq_ignore_ascii_case(needle.as_bytes())
+}
+
+#[derive(Trace, JsLifetime)]
+#[rquickjs::class]
+pub struct FormDataIter<'js> {
+    fd: Class<'js, FormData<'js>>,
+    #[qjs(skip_trace)]
+    index: usize,
+    #[qjs(skip_trace)]
+    kind: IteratorKind,
+}
+
+#[rquickjs::methods]
+impl<'js> FormDataIter<'js> {
+    fn next(&mut self, ctx: Ctx<'js>) -> Result<Object<'js>> {
+        let obj = Object::new(ctx.clone())?;
+        // Re-read on every next() — WPT expects the iterator to observe
+        // mutations made during iteration (insertions, deletions).
+        let sorted = self.fd.borrow().iter();
+
+        if self.index < sorted.len() {
+            let (k, v) = &sorted[self.index];
+            self.index += 1;
+            obj.set("done", false)?;
+            match self.kind {
+                IteratorKind::Keys => obj.set("value", k)?,
+                IteratorKind::Values => obj.set("value", v.clone().into_js(&ctx)?)?,
+                IteratorKind::Entries => {
+                    let entry = Array::new(ctx.clone())?;
+                    entry.set(0, k)?;
+                    entry.set(1, v.clone().into_js(&ctx)?)?;
+                    obj.set("value", entry)?;
+                },
+            }
+        } else {
+            obj.set("done", true)?;
+        }
+        Ok(obj)
+    }
+}
+
+impl<'js> FormDataIter<'js> {
+    fn create(
+        ctx: &Ctx<'js>,
+        fd: Class<'js, FormData<'js>>,
+        kind: IteratorKind,
+    ) -> Result<Class<'js, Self>> {
+        Class::instance(ctx.clone(), Self { fd, index: 0, kind })
+    }
+}
+
+impl<'js> CustomInspect<'js> for FormData<'js> {
+    fn custom_inspect(&self, ctx: Ctx<'js>) -> Result<Object<'js>> {
+        let obj = Object::new(ctx.clone())?;
+        for (k, v) in self.entries.borrow().iter() {
+            obj.set(k, v.clone().into_js(&ctx)?)?;
+        }
+
+        Ok(obj)
+    }
 }

--- a/modules/llrt_fetch/src/form_data.rs
+++ b/modules/llrt_fetch/src/form_data.rs
@@ -4,14 +4,17 @@ use std::{cell::RefCell, io::Write, rc::Rc};
 
 use hyper::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use llrt_buffer::{Blob, File};
-use llrt_utils::{class::CustomInspect, object::map_to_entries, result::ResultExt};
+use llrt_utils::{
+    class::{iterator_result, live_iterator, CustomInspect, IterKind},
+    result::ResultExt,
+};
 use rand::RngExt;
 use rquickjs::{
     atom::PredefinedAtom,
     class::{Trace, Tracer},
     prelude::{Opt, This},
-    Class, Coerced, Ctx, Exception, FromJs, Function, IntoJs, Iterable, JsLifetime, Object, Result,
-    Type, Value,
+    Class, Coerced, Ctx, Exception, FromJs, Function, IntoJs, JsLifetime, Object, Result, Type,
+    Value,
 };
 
 #[derive(Clone, Trace, JsLifetime)]
@@ -144,47 +147,49 @@ impl<'js> FormData<'js> {
         Ok(())
     }
 
-    pub fn keys(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        let keys: Vec<String> = self
-            .entries
-            .borrow()
-            .iter()
-            .map(|(k, _)| k.clone())
-            .collect();
-
-        Iterable::from(keys).into_js(&ctx)
+    pub fn keys(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, FormDataIter<'js>>> {
+        FormDataIter::new(&ctx, this.0, IterKind::Keys)
     }
 
-    pub fn values(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        let values: Vec<FormValue<'js>> = self
-            .entries
-            .borrow()
-            .iter()
-            .map(|(_, v)| v.clone())
-            .collect();
-
-        Iterable::from(values).into_js(&ctx)
+    pub fn values(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, FormDataIter<'js>>> {
+        FormDataIter::new(&ctx, this.0, IterKind::Values)
     }
 
-    pub fn entries(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        let entries = self.entries.borrow();
-        let array = map_to_entries(&ctx, entries.0.clone())?;
-
-        Iterable::from(array).into_js(&ctx)
+    pub fn entries(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, FormDataIter<'js>>> {
+        FormDataIter::new(&ctx, this.0, IterKind::Entries)
     }
 
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
-    pub fn iterator(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        let entries = self.entries.borrow();
-        let array = map_to_entries(&ctx, entries.0.clone())?;
-
-        Iterable::from(array).into_js(&ctx)
+    pub fn iterator(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, FormDataIter<'js>>> {
+        FormDataIter::new(&ctx, this.0, IterKind::Entries)
     }
 
-    pub fn for_each(this: This<Class<'js, FormData<'js>>>, callback: Function<'js>) -> Result<()> {
-        let sorted = this.0.borrow().iter();
-        for (k, v) in &sorted {
-            () = callback.call((v.clone(), k.clone(), this.0.clone()))?;
+    pub fn for_each(
+        this: This<Class<'js, FormData<'js>>>,
+        ctx: Ctx<'js>,
+        callback: Function<'js>,
+    ) -> Result<()> {
+        // Re-read each index so the callback's mutations are observed.
+        let mut index = 0;
+        loop {
+            let entry = this.0.borrow().entries.borrow().get(index).cloned();
+            let Some((name, value)) = entry else {
+                break;
+            };
+            () = callback.call((value.into_js(&ctx)?, name, this.0.clone()))?;
+            index += 1;
         }
         Ok(())
     }
@@ -319,6 +324,58 @@ impl<'js> FormData<'js> {
 
         Ok((body, boundary))
     }
+
+    fn read_entry(&self, index: usize, ctx: &Ctx<'js>) -> Result<Option<(Value<'js>, Value<'js>)>> {
+        match self.entries.borrow().get(index).cloned() {
+            Some((name, value)) => Ok(Some((name.into_js(ctx)?, value.into_js(ctx)?))),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Live iterator over a [`FormData`]. Re-reads on each `next()` so mutations
+/// during iteration are observed.
+#[derive(Trace, JsLifetime)]
+#[rquickjs::class]
+pub struct FormDataIter<'js> {
+    form_data: Class<'js, FormData<'js>>,
+    #[qjs(skip_trace)]
+    index: usize,
+    #[qjs(skip_trace)]
+    kind: IterKind,
+}
+
+impl<'js> FormDataIter<'js> {
+    fn new(
+        ctx: &Ctx<'js>,
+        form_data: Class<'js, FormData<'js>>,
+        kind: IterKind,
+    ) -> Result<Class<'js, Self>> {
+        live_iterator(
+            ctx,
+            Self {
+                form_data,
+                index: 0,
+                kind,
+            },
+        )
+    }
+}
+
+#[rquickjs::methods]
+impl<'js> FormDataIter<'js> {
+    fn next(&mut self, ctx: Ctx<'js>) -> Result<Object<'js>> {
+        let entry = self.form_data.borrow().read_entry(self.index, &ctx)?;
+        if entry.is_some() {
+            self.index += 1;
+        }
+        iterator_result(&ctx, self.kind, entry)
+    }
+
+    #[qjs(rename = PredefinedAtom::SymbolIterator)]
+    fn iter(this: This<Class<'js, Self>>) -> Class<'js, Self> {
+        this.0
+    }
 }
 
 fn value_to_form_entry<'js>(
@@ -388,5 +445,120 @@ impl<'js> CustomInspect<'js> for FormData<'js> {
         }
 
         Ok(obj)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use llrt_test::test_async_with;
+    use rquickjs::CatchResultExt;
+
+    async fn assert_eval(src: &'static str, expected: &'static str) {
+        test_async_with(|ctx| {
+            crate::init(&ctx).unwrap();
+            Box::pin(async move {
+                let value = ctx.eval::<String, _>(src).catch(&ctx).unwrap();
+                assert_eq!(value, expected);
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_iterate_entries() {
+        assert_eval(
+            r#"
+            const fd = new FormData();
+            fd.append("a", "1");
+            fd.append("b", "2");
+            fd.append("a", "3");
+            const out = [];
+            for (const [name, value] of fd) out.push(`${name}=${value}`);
+            out.join("&")
+        "#,
+            "a=1&b=2&a=3",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_keys_values_live() {
+        assert_eval(
+            r#"
+            const fd = new FormData();
+            fd.append("a", "1");
+            fd.append("b", "2");
+            const k = [...fd.keys()].join(",");
+            const v = [...fd.values()].join(",");
+            `${k}|${v}`
+        "#,
+            "a,b|1,2",
+        )
+        .await;
+    }
+
+    // wpt iteration.any.js: deleting the current/later entry skips it.
+    #[tokio::test]
+    async fn test_iterate_live_delete() {
+        assert_eval(
+            r#"
+            const fd = new FormData();
+            fd.append("foo", "0");
+            fd.append("baz", "1");
+            fd.append("BAR", "2");
+            const keys = [];
+            for (const [name] of fd) {
+                keys.push(name);
+                fd.delete("baz");
+            }
+            keys.join(",")
+        "#,
+            "foo,BAR",
+        )
+        .await;
+    }
+
+    // wpt iteration.any.js: deleting an already-seen entry skips the next one.
+    #[tokio::test]
+    async fn test_iterate_live_delete_earlier() {
+        assert_eval(
+            r#"
+            const fd = new FormData();
+            fd.append("foo", "0");
+            fd.append("baz", "1");
+            fd.append("BAR", "2");
+            fd.append("quux", "3");
+            const keys = [];
+            for (const [name] of fd) {
+                keys.push(name);
+                if (name === "baz") fd.delete("foo");
+            }
+            keys.join(",")
+        "#,
+            "foo,baz,quux",
+        )
+        .await;
+    }
+
+    // wpt iteration.any.js: appending during iteration reaches the new entry.
+    #[tokio::test]
+    async fn test_iterate_live_append() {
+        assert_eval(
+            r#"
+            const fd = new FormData();
+            fd.append("foo", "0");
+            fd.append("baz", "1");
+            fd.append("BAR", "2");
+            fd.append("quux", "3");
+            const keys = [];
+            for (const [name] of fd) {
+                keys.push(name);
+                if (name === "baz") fd.append("X-yZ", "4");
+            }
+            keys.join(",")
+        "#,
+            "foo,baz,BAR,quux,X-yZ",
+        )
+        .await;
     }
 }

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -24,8 +24,6 @@ use rquickjs::{
     Symbol, Value,
 };
 
-use crate::IteratorKind;
-
 type ImmutableString = Rc<str>;
 
 /// ASCII-lowercase the key in place (HTTP headers are ASCII-only) and wrap in `Rc<str>`,
@@ -276,21 +274,21 @@ impl Headers {
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, IteratorKind::Keys)
+        HeadersIter::create(&ctx, this.0, HeadersIterKind::Keys)
     }
 
     pub fn values<'js>(
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, IteratorKind::Values)
+        HeadersIter::create(&ctx, this.0, HeadersIterKind::Values)
     }
 
     pub fn entries<'js>(
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, IteratorKind::Entries)
+        HeadersIter::create(&ctx, this.0, HeadersIterKind::Entries)
     }
 
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
@@ -298,7 +296,7 @@ impl Headers {
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, IteratorKind::Entries)
+        HeadersIter::create(&ctx, this.0, HeadersIterKind::Entries)
     }
 
     pub fn for_each<'js>(this: This<Class<'js, Headers>>, callback: Function<'js>) -> Result<()> {
@@ -520,6 +518,13 @@ impl Headers {
     }
 }
 
+#[derive(Clone, Copy)]
+enum HeadersIterKind {
+    Keys,
+    Values,
+    Entries,
+}
+
 #[derive(Trace, JsLifetime)]
 #[rquickjs::class]
 pub struct HeadersIter<'js> {
@@ -527,7 +532,7 @@ pub struct HeadersIter<'js> {
     #[qjs(skip_trace)]
     index: usize,
     #[qjs(skip_trace)]
-    kind: IteratorKind,
+    kind: HeadersIterKind,
 }
 
 #[rquickjs::methods]
@@ -543,9 +548,9 @@ impl<'js> HeadersIter<'js> {
             self.index += 1;
             obj.set("done", false)?;
             match self.kind {
-                IteratorKind::Keys => obj.set("value", k.as_ref())?,
-                IteratorKind::Values => obj.set("value", v.as_ref())?,
-                IteratorKind::Entries => {
+                HeadersIterKind::Keys => obj.set("value", k.as_ref())?,
+                HeadersIterKind::Values => obj.set("value", v.as_ref())?,
+                HeadersIterKind::Entries => {
                     let entry = Array::new(ctx)?;
                     entry.set(0, k.as_ref())?;
                     entry.set(1, v.as_ref())?;
@@ -563,7 +568,7 @@ impl<'js> HeadersIter<'js> {
     fn create(
         ctx: &Ctx<'js>,
         headers: Class<'js, Headers>,
-        kind: IteratorKind,
+        kind: HeadersIterKind,
     ) -> Result<Class<'js, Self>> {
         Class::instance(
             ctx.clone(),

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -14,7 +14,7 @@ use hyper::{
     HeaderMap,
 };
 use llrt_utils::{
-    class::CustomInspect,
+    class::{iterator_result, live_iterator, CustomInspect, IterKind},
     primordials::{BasePrimordials, Primordial},
     result::ResultExt,
 };
@@ -274,21 +274,21 @@ impl Headers {
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, HeadersIterKind::Keys)
+        HeadersIter::new(&ctx, this.0, IterKind::Keys)
     }
 
     pub fn values<'js>(
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, HeadersIterKind::Values)
+        HeadersIter::new(&ctx, this.0, IterKind::Values)
     }
 
     pub fn entries<'js>(
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, HeadersIterKind::Entries)
+        HeadersIter::new(&ctx, this.0, IterKind::Entries)
     }
 
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
@@ -296,7 +296,7 @@ impl Headers {
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, HeadersIterKind::Entries)
+        HeadersIter::new(&ctx, this.0, IterKind::Entries)
     }
 
     pub fn for_each<'js>(this: This<Class<'js, Headers>>, callback: Function<'js>) -> Result<()> {
@@ -340,6 +340,17 @@ impl Headers {
         }
         result.sort_by(|a, b| a.0.cmp(&b.0));
         result
+    }
+
+    fn read_entry<'js>(
+        &self,
+        index: usize,
+        ctx: &Ctx<'js>,
+    ) -> Result<Option<(Value<'js>, Value<'js>)>> {
+        match self.sorted_entries().get(index) {
+            Some((k, v)) => Ok(Some((k.as_ref().into_js(ctx)?, v.as_ref().into_js(ctx)?))),
+            None => Ok(None),
+        }
     }
 
     pub fn from_http_headers(header_map: &HeaderMap, guard: HeadersGuard) -> Result<Self> {
@@ -518,13 +529,8 @@ impl Headers {
     }
 }
 
-#[derive(Clone, Copy)]
-enum HeadersIterKind {
-    Keys,
-    Values,
-    Entries,
-}
-
+/// Live iterator over a [`Headers`]. Re-reads on each `next()` so mutations
+/// during iteration are observed.
 #[derive(Trace, JsLifetime)]
 #[rquickjs::class]
 pub struct HeadersIter<'js> {
@@ -532,52 +538,39 @@ pub struct HeadersIter<'js> {
     #[qjs(skip_trace)]
     index: usize,
     #[qjs(skip_trace)]
-    kind: HeadersIterKind,
-}
-
-#[rquickjs::methods]
-impl<'js> HeadersIter<'js> {
-    fn next(&mut self, ctx: Ctx<'js>) -> Result<Object<'js>> {
-        let obj = Object::new(ctx.clone())?;
-        // Re-read on every next() — WPT expects the iterator to observe
-        // mutations made during iteration (insertions, deletions).
-        let sorted = self.headers.borrow().sorted_entries();
-
-        if self.index < sorted.len() {
-            let (k, v) = &sorted[self.index];
-            self.index += 1;
-            obj.set("done", false)?;
-            match self.kind {
-                HeadersIterKind::Keys => obj.set("value", k.as_ref())?,
-                HeadersIterKind::Values => obj.set("value", v.as_ref())?,
-                HeadersIterKind::Entries => {
-                    let entry = Array::new(ctx)?;
-                    entry.set(0, k.as_ref())?;
-                    entry.set(1, v.as_ref())?;
-                    obj.set("value", entry)?;
-                },
-            }
-        } else {
-            obj.set("done", true)?;
-        }
-        Ok(obj)
-    }
+    kind: IterKind,
 }
 
 impl<'js> HeadersIter<'js> {
-    fn create(
+    fn new(
         ctx: &Ctx<'js>,
         headers: Class<'js, Headers>,
-        kind: HeadersIterKind,
+        kind: IterKind,
     ) -> Result<Class<'js, Self>> {
-        Class::instance(
-            ctx.clone(),
+        live_iterator(
+            ctx,
             Self {
                 headers,
                 index: 0,
                 kind,
             },
         )
+    }
+}
+
+#[rquickjs::methods]
+impl<'js> HeadersIter<'js> {
+    fn next(&mut self, ctx: Ctx<'js>) -> Result<Object<'js>> {
+        let entry = self.headers.borrow().read_entry(self.index, &ctx)?;
+        if entry.is_some() {
+            self.index += 1;
+        }
+        iterator_result(&ctx, self.kind, entry)
+    }
+
+    #[qjs(rename = PredefinedAtom::SymbolIterator)]
+    fn iter(this: This<Class<'js, Self>>) -> Class<'js, Self> {
+        this.0
     }
 }
 

--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -24,6 +24,8 @@ use rquickjs::{
     Symbol, Value,
 };
 
+use crate::IteratorKind;
+
 type ImmutableString = Rc<str>;
 
 /// ASCII-lowercase the key in place (HTTP headers are ASCII-only) and wrap in `Rc<str>`,
@@ -274,21 +276,21 @@ impl Headers {
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, HeadersIterKind::Keys)
+        HeadersIter::create(&ctx, this.0, IteratorKind::Keys)
     }
 
     pub fn values<'js>(
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, HeadersIterKind::Values)
+        HeadersIter::create(&ctx, this.0, IteratorKind::Values)
     }
 
     pub fn entries<'js>(
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, HeadersIterKind::Entries)
+        HeadersIter::create(&ctx, this.0, IteratorKind::Entries)
     }
 
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
@@ -296,7 +298,7 @@ impl Headers {
         this: This<Class<'js, Headers>>,
         ctx: Ctx<'js>,
     ) -> Result<Class<'js, HeadersIter<'js>>> {
-        HeadersIter::create(&ctx, this.0, HeadersIterKind::Entries)
+        HeadersIter::create(&ctx, this.0, IteratorKind::Entries)
     }
 
     pub fn for_each<'js>(this: This<Class<'js, Headers>>, callback: Function<'js>) -> Result<()> {
@@ -518,13 +520,6 @@ impl Headers {
     }
 }
 
-#[derive(Clone, Copy)]
-enum HeadersIterKind {
-    Keys,
-    Values,
-    Entries,
-}
-
 #[derive(Trace, JsLifetime)]
 #[rquickjs::class]
 pub struct HeadersIter<'js> {
@@ -532,7 +527,7 @@ pub struct HeadersIter<'js> {
     #[qjs(skip_trace)]
     index: usize,
     #[qjs(skip_trace)]
-    kind: HeadersIterKind,
+    kind: IteratorKind,
 }
 
 #[rquickjs::methods]
@@ -548,9 +543,9 @@ impl<'js> HeadersIter<'js> {
             self.index += 1;
             obj.set("done", false)?;
             match self.kind {
-                HeadersIterKind::Keys => obj.set("value", k.as_ref())?,
-                HeadersIterKind::Values => obj.set("value", v.as_ref())?,
-                HeadersIterKind::Entries => {
+                IteratorKind::Keys => obj.set("value", k.as_ref())?,
+                IteratorKind::Values => obj.set("value", v.as_ref())?,
+                IteratorKind::Entries => {
                     let entry = Array::new(ctx)?;
                     entry.set(0, k.as_ref())?;
                     entry.set(1, v.as_ref())?;
@@ -568,7 +563,7 @@ impl<'js> HeadersIter<'js> {
     fn create(
         ctx: &Ctx<'js>,
         headers: Class<'js, Headers>,
-        kind: HeadersIterKind,
+        kind: IteratorKind,
     ) -> Result<Class<'js, Self>> {
         Class::instance(
             ctx.clone(),

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pub use self::security::{get_allow_list, get_deny_list, set_allow_list, set_deny_list};
 use self::{
-    form_data::FormData,
+    form_data::{FormData, FormDataIter},
     headers::{Headers, HeadersIter},
     request::Request,
     response::Response,
@@ -32,6 +32,13 @@ const MIME_TYPE_JSON_STATIC: &str = "application/json";
 const MIME_TYPE_FORM_DATA: &str = "multipart/form-data; boundary=";
 const MIME_TYPE_OCTET_STREAM: &str = "application/octet-stream";
 
+#[derive(Clone, Copy)]
+pub(crate) enum IteratorKind {
+    Keys,
+    Values,
+    Entries,
+}
+
 pub fn init(ctx: &Ctx) -> Result<()> {
     let globals = ctx.globals();
 
@@ -40,13 +47,13 @@ pub fn init(ctx: &Ctx) -> Result<()> {
     //init eagerly
     fetch::init(HTTP_CLIENT.as_ref().or_throw(ctx)?.clone(), &globals)?;
 
-    Class::<FormData>::define(&globals)?;
-
     Class::<Request>::define(&globals)?;
     Class::<Response>::define(&globals)?;
     Class::<Headers>::define_with_custom_inspect(&globals)?;
+    Class::<FormData>::define_with_custom_inspect(&globals)?;
 
     Class::<HeadersIter>::define_as_webidl_iterator(&globals, stringify!(HeadersIter))?;
+    Class::<FormDataIter>::define_as_webidl_iterator(&globals, stringify!(FormDataIter))?;
 
     Ok(())
 }

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -1,16 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 pub use self::security::{get_allow_list, get_deny_list, set_allow_list, set_deny_list};
-use self::{
-    form_data::FormData,
-    headers::{Headers, HeadersIter},
-    request::Request,
-    response::Response,
-};
+use self::{form_data::FormData, headers::Headers, request::Request, response::Response};
 use llrt_buffer::Blob;
 use llrt_http::HTTP_CLIENT;
 use llrt_utils::{
-    class::{CustomInspectExtension, WebIdlIteratorExtension},
+    class::CustomInspectExtension,
     primordials::{BasePrimordials, Primordial},
     result::ResultExt,
 };
@@ -44,8 +39,6 @@ pub fn init(ctx: &Ctx) -> Result<()> {
     Class::<Response>::define(&globals)?;
     Class::<Headers>::define_with_custom_inspect(&globals)?;
     Class::<FormData>::define_with_custom_inspect(&globals)?;
-
-    Class::<HeadersIter>::define_as_webidl_iterator(&globals, stringify!(HeadersIter))?;
 
     Ok(())
 }

--- a/modules/llrt_fetch/src/lib.rs
+++ b/modules/llrt_fetch/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pub use self::security::{get_allow_list, get_deny_list, set_allow_list, set_deny_list};
 use self::{
-    form_data::{FormData, FormDataIter},
+    form_data::FormData,
     headers::{Headers, HeadersIter},
     request::Request,
     response::Response,
@@ -32,13 +32,6 @@ const MIME_TYPE_JSON_STATIC: &str = "application/json";
 const MIME_TYPE_FORM_DATA: &str = "multipart/form-data; boundary=";
 const MIME_TYPE_OCTET_STREAM: &str = "application/octet-stream";
 
-#[derive(Clone, Copy)]
-pub(crate) enum IteratorKind {
-    Keys,
-    Values,
-    Entries,
-}
-
 pub fn init(ctx: &Ctx) -> Result<()> {
     let globals = ctx.globals();
 
@@ -53,7 +46,6 @@ pub fn init(ctx: &Ctx) -> Result<()> {
     Class::<FormData>::define_with_custom_inspect(&globals)?;
 
     Class::<HeadersIter>::define_as_webidl_iterator(&globals, stringify!(HeadersIter))?;
-    Class::<FormDataIter>::define_as_webidl_iterator(&globals, stringify!(FormDataIter))?;
 
     Ok(())
 }

--- a/modules/llrt_url/src/url_search_params.rs
+++ b/modules/llrt_url/src/url_search_params.rs
@@ -8,12 +8,12 @@ use std::{
 
 use llrt_utils::{
     bytes::get_lossy_string,
-    class::IteratorDef,
+    class::{iterator_result, live_iterator, IterKind},
     primordials::{BasePrimordials, Primordial},
 };
 use rquickjs::{
-    atom::PredefinedAtom, class::Trace, function::Opt, Array, Class, Coerced, Ctx, Exception,
-    FromJs, Function, IntoJs, Null, Object, Result, Symbol, Value,
+    atom::PredefinedAtom, class::Trace, function::Opt, prelude::This, Array, Class, Coerced, Ctx,
+    Exception, FromJs, Function, IntoJs, Null, Object, Result, Symbol, Value,
 };
 use url::Url;
 
@@ -132,16 +132,34 @@ impl<'js> URLSearchParams {
         self.sync_query();
     }
 
-    pub fn entries(&self, ctx: Ctx<'js>) -> Result<Value<'js>> {
-        self.js_iterator(ctx)
+    pub fn entries(
+        this: This<Class<'js, URLSearchParams>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, URLSearchParamsIter<'js>>> {
+        URLSearchParamsIter::new(&ctx, this.0, IterKind::Entries)
     }
 
-    pub fn for_each(&self, callback: Function<'js>) -> Result<()> {
-        self.url
-            .borrow()
-            .query_pairs()
-            .into_owned()
-            .try_for_each(|(k, v)| callback.call((v, k)))?;
+    pub fn for_each(
+        this: This<Class<'js, URLSearchParams>>,
+        callback: Function<'js>,
+    ) -> Result<()> {
+        // Re-read each index so the callback's mutations are observed.
+        let mut index = 0;
+        loop {
+            let pair = this
+                .0
+                .borrow()
+                .url
+                .borrow()
+                .query_pairs()
+                .nth(index)
+                .map(|(k, v)| (k.to_string(), v.to_string()));
+            let Some((k, v)) = pair else {
+                break;
+            };
+            () = callback.call((v, k, this.0.clone()))?;
+            index += 1;
+        }
         Ok(())
     }
 
@@ -177,12 +195,11 @@ impl<'js> URLSearchParams {
         })
     }
 
-    pub fn keys(&mut self) -> Vec<String> {
-        self.url
-            .borrow()
-            .query_pairs()
-            .map(|(k, _)| k.to_string())
-            .collect()
+    pub fn keys(
+        this: This<Class<'js, URLSearchParams>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, URLSearchParamsIter<'js>>> {
+        URLSearchParamsIter::new(&ctx, this.0, IterKind::Keys)
     }
 
     pub fn set(&mut self, key: Coerced<String>, value: Coerced<String>) {
@@ -266,27 +283,36 @@ impl<'js> URLSearchParams {
         )
     }
 
-    pub fn values(&mut self) -> Vec<String> {
-        self.url
-            .borrow()
-            .query_pairs()
-            .map(|(_, v)| v.to_string())
-            .collect()
+    pub fn values(
+        this: This<Class<'js, URLSearchParams>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, URLSearchParamsIter<'js>>> {
+        URLSearchParamsIter::new(&ctx, this.0, IterKind::Values)
     }
 
     #[qjs(rename = PredefinedAtom::SymbolIterator)]
-    pub fn iterator(&self, ctx: Ctx<'js>) -> Result<Class<'js, URLSearchParamsIter>> {
-        Class::instance(
-            ctx,
-            URLSearchParamsIter {
-                index: 0,
-                params: self.clone(),
-            },
-        )
+    pub fn iterator(
+        this: This<Class<'js, URLSearchParams>>,
+        ctx: Ctx<'js>,
+    ) -> Result<Class<'js, URLSearchParamsIter<'js>>> {
+        URLSearchParamsIter::new(&ctx, this.0, IterKind::Entries)
     }
 }
 
 impl<'js> URLSearchParams {
+    fn read_entry(&self, index: usize, ctx: &Ctx<'js>) -> Result<Option<(Value<'js>, Value<'js>)>> {
+        let pair = self
+            .url
+            .borrow()
+            .query_pairs()
+            .nth(index)
+            .map(|(k, v)| (k.to_string(), v.to_string()));
+        match pair {
+            Some((k, v)) => Ok(Some((k.into_js(ctx)?, v.into_js(ctx)?))),
+            None => Ok(None),
+        }
+    }
+
     /// Re-serialize the query string with proper percent-encoding.
     /// The url crate doesn't encode commas, so we rebuild the query
     /// using form_urlencoded::byte_serialize after each mutation.
@@ -422,45 +448,48 @@ impl<'js> URLSearchParams {
     }
 }
 
+/// Live iterator over a [`URLSearchParams`]. Re-reads on each `next()` so
+/// mutations during iteration are observed.
 #[derive(Trace, rquickjs::JsLifetime)]
 #[rquickjs::class]
-pub struct URLSearchParamsIter {
-    params: URLSearchParams,
-    index: u32,
+pub struct URLSearchParamsIter<'js> {
+    params: Class<'js, URLSearchParams>,
+    #[qjs(skip_trace)]
+    index: usize,
+    #[qjs(skip_trace)]
+    kind: IterKind,
 }
 
-#[rquickjs::methods]
-impl<'js> URLSearchParamsIter {
-    pub fn next(&mut self, ctx: Ctx<'js>) -> Result<Object<'js>> {
-        let obj = Object::new(ctx.clone())?;
-        let value = (*self.params.url.borrow())
-            .query_pairs()
-            .nth(self.index as _)
-            .map(|(k, v)| vec![k.to_string(), v.to_string()]);
-
-        if let Some(value) = value {
-            obj.set("done", false)?;
-            obj.set("value", value)?;
-        } else {
-            obj.set("done", true)?;
-        }
-
-        self.index += 1;
-
-        Ok(obj)
+impl<'js> URLSearchParamsIter<'js> {
+    fn new(
+        ctx: &Ctx<'js>,
+        params: Class<'js, URLSearchParams>,
+        kind: IterKind,
+    ) -> Result<Class<'js, Self>> {
+        live_iterator(
+            ctx,
+            Self {
+                params,
+                index: 0,
+                kind,
+            },
+        )
     }
 }
 
-impl<'js> IteratorDef<'js> for URLSearchParams {
-    fn js_entries(&self, ctx: Ctx<'js>) -> Result<Array<'js>> {
-        let array = Array::new(ctx.clone())?;
-        for (idx, (key, value)) in self.url.borrow().query_pairs().into_owned().enumerate() {
-            let entry = Array::new(ctx.clone())?;
-            entry.set(0, key)?;
-            entry.set(1, value)?;
-            array.set(idx, entry)?;
+#[rquickjs::methods]
+impl<'js> URLSearchParamsIter<'js> {
+    fn next(&mut self, ctx: Ctx<'js>) -> Result<Object<'js>> {
+        let entry = self.params.borrow().read_entry(self.index, &ctx)?;
+        if entry.is_some() {
+            self.index += 1;
         }
-        Ok(array)
+        iterator_result(&ctx, self.kind, entry)
+    }
+
+    #[qjs(rename = PredefinedAtom::SymbolIterator)]
+    fn iter(this: This<Class<'js, Self>>) -> Class<'js, Self> {
+        this.0
     }
 }
 
@@ -482,10 +511,15 @@ mod tests {
 
     use super::*;
 
+    fn setup(ctx: &rquickjs::Ctx) {
+        BasePrimordials::init(ctx).unwrap();
+        Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+    }
+
     #[tokio::test]
     async fn test_basic() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -511,7 +545,7 @@ mod tests {
     #[tokio::test]
     async fn test_iterate() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -535,9 +569,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_iterate_live_delete() {
+        // Deleting the current/later entry during iteration skips it.
+        test_sync_with(|ctx| {
+            setup(&ctx);
+            let result = ctx
+                .eval::<String, _>(
+                    r#"
+                const params = new URLSearchParams("foo=0&baz=1&BAR=2");
+                const keys = [];
+                for (const [name] of params) {
+                    keys.push(name);
+                    params.delete("baz");
+                }
+                keys.join(",")
+            "#,
+                )
+                .catch(&ctx)
+                .unwrap();
+            assert_eq!(result, "foo,BAR");
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_iterate_live_append() {
+        // Appending during iteration causes the new pair to be reached.
+        test_sync_with(|ctx| {
+            setup(&ctx);
+            let result = ctx
+                .eval::<String, _>(
+                    r#"
+                const params = new URLSearchParams("foo=0&baz=1");
+                const keys = [];
+                for (const [name] of params) {
+                    keys.push(name);
+                    if (name === "baz") params.append("end", "9");
+                }
+                keys.join(",")
+            "#,
+                )
+                .catch(&ctx)
+                .unwrap();
+            assert_eq!(result, "foo,baz,end");
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_iterate_keys_values_live() {
+        // keys()/values() must also be live index-based iterators.
+        test_sync_with(|ctx| {
+            setup(&ctx);
+            let result = ctx
+                .eval::<String, _>(
+                    r#"
+                const params = new URLSearchParams("a=1&b=2&c=3");
+                const k = [...params.keys()].join(",");
+                const v = [...params.values()].join(",");
+                `${k}|${v}`
+            "#,
+                )
+                .catch(&ctx)
+                .unwrap();
+            assert_eq!(result, "a,b,c|1,2,3");
+            Ok(())
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_iterate_entries() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -563,7 +669,7 @@ mod tests {
     #[tokio::test]
     async fn test_iterate_keys() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -589,7 +695,7 @@ mod tests {
     #[tokio::test]
     async fn test_iterate_values() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -615,7 +721,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_string() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -634,7 +740,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_string_url() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -653,7 +759,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_object() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -672,7 +778,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_array() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -691,8 +797,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_iterator() {
         test_sync_with(|ctx| {
-            BasePrimordials::init(&ctx)?;
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -715,7 +820,7 @@ mod tests {
     #[tokio::test]
     async fn test_size() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<usize, _>(
                     r#"
@@ -737,7 +842,7 @@ mod tests {
     #[tokio::test]
     async fn test_set() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -760,7 +865,7 @@ mod tests {
     #[tokio::test]
     async fn test_get() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -782,7 +887,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_missing() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<bool, _>(
                     r#"
@@ -804,7 +909,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_all() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -826,7 +931,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_all_missing() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -848,7 +953,7 @@ mod tests {
     #[tokio::test]
     async fn test_has() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<bool, _>(
                     r#"
@@ -870,7 +975,7 @@ mod tests {
     #[tokio::test]
     async fn test_has_value() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<bool, _>(
                     r#"
@@ -892,7 +997,7 @@ mod tests {
     #[tokio::test]
     async fn test_has_not() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<bool, _>(
                     r#"
@@ -914,7 +1019,7 @@ mod tests {
     #[tokio::test]
     async fn test_sort() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"
@@ -937,7 +1042,7 @@ mod tests {
     #[tokio::test]
     async fn test_for_each() {
         test_sync_with(|ctx| {
-            Class::<URLSearchParams>::define(&ctx.globals()).unwrap();
+            setup(&ctx);
             let result = ctx
                 .eval::<String, _>(
                     r#"

--- a/tests/unit/fetch.formdata.test.ts
+++ b/tests/unit/fetch.formdata.test.ts
@@ -54,9 +54,7 @@ describe("FormData class", () => {
     fd.append("a", "1");
     fd.append("b", "2");
 
-    const keys = fd.keys();
-    expect(keys).toContain("a");
-    expect(keys).toContain("b");
+    expect([...fd.keys()]).toEqual(["a", "b"]);
   });
 
   it("should return all values with values()", () => {
@@ -64,9 +62,7 @@ describe("FormData class", () => {
     fd.append("a", "apple");
     fd.append("b", "banana");
 
-    const values = fd.values();
-    expect(values).toContain("apple");
-    expect(values).toContain("banana");
+    expect([...fd.values()]).toEqual(["apple", "banana"]);
   });
 
   it("should iterate entries() properly", () => {
@@ -74,8 +70,7 @@ describe("FormData class", () => {
     fd.append("x", "100");
     fd.append("y", "200");
 
-    const collected = Array.from(fd.entries());
-    expect(collected).toEqual([
+    expect([...fd.entries()]).toEqual([
       ["x", "100"],
       ["y", "200"],
     ]);

--- a/tests/wpt/xhr-harness.js
+++ b/tests/wpt/xhr-harness.js
@@ -1,0 +1,10 @@
+import { makeRunner } from "./_harness-util.js";
+
+export const runTestDynamic = makeRunner({
+  context: () => ({
+    scripts: [
+      "encoding/resources/encodings.js",
+      "encoding/resources/decoding-helpers.js",
+    ],
+  }),
+});

--- a/tests/wpt/xhr.formdata.test.ts
+++ b/tests/wpt/xhr.formdata.test.ts
@@ -1,0 +1,4 @@
+import { runSuite } from "./_harness-util.js";
+import { runTestDynamic } from "./xhr-harness.js";
+
+runSuite(import.meta.url, runTestDynamic);


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

- Added WPT tests for xhr/formdata.
- As a result, we detected several tests that were failing and fixed them.

```
 PASS  xhr.formdata.test.js 224.489ms
xhr/formdata 223.534ms
  ✔ should pass append.any.js tests 134.984ms
  ✔ should pass constructor.any.js tests 10.700ms
  ✔ should pass delete.any.js tests 9.196ms
  ✔ should pass foreach.any.js tests 9.562ms
  ✔ should pass get.any.js tests 8.877ms
  ✔ should pass has.any.js tests 8.420ms
  ✔ should pass iteration.any.js tests 13.336ms
  ✔ should pass set-blob.any.js tests 11.256ms
  ✔ should pass set.any.js tests 12.125ms
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
