### PR TITLE
Wait for every WPT server origin before running the suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,15 +236,21 @@ test-wpt: setup-wpt js
 	@echo "Starting WPT server (logs: wpt_server.log)..."
 	@./wpt/wpt serve >wpt_server.log 2>&1 & WPT_PID=$$!; \
 	trap 'kill $$WPT_PID 2>/dev/null' EXIT; \
-	printf "Waiting for http://web-platform.test:8000/ "; \
-	for i in $$(seq 1 150); do \
-		curl -sf --connect-timeout 1 http://web-platform.test:8000/ >/dev/null 2>&1 && { echo " ready."; break; }; \
-		if ! kill -0 $$WPT_PID 2>/dev/null; then \
-			echo "WPT server exited unexpectedly:"; cat wpt_server.log; exit 1; \
-		fi; \
-		printf "."; \
-		sleep 0.2; \
-	done || { echo "WPT server failed to start:"; cat wpt_server.log; kill $$WPT_PID 2>/dev/null; exit 1; }; \
+	for url in http://web-platform.test:8000/ \
+	           http://www1.web-platform.test:8000/ \
+	           https://web-platform.test:8443/; do \
+		printf "Waiting for %s " "$$url"; \
+		ready=; \
+		for i in $$(seq 1 150); do \
+			curl -sfk --connect-timeout 1 "$$url" >/dev/null 2>&1 && { ready=1; echo " ready."; break; }; \
+			if ! kill -0 $$WPT_PID 2>/dev/null; then \
+				echo "WPT server exited unexpectedly:"; cat wpt_server.log; exit 1; \
+			fi; \
+			printf "."; \
+			sleep 0.2; \
+		done; \
+		[ -n "$$ready" ] || { echo " timeout."; cat wpt_server.log; exit 1; }; \
+	done; \
 	npx pretty-quick --pattern "tests/wpt/**/*.{js,ts,json}"; \
 	TEST_REPORT_FILE=wpt_errors.txt cargo run -- test -d bundle/js/__tests__/$(TEST_SUB_DIR); \
 	kill $$WPT_PID 2>/dev/null

--- a/modules/llrt_exceptions/src/lib.rs
+++ b/modules/llrt_exceptions/src/lib.rs
@@ -15,7 +15,7 @@ use rquickjs::{
         JsClass, Trace,
     },
     function::{Constructor, Opt},
-    object::Property,
+    object::{Accessor, Property},
     prelude::{Func, This},
     qjs, Class, Coerced, Ctx, Error, Exception, FromJs, IntoJs, JsLifetime, Object, Result, Value,
 };
@@ -51,7 +51,7 @@ impl fmt::Display for DOMException {
         f.debug_struct("DOMException")
             .field("name", &self.name())
             .field("message", &self.message())
-            .field("stack", &self.stack())
+            .field("stack", &self.stack)
             .finish()
     }
 }
@@ -194,11 +194,6 @@ impl DOMException {
     #[qjs(get, enumerable, configurable)]
     pub fn code(&self) -> u8 {
         self.code
-    }
-
-    #[qjs(get)]
-    fn stack(&self) -> String {
-        self.stack.clone()
     }
 
     #[qjs(prop, rename = PredefinedAtom::SymbolToStringTag, configurable)]
@@ -411,7 +406,43 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
         .constructor_error
         .set("isError", Func::from(is_error))?;
 
+    define_error_stack_accessor(ctx)?;
+
     Ok(())
+}
+
+// https://tc39.es/proposal-error-stack-accessor/ moves `stack` to an accessor
+// on `Error.prototype`, so DOMException inherits it instead of exposing its own.
+// QuickJS still gives plain Error instances an own `stack` data property, which
+// shadows this accessor, so the getter only runs for DOMException instances.
+fn define_error_stack_accessor<'js>(ctx: &Ctx<'js>) -> Result<()> {
+    let prototype_error = BasePrimordials::get(ctx)?.prototype_error.clone();
+    prototype_error.prop(
+        PredefinedAtom::Stack,
+        Accessor::new(
+            |this: This<Value<'js>>| -> Result<String> {
+                let stack = Class::<DOMException>::from_value(&this.0)
+                    .ok()
+                    .map(|cls| cls.borrow().stack.clone());
+                Ok(stack.unwrap_or_default())
+            },
+            |ctx: Ctx<'js>, this: This<Value<'js>>, value: Value<'js>| -> Result<()> {
+                // SetterThatIgnoresPrototypeProperties: never install on the
+                // home object itself.
+                let Some(obj) = this.0.as_object() else {
+                    return Ok(());
+                };
+                if *obj == BasePrimordials::get(&ctx)?.prototype_error {
+                    return Ok(());
+                }
+                obj.prop(
+                    PredefinedAtom::Stack,
+                    Property::from(value).writable().enumerable().configurable(),
+                )
+            },
+        )
+        .configurable(),
+    )
 }
 
 fn is_error<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<bool> {

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -15,4 +15,3 @@ streams/transform-streams > should pass terminate.any.js tests
 url > should pass IdnaTestV2.any.js tests
 url > should pass url-constructor.any.js tests
 url > should pass url-setters.any.js tests
-webidl/ecmascript-binding/es-exceptions > should pass DOMException-stack-accessor.any.js tests


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

The WPT job fails intermittently on unrelated PRs. On #1686 it reported `+fetch/api/basic > should pass response-null-body.any.js tests` caused by `TypeError: Failed to fetch`, and a rerun of the same commit passed.

`wpt serve` starts three origins asynchronously, but we only waited for `web-platform.test:8000`. Tests hitting `www1.web-platform.test:8000` or `https://web-platform.test:8443` could run before those listeners were up. Which suite lost the race varied per run, so the failures looked unrelated to the change under test.

The poll loop also swallowed its own timeout, since `for ...; done || { fail }` never fires when the loop runs out of iterations. Now we wait for all three origins and abort if any is not ready in time.

Also fixes `DOMException-stack-accessor.any.js`. The stack proposal puts `stack` on `Error.prototype` as a configurable accessor, so `DOMException.prototype` must not have its own. We now install that accessor, with the setter behaviour the spec asks for, and drop the DOMException getter. Plain Error instances keep their own `stack` data property, so they are unaffected.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._