### PR TITLE
chore(deps): Bump some RustCrypto crates from release candidate to stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -336,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core",
 ]
 
@@ -480,15 +480,6 @@ name = "cpubits"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -646,12 +637,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -784,9 +775,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.22"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
  "der",
  "digest",
@@ -808,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -2552,9 +2543,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c855a8d2ffd346aa03122626f22e96e3aa75e3bfe64e6bf6cb82f71821ed6ae7"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2565,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.14"
+version = "0.14.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941b68907ddf996ac20f0debf700c236ccc3d874637731a93c631129ca042f"
+checksum = "492f329d7eb11d22dadc988626b9ea1f503b4ab043a8b1e4e2cc4ae45dabdd70"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2579,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.14"
+version = "0.14.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd6f2fe6e76c8d5e8828e92aafa463777d1e72e70b78acc724214757e92479a"
+checksum = "ff42e4ace5424e3b6d7cb82514be89866b85af87015f80341e37dcc21a66ce6e"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -2759,7 +2750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -2813,12 +2804,13 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-rc.14"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e56e6d67fdf5744e9e245ae571450fe584b91f5af261d0e40163b618e53a1f6"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
  "primefield",
+ "wnaf",
 ]
 
 [[package]]
@@ -2903,9 +2895,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -2987,11 +2979,11 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.6.0-pre.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "ctutils",
+ "crypto-bigint",
  "hmac",
 ]
 
