### PR TITLE
feat(util): add util.inspect and inspect.custom

### DIFF
--- a/API.md
+++ b/API.md
@@ -524,6 +524,8 @@ _Also available globally_
 
 [inherits](https://nodejs.org/api/util.html#utilinheritsconstructor-superconstructor)
 
+[inspect](https://nodejs.org/api/util.html#utilinspectobject-options)
+
 [TextDecoder](https://nodejs.org/api/util.html#class-utiltextdecoder)
 
 [TextEncoder](https://nodejs.org/api/util.html#class-utiltextdecoder)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,8 +2336,10 @@ dependencies = [
  "llrt_context",
  "llrt_encoding",
  "llrt_logging",
+ "llrt_test",
  "llrt_utils",
  "rquickjs",
+ "tokio",
 ]
 
 [[package]]

--- a/modules/llrt_util/Cargo.toml
+++ b/modules/llrt_util/Cargo.toml
@@ -17,3 +17,7 @@ llrt_encoding = { version = "0.8.1-beta", path = "../../libs/llrt_encoding" }
 llrt_logging = { version = "0.8.1-beta", path = "../../libs/llrt_logging" }
 llrt_utils = { version = "0.8.1-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { version = "0.12", default-features = false }
+
+[dev-dependencies]
+llrt_test = { path = "../../libs/llrt_test" }
+tokio = { version = "1", features = ["test-util", "macros"], default-features = false }

--- a/modules/llrt_util/src/lib.rs
+++ b/modules/llrt_util/src/lib.rs
@@ -3,12 +3,16 @@
 pub mod text_decoder;
 pub mod text_encoder;
 
-use llrt_logging::format_plain;
-use llrt_utils::module::{export_default, ModuleInfo};
+use llrt_logging::{build_formatted_string, format_plain, FormatOptions};
+use llrt_utils::{
+    class::CUSTOM_INSPECT_SYMBOL_DESCRIPTION,
+    module::{export_default, ModuleInfo},
+    object::ObjectExt,
+};
 use rquickjs::{
-    function::Func,
+    function::{Func, Opt, Rest},
     module::{Declarations, Exports, ModuleDef},
-    Class, Ctx, Function, Object, Result,
+    Class, Ctx, Function, Object, Result, Symbol, Value,
 };
 use text_decoder::TextDecoder;
 use text_encoder::TextEncoder;
@@ -21,6 +25,18 @@ fn inherits<'js>(ctor: Function<'js>, super_ctor: Function<'js>) -> Result<()> {
     Ok(())
 }
 
+fn inspect<'js>(ctx: Ctx<'js>, value: Value<'js>, options: Opt<Object<'js>>) -> Result<String> {
+    let colors = options
+        .0
+        .and_then(|opts| opts.get_optional("colors").ok().flatten())
+        .unwrap_or(false);
+
+    let mut result = String::new();
+    let mut format_options = FormatOptions::new(&ctx, colors, true)?;
+    build_formatted_string(&mut result, &ctx, Rest(vec![value]), &mut format_options)?;
+    Ok(result)
+}
+
 pub struct UtilModule;
 
 impl ModuleDef for UtilModule {
@@ -29,6 +45,7 @@ impl ModuleDef for UtilModule {
         declare.declare(stringify!(TextEncoder))?;
         declare.declare(stringify!(format))?;
         declare.declare(stringify!(inherits))?;
+        declare.declare(stringify!(inspect))?;
         declare.declare("default")?;
         Ok(())
     }
@@ -47,6 +64,12 @@ impl ModuleDef for UtilModule {
                 Func::from(|ctx, args| format_plain(ctx, true, args)),
             )?;
             default.set("inherits", Func::from(inherits))?;
+
+            let inspect_fn = Function::new(ctx.clone(), inspect)?.with_name("inspect")?;
+            let inspect_custom =
+                Symbol::new_global(ctx.clone(), CUSTOM_INSPECT_SYMBOL_DESCRIPTION)?;
+            inspect_fn.set("custom", inspect_custom)?;
+            default.set("inspect", inspect_fn)?;
 
             Ok(())
         })
@@ -69,4 +92,74 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     Class::<TextDecoder>::define(&globals)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::UtilModule;
+    use llrt_test::{call_test, test_async_with, ModuleEvaluator};
+    use llrt_utils::primordials::{BasePrimordials, Primordial};
+
+    #[tokio::test]
+    async fn test_inspect() {
+        test_async_with(|ctx| {
+            Box::pin(async move {
+                BasePrimordials::init(&ctx).unwrap();
+                crate::init(&ctx).unwrap();
+                ModuleEvaluator::eval_rust::<UtilModule>(ctx.clone(), "util")
+                    .await
+                    .unwrap();
+
+                let module = ModuleEvaluator::eval_js(
+                    ctx.clone(),
+                    "test",
+                    r#"
+                        import { inspect } from 'util';
+
+                        export async function test() {
+                            return inspect({ a: 1, b: [1, 2] });
+                        }
+                    "#,
+                )
+                .await
+                .unwrap();
+                let result = call_test::<String, _>(&ctx, &module, ()).await;
+                assert_eq!(result, "{\n  a: 1,\n  b: [ 1, 2 ]\n}");
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_inspect_custom() {
+        test_async_with(|ctx| {
+            Box::pin(async move {
+                BasePrimordials::init(&ctx).unwrap();
+                crate::init(&ctx).unwrap();
+                ModuleEvaluator::eval_rust::<UtilModule>(ctx.clone(), "util")
+                    .await
+                    .unwrap();
+
+                let module = ModuleEvaluator::eval_js(
+                    ctx.clone(),
+                    "test",
+                    r#"
+                        import { inspect } from 'util';
+
+                        export async function test() {
+                            const obj = {
+                                [inspect.custom]: { customKey: "custom-value" },
+                            };
+                            return inspect(obj);
+                        }
+                    "#,
+                )
+                .await
+                .unwrap();
+                let result = call_test::<String, _>(&ctx, &module, ()).await;
+                assert_eq!(result, "{\n  customKey: 'custom-value'\n}");
+            })
+        })
+        .await;
+    }
 }

--- a/types/util.d.ts
+++ b/types/util.d.ts
@@ -114,6 +114,32 @@ declare module "util" {
     constructor: unknown,
     superConstructor: unknown
   ): void;
+  export interface InspectOptions {
+    /**
+     * If `true`, the output is styled with ANSI color codes.
+     * @default false
+     */
+    colors?: boolean | undefined;
+  }
+  /**
+   * The `util.inspect()` method returns a string representation of `object` that
+   * is intended for debugging.
+   *
+   * ```js
+   * import util from 'util';
+   *
+   * const obj = { name: 'foo' };
+   * console.log(util.inspect(obj));
+   * // Prints: { name: 'foo' }
+   * ```
+   *
+   * Objects may define their own custom `inspect(depth, opts, inspect)` function via the `util.inspect.custom` symbol.
+   * @param object Any JavaScript primitive or object.
+   */
+  export function inspect(object: any, options?: InspectOptions): string;
+  export namespace inspect {
+    const custom: unique symbol;
+  }
   /**
    * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextDecoder` API.
    *


### PR DESCRIPTION
### Issue # (if available)

Closes #1257

### Description of changes

Adds `util.inspect(object[, options])` and `util.inspect.custom`, implemented in Rust using the existing `llrt_logging` formatter (the same one `console.log` uses). `inspect.custom` exposes the existing global symbol already honored by that formatter, so objects with a `[util.inspect.custom]` property (matching the existing convention used internally for Map/Set/DataView/ArrayBuffer) get picked up automatically. Only the `colors` option is implemented; other Node inspect options are not.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
