### PR TITLE
fix(crypto): Add WPT tests and improve encrypt and decrypt compatibility

### DIFF
--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -69,6 +69,7 @@ llrt_json = { version = "0.8.1-beta", path = "../../libs/llrt_json", optional = 
 aes = { version = "0.9", optional = true }
 aes-gcm = { version = "0.11", features = [
   "alloc",
+  "hazmat",
 ], default-features = false, optional = true }
 aes-kw = { version = "0.3", features = [
   "oid",

--- a/modules/llrt_crypto/src/provider/rust/aes_variants.rs
+++ b/modules/llrt_crypto/src/provider/rust/aes_variants.rs
@@ -10,7 +10,7 @@ use aes::cipher::BlockModeEncrypt;
 use aes::{
     cipher::{
         block_padding::{Error as PaddingError, Pkcs7},
-        consts::{U12, U13, U14, U15, U16},
+        consts::{U12, U13, U14, U15, U16, U4, U8},
         InvalidLength, KeyIvInit, StreamCipher, StreamCipherError,
     },
     Aes128, Aes192, Aes256,
@@ -150,6 +150,12 @@ impl AesCtrVariant {
 }
 
 pub enum AesGcmVariant {
+    Aes128Gcm32(AesGcm<Aes128, U12, U4>),
+    Aes192Gcm32(AesGcm<Aes192, U12, U4>),
+    Aes256Gcm32(AesGcm<Aes256, U12, U4>),
+    Aes128Gcm64(AesGcm<Aes128, U12, U8>),
+    Aes192Gcm64(AesGcm<Aes192, U12, U8>),
+    Aes256Gcm64(AesGcm<Aes256, U12, U8>),
     Aes128Gcm96(AesGcm<Aes128, U12, U12>),
     Aes192Gcm96(AesGcm<Aes192, U12, U12>),
     Aes256Gcm96(AesGcm<Aes256, U12, U12>),
@@ -175,6 +181,12 @@ impl AesGcmVariant {
         key: &[u8],
     ) -> std::result::Result<Self, InvalidLength> {
         let variant = match (key_len, tag_length) {
+            (128, 32) => Self::Aes128Gcm32(AesGcm::new_from_slice(key)?),
+            (192, 32) => Self::Aes192Gcm32(AesGcm::new_from_slice(key)?),
+            (256, 32) => Self::Aes256Gcm32(AesGcm::new_from_slice(key)?),
+            (128, 64) => Self::Aes128Gcm64(AesGcm::new_from_slice(key)?),
+            (192, 64) => Self::Aes192Gcm64(AesGcm::new_from_slice(key)?),
+            (256, 64) => Self::Aes256Gcm64(AesGcm::new_from_slice(key)?),
             (128, 96) => Self::Aes128Gcm96(AesGcm::new_from_slice(key)?),
             (192, 96) => Self::Aes192Gcm96(AesGcm::new_from_slice(key)?),
             (256, 96) => Self::Aes256Gcm96(AesGcm::new_from_slice(key)?),
@@ -209,6 +221,12 @@ impl AesGcmVariant {
         let nonce: &ctr::cipher::Array<_, _> =
             &Nonce::<U12>::try_from(nonce).map_err(|_| aes_gcm::Error)?;
         match self {
+            Self::Aes128Gcm32(v) => v.encrypt(nonce, plaintext),
+            Self::Aes192Gcm32(v) => v.encrypt(nonce, plaintext),
+            Self::Aes256Gcm32(v) => v.encrypt(nonce, plaintext),
+            Self::Aes128Gcm64(v) => v.encrypt(nonce, plaintext),
+            Self::Aes192Gcm64(v) => v.encrypt(nonce, plaintext),
+            Self::Aes256Gcm64(v) => v.encrypt(nonce, plaintext),
             Self::Aes128Gcm96(v) => v.encrypt(nonce, plaintext),
             Self::Aes192Gcm96(v) => v.encrypt(nonce, plaintext),
             Self::Aes256Gcm96(v) => v.encrypt(nonce, plaintext),
@@ -240,6 +258,12 @@ impl AesGcmVariant {
         let nonce: &ctr::cipher::Array<_, _> =
             &Nonce::<U12>::try_from(nonce).map_err(|_| aes_gcm::Error)?;
         match self {
+            Self::Aes128Gcm32(v) => v.decrypt(nonce, ciphertext),
+            Self::Aes192Gcm32(v) => v.decrypt(nonce, ciphertext),
+            Self::Aes256Gcm32(v) => v.decrypt(nonce, ciphertext),
+            Self::Aes128Gcm64(v) => v.decrypt(nonce, ciphertext),
+            Self::Aes192Gcm64(v) => v.decrypt(nonce, ciphertext),
+            Self::Aes256Gcm64(v) => v.decrypt(nonce, ciphertext),
             Self::Aes128Gcm96(v) => v.decrypt(nonce, ciphertext),
             Self::Aes192Gcm96(v) => v.decrypt(nonce, ciphertext),
             Self::Aes256Gcm96(v) => v.decrypt(nonce, ciphertext),

--- a/modules/llrt_crypto/src/provider/rust/mod.rs
+++ b/modules/llrt_crypto/src/provider/rust/mod.rs
@@ -628,6 +628,12 @@ impl CryptoProvider for RustCryptoProvider {
                 };
 
                 match variant {
+                    AesGcmVariant::Aes128Gcm32(v) => v.encrypt(nonce, plaintext),
+                    AesGcmVariant::Aes192Gcm32(v) => v.encrypt(nonce, plaintext),
+                    AesGcmVariant::Aes256Gcm32(v) => v.encrypt(nonce, plaintext),
+                    AesGcmVariant::Aes128Gcm64(v) => v.encrypt(nonce, plaintext),
+                    AesGcmVariant::Aes192Gcm64(v) => v.encrypt(nonce, plaintext),
+                    AesGcmVariant::Aes256Gcm64(v) => v.encrypt(nonce, plaintext),
                     AesGcmVariant::Aes128Gcm96(v) => v.encrypt(nonce, plaintext),
                     AesGcmVariant::Aes192Gcm96(v) => v.encrypt(nonce, plaintext),
                     AesGcmVariant::Aes256Gcm96(v) => v.encrypt(nonce, plaintext),
@@ -694,6 +700,12 @@ impl CryptoProvider for RustCryptoProvider {
                 };
 
                 match variant {
+                    AesGcmVariant::Aes128Gcm32(v) => v.decrypt(nonce, ciphertext),
+                    AesGcmVariant::Aes192Gcm32(v) => v.decrypt(nonce, ciphertext),
+                    AesGcmVariant::Aes256Gcm32(v) => v.decrypt(nonce, ciphertext),
+                    AesGcmVariant::Aes128Gcm64(v) => v.decrypt(nonce, ciphertext),
+                    AesGcmVariant::Aes192Gcm64(v) => v.decrypt(nonce, ciphertext),
+                    AesGcmVariant::Aes256Gcm64(v) => v.decrypt(nonce, ciphertext),
                     AesGcmVariant::Aes128Gcm96(v) => v.decrypt(nonce, ciphertext),
                     AesGcmVariant::Aes192Gcm96(v) => v.decrypt(nonce, ciphertext),
                     AesGcmVariant::Aes256Gcm96(v) => v.decrypt(nonce, ciphertext),
@@ -1028,10 +1040,7 @@ impl CryptoProvider for RustCryptoProvider {
             .map_err(|_| CryptoError::InvalidKey(None))?;
         let modulus_length = private_key.modulus.as_bytes().len() * 8;
         let public_exponent = private_key.public_exponent.as_bytes().to_vec();
-        let key_data = pk_info
-            .private_key
-            .to_der()
-            .map_err(|_| CryptoError::InvalidKey(None))?;
+        let key_data = pk_info.private_key.as_bytes().to_vec();
         Ok(super::RsaImportResult {
             key_data,
             modulus_length: modulus_length as u32,

--- a/modules/llrt_crypto/src/subtle/derive_keys.rs
+++ b/modules/llrt_crypto/src/subtle/derive_keys.rs
@@ -56,7 +56,7 @@ fn derive_key<'js>(
     key_algorithm: KeyAlgorithmWithUsages,
 ) -> Result<Class<'js, CryptoKey<'js>>> {
     let length = match &key_algorithm.algorithm {
-        KeyAlgorithm::Aes { length } => *length,
+        KeyAlgorithm::Aes { length, .. } => *length,
         KeyAlgorithm::Hmac { length, .. } => *length,
         KeyAlgorithm::Derive { .. } => 0,
         _ => {

--- a/modules/llrt_crypto/src/subtle/encryption.rs
+++ b/modules/llrt_crypto/src/subtle/encryption.rs
@@ -1,10 +1,10 @@
-use std::borrow::Cow;
-
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
+use std::{borrow::Cow, future::Future};
 
-use rquickjs::{ArrayBuffer, Class, Ctx, Exception, Result};
+use llrt_exceptions::DOMException;
+use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
+use rquickjs::{ArrayBuffer, Class, Ctx, Exception, FromJs, Result, Value};
 
 use crate::{
     provider::{AesMode, CryptoProvider},
@@ -12,47 +12,74 @@ use crate::{
 };
 
 use super::{
-    algorithm_mismatch_error, encryption_algorithm::EncryptionAlgorithm,
-    key_algorithm::KeyAlgorithm, validate_aes_length, CryptoKey, EncryptionMode,
+    algorithm_mismatch_error,
+    encryption_algorithm::EncryptionAlgorithm,
+    key_algorithm::{AesAlgorithm, KeyAlgorithm},
+    util::ResultDomExt,
+    CryptoKey, EncryptionMode,
 };
 
-pub async fn subtle_decrypt<'js>(
+pub fn subtle_decrypt<'js>(
     ctx: Ctx<'js>,
-    algorithm: EncryptionAlgorithm,
+    algorithm: Value<'js>,
     key: Class<'js, CryptoKey<'js>>,
     data: ObjectBytes<'js>,
-) -> Result<ArrayBuffer<'js>> {
-    let key = key.borrow();
-    key.check_validity("decrypt").or_throw(&ctx)?;
-    let bytes = encrypt_decrypt(
-        &ctx,
-        &algorithm,
-        &key,
-        data.as_bytes(&ctx)?,
-        EncryptionMode::Encryption,
-        EncryptionOperation::Decrypt,
-    )?;
-    ArrayBuffer::new(ctx, bytes)
+) -> impl Future<Output = Result<ArrayBuffer<'js>>> + 'js {
+    let prepared = prepare_encrypt_decrypt(&ctx, algorithm, key, data);
+
+    async move {
+        let (algorithm, key, input) = prepared?;
+
+        let key = key.borrow();
+        key.check_validity("decrypt").or_throw_dom(&ctx)?;
+
+        let bytes = encrypt_decrypt(
+            &ctx,
+            &algorithm,
+            &key,
+            &input,
+            EncryptionMode::Encryption,
+            EncryptionOperation::Decrypt,
+        )?;
+        ArrayBuffer::new(ctx, bytes)
+    }
 }
 
-pub async fn subtle_encrypt<'js>(
+pub fn subtle_encrypt<'js>(
     ctx: Ctx<'js>,
-    algorithm: EncryptionAlgorithm,
+    algorithm: Value<'js>,
     key: Class<'js, CryptoKey<'js>>,
     data: ObjectBytes<'js>,
-) -> Result<ArrayBuffer<'js>> {
-    let key = key.borrow();
-    key.check_validity("encrypt").or_throw(&ctx)?;
+) -> impl Future<Output = Result<ArrayBuffer<'js>>> + 'js {
+    let prepared = prepare_encrypt_decrypt(&ctx, algorithm, key, data);
 
-    let bytes = encrypt_decrypt(
-        &ctx,
-        &algorithm,
-        &key,
-        data.as_bytes(&ctx)?,
-        EncryptionMode::Encryption,
-        EncryptionOperation::Encrypt,
-    )?;
-    ArrayBuffer::new(ctx, bytes)
+    async move {
+        let (algorithm, key, input) = prepared?;
+
+        let key = key.borrow();
+        key.check_validity("encrypt").or_throw_dom(&ctx)?;
+
+        let bytes = encrypt_decrypt(
+            &ctx,
+            &algorithm,
+            &key,
+            &input,
+            EncryptionMode::Encryption,
+            EncryptionOperation::Encrypt,
+        )?;
+        ArrayBuffer::new(ctx, bytes)
+    }
+}
+
+fn prepare_encrypt_decrypt<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    key: Class<'js, CryptoKey<'js>>,
+    data: ObjectBytes<'js>,
+) -> Result<(EncryptionAlgorithm, Class<'js, CryptoKey<'js>>, Vec<u8>)> {
+    let algorithm = EncryptionAlgorithm::from_js(ctx, algorithm)?;
+    let input = data.as_bytes_opt().map(<[u8]>::to_vec).unwrap_or_default();
+    Ok((algorithm, key, input))
 }
 
 pub enum EncryptionOperation {
@@ -71,22 +98,22 @@ pub fn encrypt_decrypt(
     let handle = key.handle.as_ref();
     let bytes = match algorithm {
         EncryptionAlgorithm::AesCbc { iv } => {
-            validate_aes_length(ctx, key, handle, "AES-CBC")?;
+            validate_aes_length(ctx, key, handle, AesAlgorithm::Cbc)?;
 
             match operation {
                 EncryptionOperation::Encrypt => CRYPTO_PROVIDER
                     .aes_encrypt(AesMode::Cbc, handle, iv, data, None)
-                    .or_throw(ctx)?,
+                    .or_throw_dom(ctx)?,
                 EncryptionOperation::Decrypt => CRYPTO_PROVIDER
                     .aes_decrypt(AesMode::Cbc, handle, iv, data, None)
-                    .or_throw(ctx)?,
+                    .or_throw_dom(ctx)?,
             }
         },
         EncryptionAlgorithm::AesCtr {
             counter,
             length: encryption_length,
         } => {
-            validate_aes_length(ctx, key, handle, "AES-CTR")?;
+            validate_aes_length(ctx, key, handle, AesAlgorithm::Ctr)?;
             match operation {
                 EncryptionOperation::Encrypt => CRYPTO_PROVIDER
                     .aes_encrypt(
@@ -98,7 +125,7 @@ pub fn encrypt_decrypt(
                         data,
                         None,
                     )
-                    .or_throw(ctx)?,
+                    .or_throw_dom(ctx)?,
                 EncryptionOperation::Decrypt => CRYPTO_PROVIDER
                     .aes_decrypt(
                         AesMode::Ctr {
@@ -109,7 +136,7 @@ pub fn encrypt_decrypt(
                         data,
                         None,
                     )
-                    .or_throw(ctx)?,
+                    .or_throw_dom(ctx)?,
             }
         },
         EncryptionAlgorithm::AesGcm {
@@ -117,7 +144,7 @@ pub fn encrypt_decrypt(
             tag_length,
             additional_data,
         } => {
-            validate_aes_length(ctx, key, handle, "AES-GCM")?;
+            validate_aes_length(ctx, key, handle, AesAlgorithm::Gcm)?;
             let aad = additional_data.as_deref();
 
             match operation {
@@ -131,11 +158,14 @@ pub fn encrypt_decrypt(
                         data,
                         aad,
                     )
-                    .or_throw(ctx)?,
+                    .or_throw_dom(ctx)?,
                 EncryptionOperation::Decrypt => {
                     let tag_len = (*tag_length as usize) / 8;
                     if data.len() < tag_len {
-                        return Err(Exception::throw_message(ctx, "Invalid ciphertext length"));
+                        return Err(DOMException::operation_error(
+                            ctx,
+                            "Invalid ciphertext length",
+                        ));
                     }
                     // Pass the full data (ciphertext + tag) to the decrypt function
                     CRYPTO_PROVIDER
@@ -148,7 +178,7 @@ pub fn encrypt_decrypt(
                             data,
                             aad,
                         )
-                        .or_throw(ctx)?
+                        .or_throw_dom(ctx)?
                 },
             }
         },
@@ -175,7 +205,7 @@ pub fn encrypt_decrypt(
                     }
                     CRYPTO_PROVIDER
                         .aes_kw_wrap(handle, &padded_data)
-                        .or_throw(ctx)?
+                        .or_throw_dom(ctx)?
                 },
                 EncryptionOperation::Decrypt => {
                     let unwrapped = CRYPTO_PROVIDER.aes_kw_unwrap(handle, data).or_throw(ctx)?;
@@ -205,12 +235,34 @@ pub fn encrypt_decrypt(
             match operation {
                 EncryptionOperation::Encrypt => CRYPTO_PROVIDER
                     .rsa_oaep_encrypt(handle, data, *hash, label.as_deref())
-                    .or_throw(ctx)?,
+                    .or_throw_dom(ctx)?,
                 EncryptionOperation::Decrypt => CRYPTO_PROVIDER
                     .rsa_oaep_decrypt(handle, data, *hash, label.as_deref())
-                    .or_throw(ctx)?,
+                    .or_throw_dom(ctx)?,
             }
         },
     };
     Ok(bytes)
+}
+
+pub fn validate_aes_length(
+    ctx: &Ctx<'_>,
+    key: &CryptoKey,
+    handle: &[u8],
+    expected_algorithm: AesAlgorithm,
+) -> Result<()> {
+    match &key.algorithm {
+        KeyAlgorithm::Aes { algorithm, length } if *algorithm == expected_algorithm => {
+            if *length != handle.len() as u16 * 8 {
+                return Err(DOMException::operation_error(ctx, "Invalid AES key length"));
+            }
+            Ok(())
+        },
+        KeyAlgorithm::Aes { .. } => Err(DOMException::invalid_access_error(
+            ctx,
+            "AES algorithm mismatch",
+        )),
+
+        _ => algorithm_mismatch_error(ctx, "AES"),
+    }
 }

--- a/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use llrt_exceptions::DOMException;
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt};
 use rquickjs::{Ctx, Exception, FromJs, Result, Value};
 
@@ -39,7 +40,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                     .into_boxed_slice();
 
                 if iv.len() != 16 {
-                    return Err(Exception::throw_message(
+                    return Err(DOMException::operation_error(
                         ctx,
                         "invalid length of iv. Currently supported 16 bytes",
                     ));
@@ -56,7 +57,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 let length = obj.get_required::<_, u32>("length", "algorithm")?;
 
                 if !matches!(length, 32 | 64 | 128) {
-                    return Err(Exception::throw_message(
+                    return Err(DOMException::operation_error(
                         ctx,
                         "invalid counter length. Currently supported 32/64/128 bits",
                     ));
@@ -87,11 +88,8 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 let tag_length = obj.get_optional::<_, u8>("tagLength")?.unwrap_or(128);
 
                 //ensure tag length is supported using a match statement 32, 64, 96, 104, 112, 120, or 128
-                if !matches!(tag_length, 96 | 104 | 112 | 120 | 128) {
-                    return Err(Exception::throw_message(
-                        ctx,
-                        "Invalid tagLength. Currently supported 96/104/112/120/128 bits",
-                    ));
+                if !matches!(tag_length, 32 | 64 | 96 | 104 | 112 | 120 | 128) {
+                    return Err(DOMException::operation_error(ctx, "Invalid tagLength"));
                 }
 
                 Ok(EncryptionAlgorithm::AesGcm {

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -146,7 +146,7 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
     obj.set("ext", true)?;
 
     match &key.algorithm {
-        KeyAlgorithm::Aes { length } => {
+        KeyAlgorithm::Aes { length, .. } => {
             let prefix = match length {
                 128 => "A128",
                 192 => "A192",

--- a/modules/llrt_crypto/src/subtle/generate_key.rs
+++ b/modules/llrt_crypto/src/subtle/generate_key.rs
@@ -81,7 +81,7 @@ pub async fn subtle_generate_key<'js>(
 
 fn generate_key(ctx: &Ctx<'_>, algorithm: &KeyAlgorithm) -> Result<(Vec<u8>, Vec<u8>)> {
     match algorithm {
-        KeyAlgorithm::Aes { length } => {
+        KeyAlgorithm::Aes { length, .. } => {
             // Default to AES-256
             let key = CRYPTO_PROVIDER
                 .generate_aes_key(*length)

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -245,10 +245,19 @@ pub enum EcAlgorithm {
     Ecdsa,
 }
 
+#[derive(PartialEq, Debug, Clone)]
+pub enum AesAlgorithm {
+    Cbc,
+    Ctr,
+    Gcm,
+    Kw,
+}
+
 #[derive(Debug, Clone)]
 pub enum KeyAlgorithm {
     Aes {
         length: u16,
+        algorithm: AesAlgorithm,
     },
     Ec {
         curve: EllipticCurve,
@@ -479,9 +488,17 @@ fn from_aes<'js>(
         ));
     }
 
+    let algorithm = match algorithm_name {
+        "AES-CBC" => AesAlgorithm::Cbc,
+        "AES-CTR" => AesAlgorithm::Ctr,
+        "AES-GCM" => AesAlgorithm::Gcm,
+        "AES-KW" => AesAlgorithm::Kw,
+        _ => return Err(DOMException::operation_error(ctx, "Invalid algorithm name")),
+    };
+
     KeyUsage::classify_and_check_usages(
         ctx,
-        if algorithm_name == "AES-KW" {
+        if algorithm == AesAlgorithm::Kw {
             KeyUsageAlgorithm::AesKw
         } else {
             KeyUsageAlgorithm::Symmetric
@@ -492,7 +509,7 @@ fn from_aes<'js>(
         key_kind.as_ref(),
     )?;
 
-    Ok(KeyAlgorithm::Aes { length })
+    Ok(KeyAlgorithm::Aes { length, algorithm })
 }
 
 fn from_hmac<'js>(
@@ -908,7 +925,7 @@ impl KeyAlgorithm {
         let obj = Object::new(ctx.clone())?;
         obj.set(PredefinedAtom::Name, name.as_ref())?;
         match self {
-            KeyAlgorithm::Aes { length } => {
+            KeyAlgorithm::Aes { length, .. } => {
                 obj.set(PredefinedAtom::Length, length)?;
             },
             KeyAlgorithm::Ec { curve, .. } => {

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -114,34 +114,6 @@ pub fn rsa_hash_digest<'a>(
     Ok((hash, digest))
 }
 
-pub fn validate_aes_length(
-    ctx: &Ctx<'_>,
-    key: &CryptoKey,
-    handle: &[u8],
-    expected_algorithm: &str,
-) -> Result<()> {
-    let length = match key.algorithm {
-        KeyAlgorithm::Aes { length } => length,
-        _ => return algorithm_mismatch_error(ctx, expected_algorithm),
-    };
-    if length != handle.len() as u16 * 8 {
-        return Err(Exception::throw_message(
-            ctx,
-            &[
-                "Invalid key handle length for ",
-                expected_algorithm,
-                ". Expected ",
-                &length.to_string(),
-                " bits, found ",
-                &handle.len().to_string(),
-                " bits",
-            ]
-            .concat(),
-        ));
-    }
-    Ok(())
-}
-
 pub fn to_name_and_maybe_object<'js, 'a>(
     ctx: &Ctx<'js>,
     value: Value<'js>,

--- a/tests/wpt/WebCryptoAPI.encrypt_decrypt.test.ts
+++ b/tests/wpt/WebCryptoAPI.encrypt_decrypt.test.ts
@@ -1,0 +1,6 @@
+import { runSuite } from "./_harness-util.js";
+import { runTestDynamic } from "./WebCryptoAPI.harness.js";
+
+runSuite(import.meta.url, runTestDynamic, [
+  "aes_gcm_256_iv.https.any.js", // NOTICE: Only 96-bit IVs are supported
+]);


### PR DESCRIPTION
### Issue # (if available)

Related #968

### Description of changes

Enabled the WPT for encrypt and decrypt and resolved several errors that were occurring. Specifically, the details are as follows.

- Enabled short tag lengths (32, 64 bits) for AES-GCM.
- Fixed specification inconsistencies related to turnarounds.
- We implemented appropriate checks and modified the code to ensure that the correct DOMException is thrown based on usage.

While WPT supports verification with IVs other than 96 bits, this implementation uses a fixed value in LLRT; since modifying it would require significant changes, it has been excluded from the current scope.

The following errors have been resolved by these measures.

#### WebCryptoAPI/encrypt_decrypt > should pass aes_cbc.https.any.js tests

```
Error: [AES-CBC 128-bit key with altered plaintext after call] assert_true: Should return expected result expected true got false
Error: [AES-CBC 128-bit key decryption with transferred ciphertext during call] assert_equals: Should throw an OperationError instead of Decryption failed expected"OperationError" but got "Error"
Error: [AES-CBC 128-bit key without encrypt usage] assert_equals: Should throw an InvalidAccessError instead of Invalid access: CryptoKey with 'AES-CBC', doesn't support 'encrypt' expected "InvalidAccessError" but got "Error"
```

#### WebCryptoAPI/encrypt_decrypt > should pass aes_cbc.https.any.js tests
```
Error: [AES-CBC 128-bit key with mismatched key and algorithm] promise_test: Unhandled rejection with value: object "ReferenceError: err is not defined"
Error: [AES-CBC 128-bit key, 64-bit IV] invalid length of iv. Currently supported 16 bytes
```

#### WebCryptoAPI/encrypt_decrypt > should pass aes_ctr.https.any.js tests
```
Error: [AES-CTR 128-bit key, 0-bit counter] assert_equals: Should throw an OperationError instead of invalid counter length. Currently supported 32/64/128 bits expected "OperationError" but got "Error"
```

#### WebCryptoAPI/encrypt_decrypt > should pass aes_gcm.https.any.js tests
```
Error: [AES-GCM 128-bit key, 32-bit tag, 96-bit iv] assert_unreached: encrypt error for test AES-GCM 128-bit key, 32-bit tag, 96-bit iv: Invalid tagLength. Currently supported 96/104/112/120/128 bits Reached unreachable code
Error: [AES-GCM 128-bit key, 32-bit tag, 96-bit iv] assert_unreached: encrypt error for test AES-GCM 128-bit key, 32-bit tag, 96-bit iv: Invalid length Reached unreachable code
Error: [AES-GCM 128-bit key, 32-bit tag, 96-bit iv decryption with transferred ciphertext during call] assert_equals: Should throw an OperationError instead of Invalid ciphertext length expected "OperationError" but got "Error"
```

#### WebCryptoAPI/encrypt_decrypt > should pass rsa_oaep.https.any.js tests
```
Error: [RSA-OAEP with SHA-1 and no label decryption] assert_unreached: Decryption should not throw error RSA-OAEP with SHA-1 and no label: 'Invalid key' Reached unreachable code
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
