### PR TITLE
fix: validate offsets against view bounds

### DIFF
--- a/modules/llrt_buffer/src/buffer.rs
+++ b/modules/llrt_buffer/src/buffer.rs
@@ -37,6 +37,28 @@ impl<'js> Primordial<'js> for BufferPrimordials<'js> {
 
 pub struct Buffer(pub Vec<u8>);
 
+fn resolve_view_bytes<'js>(
+    ctx: &Ctx<'js>,
+    array_buffer: ArrayBuffer<'js>,
+    byte_length: usize,
+    byte_offset: usize,
+) -> Result<&'js mut [u8]> {
+    let raw = array_buffer
+        .as_raw()
+        .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED)
+        .or_throw(ctx)?;
+
+    if byte_offset > raw.len || byte_length > raw.len - byte_offset {
+        return Err(Exception::throw_range(
+            ctx,
+            "The value of \"byteOffset\" is out of range",
+        ));
+    }
+
+    // SAFETY: bounds checked above.
+    Ok(unsafe { slice::from_raw_parts_mut(raw.ptr.as_ptr().add(byte_offset), byte_length) })
+}
+
 impl<'js> IntoJs<'js> for Buffer {
     fn into_js(self, ctx: &Ctx<'js>) -> Result<Value<'js>> {
         let array_buffer = ArrayBuffer::new(ctx.clone(), self.0)?;
@@ -337,27 +359,37 @@ fn copy<'js>(
     let source_start = args_iter.next().unwrap_or_default();
     let source_end = args_iter.next().unwrap_or_else(|| this.0.len());
 
+    let source_bytes = ObjectBytes::from(&ctx, this.0.as_inner())?;
+    let source_bytes = source_bytes.as_bytes(&ctx)?;
+
+    if source_start > source_bytes.len() {
+        return Err(Exception::throw_range(
+            &ctx,
+            "The value of \"sourceStart\" is out of range",
+        ));
+    }
+
+    // sourceEnd is clamped (not an error), unlike sourceStart above.
+    let source_end = source_end.min(source_bytes.len());
+
     let mut copyable_length = 0;
 
     if source_start >= source_end {
         return Ok(copyable_length);
     }
 
-    let source_bytes = ObjectBytes::from(&ctx, this.0.as_inner())?;
-    let source_bytes = source_bytes.as_bytes(&ctx)?;
+    if let Some((array_buffer, target_byte_length, target_byte_offset)) =
+        target.get_array_buffer()?
+    {
+        let target_bytes =
+            resolve_view_bytes(&ctx, array_buffer, target_byte_length, target_byte_offset)?;
 
-    if let Some((array_buffer, _, _)) = target.get_array_buffer()? {
-        let raw = array_buffer
-            .as_raw()
-            .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED)
-            .or_throw(&ctx)?;
+        if target_start <= target_bytes.len() {
+            copyable_length = (source_end - source_start).min(target_bytes.len() - target_start);
 
-        let target_bytes = unsafe { slice::from_raw_parts_mut(raw.ptr.as_ptr(), raw.len) };
-
-        copyable_length = (source_end - source_start).min(raw.len - target_start);
-
-        target_bytes[target_start..target_start + copyable_length]
-            .copy_from_slice(&source_bytes[source_start..source_start + copyable_length]);
+            target_bytes[target_start..target_start + copyable_length]
+                .copy_from_slice(&source_bytes[source_start..source_start + copyable_length]);
+        }
     }
 
     Ok(copyable_length)
@@ -429,19 +461,17 @@ fn write<'js>(
     string: String,
     args: Rest<Value<'js>>,
 ) -> Result<usize> {
-    let (offset, length, encoding) = get_write_parameters(&args, this.0.len())?;
+    let (offset, length, encoding) = get_write_parameters(&ctx, &args, this.0.len())?;
 
     let target = ObjectBytes::from(&ctx, this.0.as_inner())?;
 
     let mut writable_length = 0;
 
-    if let Some((array_buffer, _, _)) = target.get_array_buffer()? {
-        let raw = array_buffer
-            .as_raw()
-            .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED)
-            .or_throw(&ctx)?;
-
-        let target_bytes = unsafe { slice::from_raw_parts_mut(raw.ptr.as_ptr(), raw.len) };
+    if let Some((array_buffer, target_byte_length, target_byte_offset)) =
+        target.get_array_buffer()?
+    {
+        let target_bytes =
+            resolve_view_bytes(&ctx, array_buffer, target_byte_length, target_byte_offset)?;
 
         let encoder = Encoder::from_str(&encoding).or_throw(&ctx)?;
 
@@ -460,7 +490,11 @@ fn write<'js>(
     Ok(writable_length)
 }
 
-fn get_write_parameters(args: &Rest<Value<'_>>, len: usize) -> Result<(usize, usize, String)> {
+fn get_write_parameters<'js>(
+    ctx: &Ctx<'js>,
+    args: &Rest<Value<'js>>,
+    len: usize,
+) -> Result<(usize, usize, String)> {
     let mut offset = 0;
     let mut length = len;
     let mut encoding = "utf8".to_owned();
@@ -470,6 +504,13 @@ fn get_write_parameters(args: &Rest<Value<'_>>, len: usize) -> Result<(usize, us
             return Ok((0, len, s.to_string()?));
         }
         offset = v1.as_int().unwrap_or(0) as usize;
+        if offset > len {
+            return Err(Exception::throw_range(
+                ctx,
+                "The value of \"offset\" is out of range",
+            ));
+        }
+        length = len - offset;
     }
 
     if let Some(v2) = args.0.get(1) {
@@ -674,13 +715,11 @@ fn write_buf<'js>(
     let target = ObjectBytes::from(ctx, this.0.as_inner())?;
     let mut writable_length = 0;
 
-    if let Some((array_buffer, _, _)) = target.get_array_buffer()? {
-        let raw = array_buffer
-            .as_raw()
-            .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED)
-            .or_throw(ctx)?;
-
-        let target_bytes = unsafe { slice::from_raw_parts_mut(raw.ptr.as_ptr(), raw.len) };
+    if let Some((array_buffer, target_byte_length, target_byte_offset)) =
+        target.get_array_buffer()?
+    {
+        let target_bytes =
+            resolve_view_bytes(ctx, array_buffer, target_byte_length, target_byte_offset)?;
 
         writable_length = offset + bytes.len();
         target_bytes[offset..writable_length].copy_from_slice(&bytes);
@@ -698,19 +737,17 @@ fn read_buf<'js>(
 ) -> Result<Value<'js>> {
     // Retrieve the array buffer
     let target = ObjectBytes::from(ctx, this.0.as_inner())?;
-    let Some((array_buffer, _, _)) = target.get_array_buffer()? else {
+    let Some((array_buffer, target_byte_length, target_byte_offset)) = target.get_array_buffer()?
+    else {
         return Err(Exception::throw_message(ctx, ERROR_MSG_NOT_ARRAY_BUFFER));
     };
-    let raw = array_buffer
-        .as_raw()
-        .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED)
-        .or_throw(ctx)?;
-    let target_bytes = unsafe { slice::from_raw_parts_mut(raw.ptr.as_ptr(), raw.len) };
+    let target_bytes =
+        resolve_view_bytes(ctx, array_buffer, target_byte_length, target_byte_offset)?;
 
     // Enforce the bounds
     let start = offset.0.unwrap_or_default();
     let end = start + (kind.bits() / 8) as usize;
-    if end > raw.len {
+    if end > target_bytes.len() {
         return Err(Exception::throw_range(
             ctx,
             "The value of \"offset\" is out of range",

--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -149,11 +149,30 @@ fn random_fill_sync<'js>(
             .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED)
             .or_throw(&ctx)?;
 
+        if offset > source_length {
+            return Err(Exception::throw_range(
+                &ctx,
+                "The value of \"offset\" is out of range",
+            ));
+        }
+        if let Some(size) = size.0 {
+            if offset + size > source_length {
+                return Err(Exception::throw_range(
+                    &ctx,
+                    "The value of \"size + offset\" is out of range",
+                ));
+            }
+        }
+
         let (start, end) = get_start_end_indexes(source_length, size.0, offset);
 
-        let bytes = unsafe { slice::from_raw_parts_mut(raw.ptr.as_ptr(), source_length) };
+        // SAFETY: source_offset..+source_length stays in the backing buffer;
+        // start/end are clamped to it above.
+        let bytes = unsafe {
+            slice::from_raw_parts_mut(raw.ptr.as_ptr().add(source_offset), source_length)
+        };
 
-        rand::rng().fill(&mut bytes[start + source_offset..end - source_offset]);
+        rand::rng().fill(&mut bytes[start..end]);
     }
 
     Ok(obj)

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -474,6 +474,47 @@ describe("copy", () => {
     expect(bufSrc.copy(bufDest, 5, 10, 9)).toEqual(0);
     expect(bufDest.toString()).toEqual("**************************");
   });
+
+  it("should return 0 and not modify the destination buffer when targetStart is out of range, instead of crashing", () => {
+    const bufSrc = Buffer.from("hello world");
+    const bufDest = Buffer.alloc(4);
+    expect(bufSrc.copy(bufDest, 100, 0, 5)).toEqual(0);
+    expect(bufDest.toString()).toEqual("\u0000\u0000\u0000\u0000");
+  });
+
+  it("should throw a RangeError instead of crashing when sourceStart is out of range", () => {
+    const bufSrc = Buffer.from("hello world");
+    const bufDest = Buffer.alloc(4);
+    expect(() => {
+      bufSrc.copy(bufDest, 0, 1000);
+    }).toThrow(RangeError);
+  });
+
+  it("should clamp sourceEnd to the source buffer's length instead of throwing", () => {
+    const bufSrc = Buffer.from("hello");
+    const bufDest = Buffer.alloc(10);
+    expect(bufSrc.copy(bufDest, 0, 0, 1000)).toEqual(5);
+    expect(bufDest.toString("utf8", 0, 5)).toEqual("hello");
+  });
+
+  it("should copy into the destination view's actual location, not its backing buffer's start", () => {
+    const backing = new ArrayBuffer(64);
+    const bufSrc = Buffer.from([1, 2, 3, 4, 5]);
+    const target = Buffer.from(backing, 40, 10);
+    expect(bufSrc.copy(target, 0, 0, 5)).toEqual(5);
+    const full = new Uint8Array(backing);
+    expect(Array.from(full.slice(0, 5))).toEqual([0, 0, 0, 0, 0]);
+    expect(Array.from(full.slice(40, 45))).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("should bound the copy to the destination view's own length, not its backing buffer's length", () => {
+    const backing = new ArrayBuffer(20);
+    const view = new Uint8Array(backing, 0, 5);
+    const bufSrc = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(bufSrc.copy(view, 0, 0, 10)).toEqual(5);
+    const full = new Uint8Array(backing);
+    expect(Array.from(full.slice(5, 10))).toEqual([0, 0, 0, 0, 0]);
+  });
 });
 
 describe("subarray", () => {
@@ -681,6 +722,42 @@ describe("write", () => {
     const buf2 = Buffer.alloc(15);
     expect(buf2.write("68656c6c6f", 9, 12, "hex")).toEqual(5);
     expect(buf2.toString("utf8").substring(9, 12)).toEqual("hel");
+  });
+
+  it("should default the writable length to the remaining space when only an offset is given", () => {
+    const buf = Buffer.alloc(10);
+    expect(buf.write("hello world", 5)).toEqual(5);
+    expect(buf.toString()).toEqual("\u0000\u0000\u0000\u0000\u0000hello");
+  });
+
+  it("should write nothing when offset equals the buffer's length", () => {
+    const buf = Buffer.alloc(4);
+    expect(buf.write("x", 4)).toEqual(0);
+  });
+
+  it("should throw a RangeError instead of crashing when offset is out of range", () => {
+    const buf = Buffer.alloc(4);
+    expect(() => {
+      buf.write("hello world", 100);
+    }).toThrow(RangeError);
+  });
+
+  it("should write into a view's actual location, not its backing buffer's start", () => {
+    const backing = new ArrayBuffer(64);
+    const view = Buffer.from(backing, 40, 10);
+    expect(view.write("HELLO")).toEqual(5);
+    const full = new Uint8Array(backing);
+    expect(Array.from(full.slice(0, 5))).toEqual([0, 0, 0, 0, 0]);
+    expect(Array.from(full.slice(40, 45))).toEqual([72, 69, 76, 76, 79]);
+  });
+
+  it("should write into a subarray's actual location, not its backing buffer's start", () => {
+    const backing = new ArrayBuffer(64);
+    const view = Buffer.from(backing).subarray(40, 50);
+    expect(view.write("HELLO")).toEqual(5);
+    const full = new Uint8Array(backing);
+    expect(Array.from(full.slice(0, 5))).toEqual([0, 0, 0, 0, 0]);
+    expect(Array.from(full.slice(40, 45))).toEqual([72, 69, 76, 76, 79]);
   });
 });
 
@@ -907,6 +984,16 @@ describe("writeInt32BE", () => {
       const buf = Buffer.alloc(8);
       buf.writeInt32BE(0x01020304, 5);
     }).toThrow(RangeError);
+  });
+
+  it("should write into a view's actual location, not its backing buffer's start", () => {
+    const backing = new ArrayBuffer(64);
+    const view = Buffer.from(backing, 40, 10);
+    expect(view.writeInt32BE(0x11223344, 0)).toEqual(4);
+    const full = new Uint8Array(backing);
+    expect(Array.from(full.slice(0, 4))).toEqual([0, 0, 0, 0]);
+    expect(Array.from(full.slice(40, 44))).toEqual([0x11, 0x22, 0x33, 0x44]);
+    expect(view.readInt32BE(0)).toEqual(0x11223344);
   });
 });
 

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -117,6 +117,38 @@ describe("random", () => {
     });
   });
 