@@ -3307,7 +3299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -3318,7 +3310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -4233,6 +4225,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4240,9 +4243,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d5d6ff67acd3945b933e592bfa7143db4fcbb2f871754b6b9fbd7847fc5aea"
+checksum = "eee64e8620caa64914d669b1f68f858aaff54e2d0f9ad3b30a613b58a1baa83e"
 dependencies = [
  "curve25519-dalek",
  "rand_core",

--- a/libs/llrt_numbers/Cargo.toml
+++ b/libs/llrt_numbers/Cargo.toml
@@ -19,7 +19,7 @@ ryu = { version = "1", default-features = false }
 [dev-dependencies]
 criterion = { version = "0.8", default-features = false }
 llrt_test = { version = "0.8.1-beta", path = "../llrt_test" }
-rand = { version = "0.10.1", features = ["alloc"], default-features = false }
+rand = { version = "0.10", features = ["alloc"], default-features = false }
 
 [[bench]]
 name = "numbers"

--- a/llrt_core/Cargo.toml
+++ b/llrt_core/Cargo.toml
@@ -51,7 +51,7 @@ llrt_utils = { path = "../libs/llrt_utils", features = ["all"] }
 once_cell = { version = "1", features = ["std"], default-features = false }
 phf = { version = "0.14", default-features = false }
 quick-xml = { version = "0.41", default-features = false }
-rand = { version = "0.10.1", features = [
+rand = { version = "0.10", features = [
   "alloc",
   "thread_rng",
 ], default-features = false }
@@ -71,9 +71,9 @@ zstd = { version = "0.13", default-features = false }
 openssl = { version = "0.10", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-md-5 = { version = "0.11.0", default-features = false }
+md-5 = { version = "0.11", default-features = false }
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-md-5 = { version = "0.11.0", default-features = false }
+md-5 = { version = "0.11", default-features = false }
 
 [build-dependencies]
 rquickjs = { version = "0.12", default-features = false }

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -66,7 +66,7 @@ rquickjs = { version = "0.12", default-features = false }
 # optional
 llrt_json = { version = "0.8.1-beta", path = "../../libs/llrt_json", optional = true }
 aes = { version = "0.9", optional = true }
-aes-gcm = { version = "0.11.0-rc.4", features = [
+aes-gcm = { version = "0.11", features = [
   "alloc",
 ], default-features = false, optional = true }
 aes-kw = { version = "0.3", features = [
@@ -81,47 +81,47 @@ der = { version = "0.8", features = [
   "derive",
   "alloc",
 ], default-features = false, optional = true }
-ecdsa = { version = "0.17.0-rc.18", default-features = false, optional = true }
-ed25519-dalek = { version = "3.0.0-pre.7", features = [
+ecdsa = { version = "0.17", default-features = false, optional = true }
+ed25519-dalek = { version = "3.0.0-rc.1", features = [
   "alloc",
   "pkcs8",
   "rand_core",
 ], default-features = false, optional = true }
-elliptic-curve = { version = "0.14.0-rc.33", features = [
+elliptic-curve = { version = "0.14", features = [
   "alloc",
   "sec1",
 ], default-features = false, optional = true }
-hkdf = { version = "0.13.0", default-features = false, optional = true }
-hmac = { version = "0.13.0-rc.6", default-features = false, optional = true }
+hkdf = { version = "0.13", default-features = false, optional = true }
+hmac = { version = "0.13", default-features = false, optional = true }
 rsa = { version = "0.10.0-rc.18", features = [
   "std",
   "sha2",
   "encoding",
 ], default-features = false, optional = true }
-p256 = { version = "0.14.0-rc.10", features = [
+p256 = { version = "0.14", features = [
   "ecdh",
   "ecdsa",
   "pkcs8",
 ], default-features = false, optional = true }
-p384 = { version = "0.14.0-rc.10", features = [
+p384 = { version = "0.14.0-rc.15", features = [
   "ecdh",
   "ecdsa",
   "pkcs8",
 ], default-features = false, optional = true }
-p521 = { version = "0.14.0-rc.10", features = [
+p521 = { version = "0.14.0-rc.15", features = [
   "ecdh",
   "ecdsa",
   "pkcs8",
 ], default-features = false, optional = true }
 pbkdf2 = { version = "0.13", default-features = false, optional = true }
-pkcs8 = { version = "0.11.0-rc.11", default-features = false, features = [
+pkcs8 = { version = "0.11", default-features = false, features = [
   "alloc",
 ], optional = true }
 sha1 = { version = "0.11", default-features = false, optional = true }
 spki = { version = "0.8", features = [
   "alloc",
 ], default-features = false, optional = true }
-x25519-dalek = { version = "3.0.0-pre.6", features = [
+x25519-dalek = { version = "3.0.0-rc.1", features = [
   "static_secrets",
   "zeroize",
 ], default-features = false, optional = true }

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -52,7 +52,7 @@ percent-encoding = { version = "2", features = [
   "std",
 ], default-features = false }
 sha2 = { version = "0.11", default-features = false }
-rand = { version = "0.10.1", features = [
+rand = { version = "0.10", features = [
   "std",
   "thread_rng",
 ], default-features = false }

--- a/modules/llrt_fs/Cargo.toml
+++ b/modules/llrt_fs/Cargo.toml
@@ -19,7 +19,7 @@ llrt_path = { version = "0.8.1-beta", path = "../llrt_path" }
 llrt_utils = { version = "0.8.1-beta", path = "../../libs/llrt_utils", features = [
   "fs",
 ], default-features = false }
-rand = { version = "0.10.1", features = [
+rand = { version = "0.10", features = [
   "alloc",
   "thread_rng",
 ], default-features = false }

--- a/modules/llrt_net/Cargo.toml
+++ b/modules/llrt_net/Cargo.toml
@@ -24,4 +24,4 @@ tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 llrt_test = { path = "../../libs/llrt_test" }
-rand = { version = "0.10.1", features = ["alloc"], default-features = false }
+rand = { version = "0.10", features = ["alloc"], default-features = false }

--- a/modules/llrt_path/Cargo.toml
+++ b/modules/llrt_path/Cargo.toml
@@ -20,7 +20,7 @@ memchr = { version = "2", default-features = false }
 [dev-dependencies]
 criterion = { version = "0.8", default-features = false }
 once_cell = { version = "1", features = ["std"], default-features = false }
-rand = { version = "0.10.1", features = [
+rand = { version = "0.10", features = [
   "alloc",
   "thread_rng",
 ], default-features = false }


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

The RustCrypto-related dependencies in Cargo.toml were outdated, so we are updating them to the latest versions.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
