### PR TITLE
fix: increase WPT test timeout to reduce CI flakiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ update-wpt: setup-wpt
 
 test-wpt: export JS_MINIFY = 0
 test-wpt: export TEST_SUB_DIR = wpt
+test-wpt: export TEST_TIMEOUT = 20000
 test-wpt: setup-wpt js
 	@echo "Starting WPT server (logs: wpt_server.log)..."
 	@./wpt/wpt serve >wpt_server.log 2>&1 & WPT_PID=$$!; \


### PR DESCRIPTION
### Issue # (if available)

N/A

### Description of changes

WPT tests were timing out on CI under load, bumped the timeout.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._