+  it("should fill only the requested view range for a typed array with a non-zero byteOffset", () => {
+    const backing = new ArrayBuffer(64);
+    const view = new Uint8Array(backing, 16, 32);
+    view.fill(0);
+    randomFillSync(view, 20);
+    // Bytes before the fill offset must remain untouched.
+    for (let i = 0; i < 20; i++) {
+      expect(view[i]).toEqual(0);
+    }
+    // The rest of the backing buffer (outside the view) must be untouched too.
+    const full = new Uint8Array(backing);
+    for (let i = 0; i < 16; i++) {
+      expect(full[i]).toEqual(0);
+    }
+  });
+
+  it("should throw a RangeError instead of crashing when offset exceeds the view length", () => {
+    const backing = new ArrayBuffer(64);
+    const view = new Uint8Array(backing, 16, 32);
+    expect(() => {
+      randomFillSync(view, 100);
+    }).toThrow(RangeError);
+  });
+
+  it("should throw a RangeError instead of crashing when size + offset exceeds the view length", () => {
+    const backing = new ArrayBuffer(64);
+    const view = new Uint8Array(backing, 16, 32);
+    expect(() => {
+      randomFillSync(view, 0, 100);
+    }).toThrow(RangeError);
+  });
+
   it("should generate a random UUID using randomUUID", () => {
     const uuid = randomUUID();
     expect(uuid.length).toEqual(36);


### PR DESCRIPTION
### Description of changes

Buffer.prototype.copy/write and crypto.randomFillSync could abort the process on out-of-range offsets

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
