### PR TITLE
fix: cookie handling not working with Hono framework

### DIFF
--- a/modules/llrt_fetch/src/headers.rs
+++ b/modules/llrt_fetch/src/headers.rs
@@ -611,8 +611,6 @@ fn is_forbidden_request_header(name: &str) -> bool {
         || name == ACCESS_CONTROL_REQUEST_METHOD
         || name == CONNECTION
         || name == CONTENT_LENGTH
-        || name == COOKIE
-        || name == "cookie2"
         || name == DATE
         || name == "dnt"
         || name == EXPECT

--- a/tests/unit/fetch.request.test.ts
+++ b/tests/unit/fetch.request.test.ts
@@ -437,4 +437,13 @@ describe("Request class", () => {
       });
     }).toThrow();
   });
+
+  it("should preserve Cookie headers when initializing a Request and setting on request.headers", () => {
+    const req = new Request("https://example.com", {
+      headers: { cookie: "foo=bar" },
+    });
+    expect(req.headers.get("cookie")).toEqual("foo=bar");
+    req.headers.append("cookie", "baz=qux");
+    expect(req.headers.get("cookie")).toEqual("foo=bar; baz=qux");
+  });
 });

--- a/tests/wpt/_harness-util.js
+++ b/tests/wpt/_harness-util.js
@@ -79,13 +79,24 @@ export function createContext({ extras = {}, scripts = [] } = {}) {
   return context;
 }
 
-function attachCompletion(context, done) {
+function attachCompletion(context, done, ctx = {}) {
   context.add_completion_callback((tests) => {
     const real = tests.filter(
       ({ name, status }) => !(name === "Loading data..." && status === 0)
     );
     if (real.length === 0) return done(new Error("No tests were executed!"));
-    const failure = real.find((t) => t.status !== 0);
+    const failure = real.find((t) => {
+      if (t.status === 0) return false;
+      if (ctx.skipErrors && ctx.skipErrors.length > 0) {
+        const errStr = `[${t.name}] ${t.message || String(t)}`;
+        return !ctx.skipErrors.some((skip) =>
+          typeof skip === "string"
+            ? errStr.includes(skip) || t.name.includes(skip)
+            : skip.test(errStr)
+        );
+      }
+      return true;
+    });
     done(failure && `[${failure.name}] ${failure.message || String(failure)}`);
   });
 }
@@ -115,7 +126,7 @@ export function makeRunner(config) {
   return (source, done, ctx = {}) => {
     const context = createContext(config.context ? config.context(ctx) : {});
     config.postSetup?.(context, ctx);
-    attachCompletion(context, done);
+    attachCompletion(context, done, ctx);
     const [src, extras = ""] = config.wrap
       ? config.wrap(source, ctx)
       : [source, loadMetaScripts(source, ctx.testDir)];
@@ -134,9 +145,16 @@ export function runSuite(metaUrl, harness, skipFiles = []) {
     .split(".")
     .join(path.sep);
   const targetDir = path.join(WPT_DIR, subDir);
+
+  const matchesFile = (file, pattern) => {
+    if (typeof pattern === "string") return pattern === file;
+    if (pattern instanceof RegExp) return pattern.test(file);
+    return false;
+  };
+
   const skip = (f) =>
     /\.tentative\./.test(f) ||
-    skipFiles.some((s) => (s instanceof RegExp ? s.test(f) : s === f));
+    skipFiles.some((s) => !Array.isArray(s) && matchesFile(f, s));
   const testFiles = fs
     .readdirSync(targetDir)
     .filter((f) => f.endsWith(".any.js") && !skip(f));
@@ -145,7 +163,17 @@ export function runSuite(metaUrl, harness, skipFiles = []) {
     for (const file of testFiles) {
       it(`should pass ${file} tests`, (done) => {
         const source = fs.readFileSync(path.join(targetDir, file), "utf8");
-        harness(source, done, { baseDir: WPT_DIR, testDir: targetDir });
+        const fileErrorSkipRules = skipFiles.filter(
+          (s) => Array.isArray(s) && matchesFile(file, s[0])
+        );
+        const skipErrors = fileErrorSkipRules.flatMap((s) =>
+          Array.isArray(s[1]) ? s[1] : [s[1]]
+        );
+        harness(source, done, {
+          baseDir: WPT_DIR,
+          testDir: targetDir,
+          ...(skipErrors.length > 0 ? { skipErrors } : {}),
+        });
       });
     }
   });

--- a/tests/wpt/fetch.api.request.test.ts
+++ b/tests/wpt/fetch.api.request.test.ts
@@ -9,4 +9,12 @@ runSuite(import.meta.url, runTestDynamic, [
   "request-cache-no-store.any.js", // ReferenceError: promise_test is not defined
   "request-cache-only-if-cached.any.js", // ReferenceError: promise_test is not defined
   "request-cache-reload.any.js", // ReferenceError: promise_test is not defined
+  [
+    "request-headers.any.js",
+    [
+      '[Adding invalid request header "Cookie: KO"] assert_equals: expected (object) null but got (string) "KO"',
+      '[Adding invalid request header "Cookie2: KO"] assert_equals: expected (object) null but got (string) "KO"',
+      '[Check that request constructor is filtering headers provided as init parameter] assert_equals: expected (object) null but got (string) "potato"',
+    ],
+  ],
 ]);


### PR DESCRIPTION
### Issue # (if available)

Resolves https://github.com/awslabs/llrt/issues/1638

### Description of changes

Exempt cookie headers from being stripped, they are ok for server-side runtimes.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
