### PR TITLE
fix(crypto): Improvements to subtle.generateKey

### DIFF
--- a/modules/llrt_crypto/src/provider/mod.rs
+++ b/modules/llrt_crypto/src/provider/mod.rs
@@ -444,6 +444,17 @@ impl std::fmt::Display for CryptoError {
 
 impl std::error::Error for CryptoError {}
 
+pub fn parse_rsa_public_exponent(public_exponent: &[u8]) -> Result<u64, CryptoError> {
+    match public_exponent {
+        [0x01, 0x00, 0x01] => Ok(65537),
+        [0x03] => Ok(3),
+        bytes if bytes.ends_with(&[0x03]) && bytes[..bytes.len() - 1].iter().all(|&b| b == 0) => {
+            Ok(3)
+        },
+        _ => Err(CryptoError::OperationFailed(None)),
+    }
+}
+
 #[cfg(feature = "crypto-openssl")]
 pub type DefaultProvider = openssl::OpenSslProvider;
 

--- a/modules/llrt_crypto/src/provider/rust/mod.rs
+++ b/modules/llrt_crypto/src/provider/rust/mod.rs
@@ -55,7 +55,9 @@ use sha1::Sha1;
 
 use crate::{
     hash::HashAlgorithm,
-    provider::{AesMode, CryptoError, CryptoProvider, HmacProvider, SimpleDigest},
+    provider::{
+        parse_rsa_public_exponent, AesMode, CryptoError, CryptoProvider, HmacProvider, SimpleDigest,
+    },
     random_byte_array,
     subtle::EllipticCurve,
 };
@@ -928,16 +930,7 @@ impl CryptoProvider for RustCryptoProvider {
         modulus_length: u32,
         public_exponent: &[u8],
     ) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
-        let exponent: u64 = match public_exponent {
-            [0x01, 0x00, 0x01] => 65537,
-            [0x03] => 3,
-            bytes
-                if bytes.ends_with(&[0x03]) && bytes[..bytes.len() - 1].iter().all(|&b| b == 0) =>
-            {
-                3
-            },
-            _ => return Err(CryptoError::InvalidData(None)),
-        };
+        let exponent = parse_rsa_public_exponent(public_exponent)?;
 
         let exp = BoxedUint::from(exponent);
         let mut rng = rand::rng();

--- a/modules/llrt_crypto/src/subtle/generate_key.rs
+++ b/modules/llrt_crypto/src/subtle/generate_key.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use rquickjs::{object::Property, Array, Class, Ctx, Exception, Object, Result, Value};
+use llrt_exceptions::DOMException;
+use rquickjs::{object::Property, Array, Class, Ctx, Object, Result, Value};
 
 use crate::{provider::CryptoProvider, CRYPTO_PROVIDER};
 
@@ -10,12 +11,13 @@ use super::{
     algorithm_not_supported_error,
     crypto_key::KeyKind,
     key_algorithm::{KeyAlgorithm, KeyAlgorithmMode, KeyAlgorithmWithUsages},
+    util::ResultDomExt,
 };
 
 pub async fn subtle_generate_key<'js>(
     ctx: Ctx<'js>,
     algorithm: Value<'js>,
-    extractable: bool,
+    extractable: Value<'js>,
     key_usages: Array<'js>,
 ) -> Result<Value<'js>> {
     let KeyAlgorithmWithUsages {
@@ -26,6 +28,10 @@ pub async fn subtle_generate_key<'js>(
     } = KeyAlgorithm::from_js(&ctx, KeyAlgorithmMode::Generate, algorithm, key_usages)?;
 
     let (private_key, public_or_secret_key) = generate_key(&ctx, &key_algorithm)?;
