### PR TITLE
fix(core): fix incompatibilities caused by the latest cargo fix

### DIFF
--- a/llrt_core/build.rs
+++ b/llrt_core/build.rs
@@ -183,10 +183,7 @@ fn generate_bytecode_cache(out_dir: &str) -> StdResult<(), Box<dyn Error>> {
 
             info!("Done!");
 
-            ph_map.entry(
-                module_name,
-                format!("include_bytes!(\"{}\")", &lrt_filename),
-            );
+            ph_map.entry(module_name, format!("include_bytes!(\"{}\")", lrt_filename));
         }
 
         StdResult::<_, Box<dyn Error>>::Ok(())

--- a/llrt_core/src/runtime_client.rs
+++ b/llrt_core/src/runtime_client.rs
@@ -421,7 +421,7 @@ async fn start_process_events<'js>(
         .await
         {
             if request_id.is_empty() {
-                return Err(err)?;
+                return Err(err);
             }
 
             let err = CaughtError::from_error(ctx, err);
@@ -489,7 +489,7 @@ async fn post_error<'js>(
     let mut error_stack = None;
     let mut error_type = None;
     let error_msg = match error {
-        CaughtError::Error(err) => format!("Error: {:?}", &err),
+        CaughtError::Error(err) => format!("Error: {:?}", err),
         CaughtError::Exception(ex) => {
             let error_name = get_class_name(ex)
                 .unwrap_or(None)


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

After applying the latest rust toolchain, we found new incompatibilities and have fixed them.

```
% rustup update
   stable-aarch64-apple-darwin unchanged - rustc 1.97.0 (2d8144b78 2026-07-07)
  nightly-aarch64-apple-darwin unchanged - rustc 1.99.0-nightly (af3d95584 2026-07-09)
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