+
+    let Some(extractable) = extractable.as_bool() else {
+        return Err(DOMException::not_supported_error(&ctx, "Invalid parameter"));
+    };
 
     if matches!(
         key_algorithm,
@@ -62,7 +68,7 @@ pub async fn subtle_generate_key<'js>(
         CryptoKey::new(
             KeyKind::Public,
             name,
-            extractable,
+            true,
             key_algorithm,
             public_usages,
             public_or_secret_key,
@@ -79,37 +85,33 @@ fn generate_key(ctx: &Ctx<'_>, algorithm: &KeyAlgorithm) -> Result<(Vec<u8>, Vec
     match algorithm {
         KeyAlgorithm::Aes { length } => {
             // Default to AES-256
-            let key = CRYPTO_PROVIDER.generate_aes_key(*length).map_err(|e| {
-                Exception::throw_message(ctx, &format!("AES key generation failed: {}", e))
-            })?;
+            let key = CRYPTO_PROVIDER
+                .generate_aes_key(*length)
+                .or_throw_dom(ctx, "AES key generation failed")?;
             Ok((vec![], key))
         },
         KeyAlgorithm::Hmac { hash, length } => {
             let key = CRYPTO_PROVIDER
                 .generate_hmac_key(*hash, *length)
-                .map_err(|e| {
-                    Exception::throw_message(ctx, &format!("HMAC key generation failed: {}", e))
-                })?;
+                .or_throw_dom(ctx, "HMAC key generation failed")?;
             Ok((vec![], key))
         },
-        KeyAlgorithm::Ec { curve, .. } => CRYPTO_PROVIDER.generate_ec_key(*curve).map_err(|e| {
-            Exception::throw_message(ctx, &format!("EC key generation failed: {}", e))
-        }),
-        KeyAlgorithm::Ed25519 => CRYPTO_PROVIDER.generate_ed25519_key().map_err(|e| {
-            Exception::throw_message(ctx, &format!("Ed25519 key generation failed: {}", e))
-        }),
-        KeyAlgorithm::X25519 => CRYPTO_PROVIDER.generate_x25519_key().map_err(|e| {
-            Exception::throw_message(ctx, &format!("X25519 key generation failed: {}", e))
-        }),
+        KeyAlgorithm::Ec { curve, .. } => CRYPTO_PROVIDER
+            .generate_ec_key(*curve)
+            .or_throw_dom(ctx, "EC key generation failed"),
+        KeyAlgorithm::Ed25519 => CRYPTO_PROVIDER
+            .generate_ed25519_key()
+            .or_throw_dom(ctx, "Ed25519 key generation failed"),
+        KeyAlgorithm::X25519 => CRYPTO_PROVIDER
+            .generate_x25519_key()
+            .or_throw_dom(ctx, "X25519 key generation failed"),
         KeyAlgorithm::Rsa {
             modulus_length,
             public_exponent,
             ..
         } => CRYPTO_PROVIDER
             .generate_rsa_key(*modulus_length, public_exponent.as_ref())
-            .map_err(|e| {
-                Exception::throw_message(ctx, &format!("RSA key generation failed: {}", e))
-            }),
+            .or_throw_dom(ctx, "RSA key generation failed"),
         _ => algorithm_not_supported_error(ctx),
     }
 }
@@ -126,7 +128,10 @@ pub fn get_hash_length(ctx: &Ctx, hash: &HashAlgorithm, length: u16) -> Result<u
     }
 
     if !length.is_multiple_of(8) || (length / 8) as usize > 128 {
-        return Err(Exception::throw_message(ctx, "Invalid HMAC key length"));
+        return Err(DOMException::not_supported_error(
+            ctx,
+            "Invalid HMAC key length",
+        ));
     }
 
     Ok((length / 8) as usize)

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -18,14 +18,14 @@ use rquickjs::{
 #[cfg(feature = "_subtle-full")]
 use spki::{AlgorithmIdentifier, ObjectIdentifier};
 
-use crate::{hash::HashAlgorithm, subtle::normalize_algorithm_name};
+use crate::{hash::HashAlgorithm, provider::parse_rsa_public_exponent};
 
 #[cfg(feature = "_subtle-full")]
 use super::algorithm_mismatch_error;
 use super::{
     algorithm_not_supported_error,
     crypto_key::KeyKind,
-    to_name_and_maybe_object,
+    normalize_algorithm_name, to_name_and_maybe_object,
     util::{NotSupportedError, ResultDomExt},
     EllipticCurve,
 };
@@ -572,8 +572,6 @@ fn from_rsa<'js>(
     private_usages: &mut Vec<String>,
     public_usages: &mut Vec<String>,
 ) -> Result<KeyAlgorithm> {
-    use crate::provider::parse_rsa_public_exponent;
-
     let obj = obj.or_throw(ctx)?;
     let hash = extract_sha_hash(ctx, &obj)?;
     let is_generate = mode == KeyAlgorithmMode::Generate;

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use der::{asn1::OctetStringRef, Decode, Encode};
 #[cfg(feature = "_subtle-full")]
 use llrt_encoding::bytes_from_b64_url_safe;
+use llrt_exceptions::DOMException;
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt, str_enum};
 #[cfg(feature = "_subtle-full")]
 use pkcs8::PrivateKeyInfoRef;
@@ -17,12 +18,16 @@ use rquickjs::{
 #[cfg(feature = "_subtle-full")]
 use spki::{AlgorithmIdentifier, ObjectIdentifier};
 
-use crate::hash::HashAlgorithm;
+use crate::{hash::HashAlgorithm, subtle::normalize_algorithm_name};
 
 #[cfg(feature = "_subtle-full")]
 use super::algorithm_mismatch_error;
 use super::{
-    algorithm_not_supported_error, crypto_key::KeyKind, to_name_and_maybe_object, EllipticCurve,
+    algorithm_not_supported_error,
+    crypto_key::KeyKind,
+    to_name_and_maybe_object,
+    util::{NotSupportedError, ResultDomExt},
+    EllipticCurve,
 };
 
 #[derive(Clone, Copy, PartialEq)]
@@ -86,7 +91,7 @@ impl KeyUsage {
             let usage = KeyUsage::try_from(value.as_str()).or_throw(ctx)?;
             let usage = usage.mask();
             if allowed_usages & usage != usage {
-                return Err(Exception::throw_message(
+                return Err(Exception::throw_syntax(
                     ctx,
                     &["Invalid key usage '", &value, "'"].concat(),
                 ));
@@ -105,15 +110,11 @@ impl KeyUsage {
         *private_usages = generated_private_usages;
         *public_usages = generated_public_usages;
 
-        if !has_any_usages {
-            return Err(Exception::throw_message(ctx, "Key usages empty"));
-        }
-
-        if private_usages_mask > 0 && private_usages.is_empty() {
-            return Err(Exception::throw_message(
-                ctx,
-                "No required private key usages provided",
-            ));
+        if !has_any_usages
+            && key_usage_algorithm.requires_non_empty_usages()
+            && !matches!(kind, Some(KeyKind::Public))
+        {
+            return Err(Exception::throw_syntax(ctx, "Key usages empty"));
         }
 
         if private_usages != public_usages {
@@ -126,7 +127,7 @@ impl KeyUsage {
             };
 
             if !valid_usage {
-                return Err(Exception::throw_message(ctx, "Invalid key usage"));
+                return Err(Exception::throw_syntax(ctx, "Invalid key usage"));
             }
         }
 
@@ -151,11 +152,12 @@ pub enum KeyUsageAlgorithm {
 
     Hmac = (KeyUsage::Sign.mask()) | (KeyUsage::Verify.mask()),
 
-    //two mask algorithms (asymmetric) - use high bits as for private, low bits for public
-    //HKDF, PBKDF2, X25519
-    Derive = ((KeyUsage::DeriveKey.mask() | KeyUsage::DeriveBits.mask()) << 8)
-        | KeyUsage::DeriveKey.mask()
-        | KeyUsage::DeriveBits.mask(),
+    // asymmetric derive algorithms - use high bits as private usages
+    // ECDH/X25519
+    DeriveAsymmetric = ((KeyUsage::DeriveKey.mask() | KeyUsage::DeriveBits.mask()) << 8),
+
+    // HKDF/PBKDF2
+    DeriveSymmetric = KeyUsage::DeriveKey.mask() | KeyUsage::DeriveBits.mask(),
 
     RsaOaep = ((KeyUsage::Decrypt.mask() | KeyUsage::UnwrapKey.mask()) << 8) //private
     | KeyUsage::Encrypt.mask() | KeyUsage::WrapKey.mask(), //public
@@ -170,6 +172,19 @@ impl KeyUsageAlgorithm {
         let private_mask = value >> 8;
         let public_mask = value & 0xFF;
         (private_mask, public_mask)
+    }
+
+    fn requires_non_empty_usages(self) -> bool {
+        matches!(
+            self,
+            Self::Symmetric
+                | Self::AesKw
+                | Self::Hmac
+                | Self::DeriveAsymmetric
+                | Self::DeriveSymmetric
+                | Self::Sign
+                | Self::RsaOaep
+        )
     }
 }
 
@@ -273,13 +288,14 @@ impl<'js> FromJs<'js> for KeyFormat {
                 _ => {},
             };
         }
-        Err(Exception::throw_message(
+        Err(DOMException::not_supported_error(
             ctx,
             "Key import/export format must be 'jwk','raw','spki' or 'pkcs8'",
         ))
     }
 }
 
+#[derive(PartialEq)]
 pub enum KeyFormatData<'js> {
     Jwk(Object<'js>),
     Raw(ObjectBytes<'js>),
@@ -287,6 +303,7 @@ pub enum KeyFormatData<'js> {
     Pkcs8(ObjectBytes<'js>),
 }
 
+#[derive(PartialEq)]
 pub enum KeyAlgorithmMode<'a, 'js> {
     Import {
         format: KeyFormatData<'js>,
@@ -399,7 +416,7 @@ fn from_x25519<'js>(
     let key_kind = import(ctx, mode, algorithm_name)?;
     KeyUsage::classify_and_check_usages(
         ctx,
-        KeyUsageAlgorithm::Derive,
+        KeyUsageAlgorithm::DeriveAsymmetric,
         usages,
         private_usages,
         public_usages,
@@ -450,9 +467,9 @@ fn from_aes<'js>(
     let (length, key_kind) = import(ctx, mode, obj, algorithm_name)?;
 
     if !matches!(length, 128 | 192 | 256) {
-        return Err(Exception::throw_message(
+        return Err(DOMException::operation_error(
             ctx,
-            &format!(
+            format!(
                 "Algorithm 'length' must be one of: 128, 192, or 256 = {}",
                 length
             ),
@@ -486,7 +503,18 @@ fn from_hmac<'js>(
 ) -> Result<KeyAlgorithm> {
     let obj = obj.or_throw(ctx)?;
     let hash = extract_sha_hash(ctx, &obj)?;
-    let mut length: u16 = obj.get_optional("length")?.unwrap_or_default();
+    if !matches!(
+        hash,
+        HashAlgorithm::Sha1 | HashAlgorithm::Sha256 | HashAlgorithm::Sha384 | HashAlgorithm::Sha512
+    ) {
+        return Err(DOMException::not_supported_error(
+            ctx,
+            "Unsupported HMAC hash algorithm",
+        ));
+    }
+    let mut length: u16 = obj
+        .get_optional("length")?
+        .unwrap_or_else(|| (hash.block_len() * 8) as u16);
 
     #[cfg(feature = "_subtle-full")]
     #[inline]
@@ -544,8 +572,11 @@ fn from_rsa<'js>(
     private_usages: &mut Vec<String>,
     public_usages: &mut Vec<String>,
 ) -> Result<KeyAlgorithm> {
+    use crate::provider::parse_rsa_public_exponent;
+
     let obj = obj.or_throw(ctx)?;
     let hash = extract_sha_hash(ctx, &obj)?;
+    let is_generate = mode == KeyAlgorithmMode::Generate;
 
     #[cfg(feature = "_subtle-full")]
     #[inline]
@@ -565,7 +596,9 @@ fn from_rsa<'js>(
                 obj.get_required("publicExponent", "algorithm")?;
             let public_exponent = public_exponent
                 .as_bytes()
-                .ok_or_else(|| Exception::throw_message(ctx, "Array buffer has been detached"))?
+                .ok_or_else(|| {
+                    DOMException::not_supported_error(ctx, "Array buffer has been detached")
+                })?
                 .to_owned()
                 .into_boxed_slice();
             Ok((modulus_length, public_exponent, None))
@@ -585,7 +618,9 @@ fn from_rsa<'js>(
         let public_exponent: TypedArray<u8> = obj.get_required("publicExponent", "algorithm")?;
         let public_exponent = public_exponent
             .as_bytes()
-            .ok_or_else(|| Exception::throw_message(ctx, "Array buffer has been detached"))?
+            .ok_or_else(|| {
+                DOMException::not_supported_error(ctx, "Array buffer has been detached")
+            })?
             .to_owned()
             .into_boxed_slice();
         Ok((modulus_length, public_exponent, None))
@@ -593,6 +628,10 @@ fn from_rsa<'js>(
 
     let (modulus_length, public_exponent, key_kind) =
         import(ctx, mode, &obj, algorithm_name, &hash)?;
+
+    if is_generate {
+        parse_rsa_public_exponent(&public_exponent).or_throw_dom(ctx, "")?;
+    }
 
     KeyUsage::classify_and_check_usages(
         ctx,
@@ -671,7 +710,7 @@ fn from_hkdf<'js>(
 
     KeyUsage::classify_and_check_usages(
         ctx,
-        KeyUsageAlgorithm::Derive,
+        KeyUsageAlgorithm::DeriveSymmetric,
         usages,
         private_usages,
         public_usages,
@@ -738,7 +777,7 @@ fn from_pbkdf2<'js>(
 
     KeyUsage::classify_and_check_usages(
         ctx,
-        KeyUsageAlgorithm::Derive,
+        KeyUsageAlgorithm::DeriveSymmetric,
         usages,
         private_usages,
         public_usages,
@@ -758,16 +797,17 @@ impl KeyAlgorithm {
         // When _subtle-full is not enabled, Import mode is not supported
         #[cfg(not(feature = "_subtle-full"))]
         if matches!(mode, KeyAlgorithmMode::Import { .. }) {
-            return Err(Exception::throw_message(
+            return Err(DOMException::not_supported_error(
                 ctx,
                 "Key import is not supported with this crypto provider",
             ));
         }
 
         let (name, obj) = to_name_and_maybe_object(ctx, value)?;
+        let name = normalize_algorithm_name(&name);
         let mut public_usages = vec![];
         let mut private_usages = vec![];
-        let algorithm_name = name.as_str();
+        let algorithm_name = name.as_ref();
         let algorithm = match algorithm_name {
             "Ed25519" => from_ed25519(
                 ctx,
@@ -803,7 +843,7 @@ impl KeyAlgorithm {
                 &usages,
                 &mut private_usages,
                 &mut public_usages,
-                KeyUsageAlgorithm::Derive,
+                KeyUsageAlgorithm::DeriveAsymmetric,
             )?,
             "ECDSA" => Self::from_ec(
                 ctx,
@@ -931,7 +971,9 @@ impl KeyAlgorithm {
     ) -> Result<KeyAlgorithm> {
         let obj = obj.or_throw(ctx)?;
         let curve_name: String = obj.get_required("namedCurve", "algorithm")?;
-        let curve = EllipticCurve::try_from(curve_name.as_str()).or_throw(ctx)?;
+        let curve = EllipticCurve::try_from(curve_name.as_str())
+            .map_err(NotSupportedError)
+            .or_throw_dom(ctx, "")?;
 
         #[cfg(feature = "_subtle-full")]
         let key_kind = if let KeyAlgorithmMode::Import { format, kind, data } = mode {
@@ -968,9 +1010,9 @@ fn import_derive_key<'js>(
         *data = object_bytes.into_bytes(ctx)?;
         *kind = KeyKind::Secret;
     } else {
-        return Err(Exception::throw_message(
+        return Err(DOMException::not_supported_error(
             ctx,
-            &[algorithm_name, " only supports 'raw' import format"].concat(),
+            [algorithm_name, " only supports 'raw' import format"].concat(),
         ));
     }
 
@@ -1148,10 +1190,9 @@ fn import_symmetric_key<'js>(
                     //AES - A256KW, A256GCM, A256CRT, A512CBC etc
                     ("A", None) => {
                         //extract AES-{suffix}
-                        let (_, name_suffix) = algorithm_name.split_once("-").unwrap_or_default();
                         let aes_variant = &alg[4..];
 
-                        if aes_variant != name_suffix {
+                        if !algorithm_name.ends_with(aes_variant) {
                             return algorithm_mismatch_error(ctx, algorithm_name);
                         }
                     },
@@ -1216,9 +1257,9 @@ fn import_ec_key<'js>(
 
             let jwk_crv: String = object.get_required("crv", "keyData")?;
             if curve_name != jwk_crv {
-                return Err(Exception::throw_type(
+                return Err(DOMException::not_supported_error(
                     ctx,
-                    &["Key is using a ", curve_name].concat(),
+                    ["Key is using a ", curve_name].concat(),
                 ));
             }
 
@@ -1342,9 +1383,9 @@ fn import_okp_key<'js>(
         KeyFormatData::Raw(object_bytes) => {
             let bytes = object_bytes.into_bytes(ctx)?;
             if bytes.len() != 32 {
-                return Err(Exception::throw_type(
+                return Err(DOMException::not_supported_error(
                     ctx,
-                    &[algorithm_name, " keys must be 32 bytes long"].concat(),
+                    [algorithm_name, " keys must be 32 bytes long"].concat(),
                 ));
             }
             *data = bytes;
@@ -1374,12 +1415,14 @@ pub fn extract_sha_hash<'js>(ctx: &Ctx<'js>, obj: &Object<'js>) -> Result<HashAl
     } else if let Some(obj) = hash.into_object() {
         obj.get_required("name", "hash")
     } else {
-        return Err(Exception::throw_message(
+        return Err(DOMException::not_supported_error(
             ctx,
             "hash must be a string or an object",
         ));
     }?;
-    HashAlgorithm::try_from(hash.as_str()).or_throw(ctx)
+    HashAlgorithm::try_from(hash.as_str())
+        .map_err(NotSupportedError)
+        .or_throw_dom(ctx, "")
 }
 
 fn create_hash_object<'js>(ctx: &Ctx<'js>, hash: &HashAlgorithm) -> Result<Object<'js>> {
@@ -1390,8 +1433,8 @@ fn create_hash_object<'js>(ctx: &Ctx<'js>, hash: &HashAlgorithm) -> Result<Objec
 
 #[cfg(feature = "_subtle-full")]
 pub fn hash_mismatch_error<T>(ctx: &Ctx<'_>, hash: &HashAlgorithm) -> Result<T> {
-    Err(Exception::throw_message(
+    Err(DOMException::type_mismatch_error(
         ctx,
-        &["Algorithm hash expected to be ", hash.as_str()].concat(),
+        ["Algorithm hash expected to be ", hash.as_str()].concat(),
     ))
 }

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -15,6 +15,7 @@ mod import_key;
 mod key_algorithm;
 mod sign;
 mod sign_algorithm;
+mod util;
 mod verify;
 #[cfg(feature = "_subtle-full")]
 mod wrapping;
@@ -45,6 +46,7 @@ mod key_algorithm;
 #[cfg(not(feature = "_subtle-full"))]
 use key_algorithm::KeyAlgorithm;
 
+use llrt_exceptions::DOMException;
 use llrt_utils::{object::ObjectExt, str_enum};
 use rquickjs::{atom::PredefinedAtom, Ctx, Exception, Object, Result, Value};
 
@@ -160,17 +162,27 @@ pub fn to_name_and_maybe_object<'js, 'a>(
     Ok((name, obj))
 }
 
+pub fn normalize_algorithm_name(name: &str) -> String {
+    let name = name.trim().to_ascii_uppercase();
+    match name.as_str() {
+        "ED25519" => "Ed25519".to_string(),
+        "RSASSA-PKCS1-V1_5" => "RSASSA-PKCS1-v1_5".to_string(),
+        _ => name,
+    }
+}
+
 pub fn algorithm_mismatch_error<T>(ctx: &Ctx<'_>, expected_algorithm: &str) -> Result<T> {
-    Err(Exception::throw_message(
+    Err(DOMException::type_mismatch_error(
         ctx,
-        &["Key algorithm must be ", expected_algorithm].concat(),
+        ["Key algorithm must be ", expected_algorithm].concat(),
     ))
 }
 
 pub fn algorithm_not_supported_error<T>(ctx: &Ctx<'_>) -> Result<T> {
-    let ctor: rquickjs::function::Constructor = ctx.globals().get("DOMException")?;
-    let exc: Value = ctor.construct(("Algorithm not supported", "NotSupportedError"))?;
-    Err(ctx.throw(exc))
+    Err(DOMException::not_supported_error(
+        ctx,
+        "Algorithm not supported",
+    ))
 }
 
 // Stub implementations for providers without _subtle-full

--- a/modules/llrt_crypto/src/subtle/util.rs
+++ b/modules/llrt_crypto/src/subtle/util.rs
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::{fmt::Display, result::Result as StdResult};
+
+use llrt_exceptions::DOMException;
+use rquickjs::{Ctx, Error, Result};
+
+use crate::provider::CryptoError;
+
+pub trait IntoDomException {
+    fn into_dom_exception(self, ctx: &Ctx, msg: &str) -> Error;
+}
+
+impl IntoDomException for CryptoError {
+    fn into_dom_exception(self, ctx: &Ctx, msg: &str) -> Error {
+        let message = with_message(&self, msg);
+        match self {
+            CryptoError::UnsupportedAlgorithm => DOMException::not_supported_error(ctx, message),
+            CryptoError::InvalidLength
+            | CryptoError::InvalidKey(_)
+            | CryptoError::InvalidData(_)
+            | CryptoError::InvalidSignature(_) => DOMException::data_error(ctx, message),
+            CryptoError::SigningFailed(_)
+            | CryptoError::VerificationFailed
+            | CryptoError::OperationFailed(_)
+            | CryptoError::DerivationFailed(_)
+            | CryptoError::EncryptionFailed(_)
+            | CryptoError::DecryptionFailed(_) => DOMException::operation_error(ctx, message),
+        }
+    }
+}
+
+pub trait ResultDomExt<T> {
+    fn or_throw_dom(self, ctx: &Ctx, msg: &str) -> Result<T>;
+}
+
+impl<T, E: IntoDomException> ResultDomExt<T> for StdResult<T, E> {
+    fn or_throw_dom(self, ctx: &Ctx, msg: &str) -> Result<T> {
+        self.map_err(|e| e.into_dom_exception(ctx, msg))
+    }
+}
+
+impl<T> ResultDomExt<T> for Option<T> {
+    fn or_throw_dom(self, ctx: &Ctx, msg: &str) -> Result<T> {
+        let message = if msg.is_empty() {
+            "Value is not present"
+        } else {
+            msg
+        };
+
+        self.ok_or_else(|| DOMException::not_supported_error(ctx, message))
+    }
+}
+
+pub struct NotSupportedError<E>(pub E);
+
+impl<E: Display> IntoDomException for NotSupportedError<E> {
+    fn into_dom_exception(self, ctx: &Ctx, msg: &str) -> Error {
+        DOMException::not_supported_error(ctx, with_message(self.0, msg))
+    }
+}
+
+fn with_message<E: Display>(err: E, msg: &str) -> String {
+    if msg.is_empty() {
+        err.to_string()
+    } else {
+        [msg, ": ", &err.to_string()].concat()
+    }
+}

--- a/modules/llrt_exceptions/src/lib.rs
+++ b/modules/llrt_exceptions/src/lib.rs
@@ -20,8 +20,6 @@ use rquickjs::{
     qjs, Class, Coerced, Ctx, Error, Exception, FromJs, IntoJs, JsLifetime, Object, Result, Value,
 };
 
-use crate::DOMExceptionName::{NotSupportedError, OperationError, TypeMismatchError};
-
 #[derive(JsLifetime)]
 struct ExceptionPrimordials<'js> {
     constructor_dom_exception: Constructor<'js>,
@@ -230,19 +228,23 @@ impl<'js> DOMException {
     }
 
     pub fn not_supported_error(ctx: &Ctx<'js>, message: impl Into<String>) -> Error {
-        Self::create_error(ctx, NotSupportedError, message)
+        Self::create_error(ctx, DOMExceptionName::NotSupportedError, message)
     }
 
     pub fn type_mismatch_error(ctx: &Ctx<'js>, message: impl Into<String>) -> Error {
-        Self::create_error(ctx, TypeMismatchError, message)
+        Self::create_error(ctx, DOMExceptionName::TypeMismatchError, message)
     }
 
     pub fn operation_error(ctx: &Ctx<'js>, message: impl Into<String>) -> Error {
-        Self::create_error(ctx, OperationError, message)
+        Self::create_error(ctx, DOMExceptionName::OperationError, message)
     }
 
     pub fn quota_exceeded_error(ctx: &Ctx<'js>, message: impl Into<String>) -> Error {
         Self::create_error(ctx, DOMExceptionName::QuotaExceededError, message)
+    }
+
+    pub fn data_error(ctx: &Ctx<'js>, message: impl Into<String>) -> Error {
+        Self::create_error(ctx, DOMExceptionName::DataError, message)
     }
 
     fn define_quota_exceeded_error(ctx: &Ctx<'js>) -> Result<()> {

--- a/tests/wpt/WebCryptoAPI.generateKey.test.ts
+++ b/tests/wpt/WebCryptoAPI.generateKey.test.ts
@@ -1,0 +1,8 @@
+import { runSuite } from "./_harness-util.js";
+import { runTestDynamic } from "./WebCryptoAPI.harness.js";
+
+runSuite(import.meta.url, runTestDynamic, [
+  "successes_RSA-OAEP.https.any.js", // Error: Test timed out after 5000ms
+  "successes_RSA-PSS.https.any.js", // Error: Test timed out after 5000ms
+  "successes_RSASSA-PKCS1-v1_5.https.any.js", // Error: Test timed out after 5000ms
+]);


### PR DESCRIPTION
### Issue # (if available)

Related #968

### Description of changes

We are introducing WPT tests for `subtle.generateKey()`. As several issues came to light during the process, we implemented the following improvements.

- Fixed the location where a `DOMException` of the incorrect type was being thrown.
- Added a mechanism (the `IntoDomException` trait) to map custom `CryptoError`s originating from `CryptoProvider` to the appropriate `DOMException`. Mapping a single `CryptoError` to multiple `DOMException`s is not supported. In such cases, please consider splitting the `CryptoError` into separate errors.
- Some of the `KeyUsage` determinations were incorrect, so the implementation was updated to comply with the specifications. 
- Other minor corrections.

These measures resolved the following errors, and all tests (with the exception of some tests that experience timeouts) now pass.

#### WebCryptoAPI/generateKey > should pass *.https.any.js tests

```
Error: [Bad algorithm: generateKey(AES, RED, [decrypt])] Error converting from js 'string' into type 'bool'
Error: [Bad algorithm: generateKey({hash: MD5, name: HMAC}, false, [decrypt])] assert_equals: Bad algorithm not supported expected: "NotSupportedError" but got: "Error"
Error: [Bad algorithm: generateKey({hash: MD5, name: HMAC}, false, [sign])] assert_unreached: Operation succeeded, but should not have
Error: [Bad algorithm: generateKey( {hash: SHA, modulusLength:2048, name:RSA-PSS, publicExponent:{0:1,1:0,2:1}}, false, [decrypt] )] expected: "NotSupportedError" but got: "Error"
Error: [Bad usages: generateKey({length:128,name:AES-CBC}, true, [sign])] expected: "SyntaxError" but got: "NotSupportedError"
Error: [Bad algorithm property: generateKey( {name:ECDH,namedCurve:P-512}, false, [deriveKey] )] expected: "NotSupportedError" but got: "Error"
Error: [Bad algorithm property: generateKey({length:64,name:AES-CBC},false,[encrypt])] expected: "OperationError" but got: "NotSupportedError"
Error: [Bad algorithm property: generateKey( {hash:SHA-256, modulusLength:1024, name:RSA-OAEP, publicExponent:{0:1}}, false, [decrypt,encrypt] )] expected: "OperationError" but got: "NotSupportedError"
Error: [Bad algorithm property: generateKey( {hash:SHA-256, modulusLength:1024, name:RSA-OAEP, publicExponent:{0:1}}, false, [] )] expected: "OperationError" but got: "SyntaxError"
Error: [Empty usages: generateKey({length:128,name:AES-CBC},false,[])] assert_unreached: Operation succeeded, but should not have
Error: [Success: generateKey({length:128,name:aes-cbc},false,[encrypt])] assert_unreached: exportKey threw an unexpected error: NotSupportedError: Algorithm not supported
Error: [Bad algorithm property: generateKey( {hash:SHA-256, modulusLength:1024, name:RSA-OAEP, publicExponent:{0:1}}, false, [decrypt,encrypt] )] expected: "OperationError" but got: "DataError"
Error: exportKey threw an unexpected error: assert_equals: Correct length expected: 512 but got: 0
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
