### PR TITLE
feat(util): add TextEncoderStream and TextDecoderStream

### DIFF
--- a/API.md
+++ b/API.md
@@ -526,7 +526,11 @@ _Also available globally_
 
 [TextDecoder](https://nodejs.org/api/util.html#class-utiltextdecoder)
 
+[TextDecoderStream](https://nodejs.org/api/webstreams.html#class-textdecoderstream)
+
 [TextEncoder](https://nodejs.org/api/util.html#class-utiltextdecoder)
+
+[TextEncoderStream](https://nodejs.org/api/webstreams.html#class-textencoderstream)
 
 ## zlib
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,8 +2336,11 @@ dependencies = [
  "llrt_context",
  "llrt_encoding",
  "llrt_logging",
+ "llrt_stream_web",
+ "llrt_test",
  "llrt_utils",
  "rquickjs",
+ "tokio",
 ]
 
 [[package]]

--- a/modules/llrt_stream_web/src/lib.rs
+++ b/modules/llrt_stream_web/src/lib.rs
@@ -9,7 +9,7 @@ use readable::{
 };
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
-    Class, Ctx, Result,
+    Class, Ctx, Object, Result,
 };
 use writable::{WritableStream, WritableStreamDefaultController, WritableStreamDefaultWriter};
 
@@ -42,6 +42,26 @@ pub use readable::{
 };
 pub use readable::{CancelAlgorithm, PullAlgorithm, ReadableStreamControllerClass, StartAlgorithm};
 pub use readable::{NativePull, NativePullFn, NativePullResult};
+
+/// Creates a transform stream using LLRT's built-in Web Streams implementation.
+///
+/// This does not consult the global `TransformStream` binding.
+pub fn create_transform_stream<'js>(
+    ctx: &Ctx<'js>,
+    transformer: Object<'js>,
+) -> Result<Object<'js>> {
+    init_primordials(ctx)?;
+    Ok(TransformStream::from_transformer(ctx.clone(), transformer)?.into_inner())
+}
+
+fn init_primordials(ctx: &Ctx<'_>) -> Result<()> {
+    BasePrimordials::init(ctx)?;
+    PromisePrimordials::init(ctx)?;
+    ArrayConstructorPrimordials::init(ctx)?;
+    WritableStreamDefaultControllerPrimordials::init(ctx)?;
+    IteratorPrimordials::init(ctx)?;
+    Ok(())
+}
 
 /// Defines web streams, which are exposed through the "stream/web" Node import, but also at the global scope
 /// Web streams consist of Readable, Writable, and Transform streams. Transform is currently unimplemented.
@@ -134,11 +154,7 @@ impl From<StreamWebModule> for ModuleInfo<StreamWebModule> {
 pub fn init(ctx: &Ctx) -> Result<()> {
     let globals = &ctx.globals();
 
-    BasePrimordials::init(ctx)?;
-    PromisePrimordials::init(ctx)?;
-    ArrayConstructorPrimordials::init(ctx)?;
-    WritableStreamDefaultControllerPrimordials::init(ctx)?;
-    IteratorPrimordials::init(ctx)?;
+    init_primordials(ctx)?;
 
     // https://min-common-api.proposal.wintertc.org/#api-index
     Class::<ByteLengthQueuingStrategy>::define(globals)?;

--- a/modules/llrt_stream_web/src/transform/stream.rs
+++ b/modules/llrt_stream_web/src/transform/stream.rs
@@ -37,6 +37,18 @@ pub(crate) type TransformStreamClass<'js> = Class<'js, TransformStream<'js>>;
 
 #[rquickjs::methods(rename_all = "camelCase")]
 impl<'js> TransformStream<'js> {
+    pub(crate) fn from_transformer(
+        ctx: Ctx<'js>,
+        transformer: Object<'js>,
+    ) -> Result<Class<'js, Self>> {
+        Self::new(
+            ctx,
+            Opt(Some(Undefined(Some(transformer)))),
+            Opt(None),
+            Opt(None),
+        )
+    }
+
     #[qjs(constructor)]
     fn new(
         ctx: Ctx<'js>,

--- a/modules/llrt_util/Cargo.toml
+++ b/modules/llrt_util/Cargo.toml
@@ -15,10 +15,10 @@ path = "src/lib.rs"
 llrt_context = { version = "0.8.1-beta", path = "../../libs/llrt_context" }
 llrt_encoding = { version = "0.8.1-beta", path = "../../libs/llrt_encoding" }
 llrt_logging = { version = "0.8.1-beta", path = "../../libs/llrt_logging" }
+llrt_stream_web = { version = "0.8.1-beta", path = "../llrt_stream_web" }
 llrt_utils = { version = "0.8.1-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { version = "0.12", default-features = false }
 
 [dev-dependencies]
-llrt_stream_web = { path = "../llrt_stream_web" }
 llrt_test = { path = "../../libs/llrt_test" }
 tokio = { version = "1", features = ["macros", "test-util"], default-features = false }

--- a/modules/llrt_util/Cargo.toml
+++ b/modules/llrt_util/Cargo.toml
@@ -17,3 +17,8 @@ llrt_encoding = { version = "0.8.1-beta", path = "../../libs/llrt_encoding" }
 llrt_logging = { version = "0.8.1-beta", path = "../../libs/llrt_logging" }
 llrt_utils = { version = "0.8.1-beta", path = "../../libs/llrt_utils", default-features = false }
 rquickjs = { version = "0.12", default-features = false }
+
+[dev-dependencies]
+llrt_stream_web = { path = "../llrt_stream_web" }
+llrt_test = { path = "../../libs/llrt_test" }
+tokio = { version = "1", features = ["macros", "test-util"], default-features = false }

--- a/modules/llrt_util/src/lib.rs
+++ b/modules/llrt_util/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+mod style_text;
 #[cfg(test)]
 mod tests;
-mod style_text;
 pub mod text_decoder;
 pub mod text_decoder_stream;
 pub mod text_encoder;

--- a/modules/llrt_util/src/lib.rs
+++ b/modules/llrt_util/src/lib.rs
@@ -1,17 +1,39 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+#[cfg(test)]
+mod tests;
 pub mod text_decoder;
+pub mod text_decoder_stream;
 pub mod text_encoder;
+pub mod text_encoder_stream;
 
 use llrt_logging::format_plain;
-use llrt_utils::module::{export_default, ModuleInfo};
+use llrt_utils::{
+    module::{export_default, ModuleInfo},
+    primordials::Primordial,
+};
 use rquickjs::{
-    function::Func,
+    function::{Constructor, Func},
     module::{Declarations, Exports, ModuleDef},
-    Class, Ctx, Function, Object, Result,
+    Class, Ctx, Function, JsLifetime, Object, Result,
 };
 use text_decoder::TextDecoder;
+use text_decoder_stream::TextDecoderStream;
 use text_encoder::TextEncoder;
+use text_encoder_stream::TextEncoderStream;
+
+#[derive(JsLifetime)]
+pub(crate) struct UtilPrimordials<'js> {
+    pub(crate) constructor_transform_stream: Constructor<'js>,
+}
+
+impl<'js> Primordial<'js> for UtilPrimordials<'js> {
+    fn new(ctx: &Ctx<'js>) -> Result<Self> {
+        Ok(Self {
+            constructor_transform_stream: ctx.globals().get("TransformStream")?,
+        })
+    }
+}
 
 fn inherits<'js>(ctor: Function<'js>, super_ctor: Function<'js>) -> Result<()> {
     let super_proto: Object<'js> = super_ctor.get("prototype")?;
@@ -26,7 +48,9 @@ pub struct UtilModule;
 impl ModuleDef for UtilModule {
     fn declare(declare: &Declarations) -> Result<()> {
         declare.declare(stringify!(TextDecoder))?;
+        declare.declare(stringify!(TextDecoderStream))?;
         declare.declare(stringify!(TextEncoder))?;
+        declare.declare(stringify!(TextEncoderStream))?;
         declare.declare(stringify!(format))?;
         declare.declare(stringify!(inherits))?;
         declare.declare("default")?;
@@ -39,9 +63,13 @@ impl ModuleDef for UtilModule {
 
             let encoder: Function = globals.get(stringify!(TextEncoder))?;
             let decoder: Function = globals.get(stringify!(TextDecoder))?;
+            let encoder_stream: Function = globals.get(stringify!(TextEncoderStream))?;
+            let decoder_stream: Function = globals.get(stringify!(TextDecoderStream))?;
 
             default.set(stringify!(TextEncoder), encoder)?;
             default.set(stringify!(TextDecoder), decoder)?;
+            default.set(stringify!(TextEncoderStream), encoder_stream)?;
+            default.set(stringify!(TextDecoderStream), decoder_stream)?;
             default.set(
                 "format",
                 Func::from(|ctx, args| format_plain(ctx, true, args)),
@@ -67,6 +95,11 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
 
     Class::<TextEncoder>::define(&globals)?;
     Class::<TextDecoder>::define(&globals)?;
+
+    UtilPrimordials::init(ctx)?;
+
+    Class::<TextEncoderStream>::define(&globals)?;
+    Class::<TextDecoderStream>::define(&globals)?;
 
     Ok(())
 }

--- a/modules/llrt_util/src/lib.rs
+++ b/modules/llrt_util/src/lib.rs
@@ -13,31 +13,17 @@ use llrt_utils::{
     class::CUSTOM_INSPECT_SYMBOL_DESCRIPTION,
     module::{export_default, ModuleInfo},
     object::ObjectExt,
-    primordials::Primordial,
 };
 use rquickjs::{
-    function::{Constructor, Func, Opt, Rest},
+    function::{Func, Opt, Rest},
     module::{Declarations, Exports, ModuleDef},
-    Class, Ctx, Function, JsLifetime, Object, Result, Symbol, Value,
+    Class, Ctx, Function, Object, Result, Symbol, Value,
 };
 use style_text::style_text;
 use text_decoder::TextDecoder;
 use text_decoder_stream::TextDecoderStream;
 use text_encoder::TextEncoder;
 use text_encoder_stream::TextEncoderStream;
-
-#[derive(JsLifetime)]
-pub(crate) struct UtilPrimordials<'js> {
-    pub(crate) constructor_transform_stream: Constructor<'js>,
-}
-
-impl<'js> Primordial<'js> for UtilPrimordials<'js> {
-    fn new(ctx: &Ctx<'js>) -> Result<Self> {
-        Ok(Self {
-            constructor_transform_stream: ctx.globals().get("TransformStream")?,
-        })
-    }
-}
 
 fn inherits<'js>(ctor: Function<'js>, super_ctor: Function<'js>) -> Result<()> {
     let super_proto: Object<'js> = super_ctor.get("prototype")?;
@@ -120,9 +106,6 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
 
     Class::<TextEncoder>::define(&globals)?;
     Class::<TextDecoder>::define(&globals)?;
-
-    UtilPrimordials::init(ctx)?;
-
     Class::<TextEncoderStream>::define(&globals)?;
     Class::<TextDecoderStream>::define(&globals)?;
 

--- a/modules/llrt_util/src/style_text.rs
+++ b/modules/llrt_util/src/style_text.rs
@@ -116,6 +116,7 @@ mod tests {
     async fn single_format() {
         test_async_with(|ctx| {
             Box::pin(async move {
+                llrt_stream_web::init(&ctx).unwrap();
                 crate::init(&ctx).unwrap();
                 ModuleEvaluator::eval_rust::<UtilModule>(ctx.clone(), "util")
                     .await
@@ -145,6 +146,7 @@ mod tests {
     async fn array_of_formats_nests() {
         test_async_with(|ctx| {
             Box::pin(async move {
+                llrt_stream_web::init(&ctx).unwrap();
                 crate::init(&ctx).unwrap();
                 ModuleEvaluator::eval_rust::<UtilModule>(ctx.clone(), "util")
                     .await
@@ -174,6 +176,7 @@ mod tests {
     async fn unknown_format_throws() {
         test_async_with(|ctx| {
             Box::pin(async move {
+                llrt_stream_web::init(&ctx).unwrap();
                 crate::init(&ctx).unwrap();
                 ModuleEvaluator::eval_rust::<UtilModule>(ctx.clone(), "util")
                     .await

--- a/modules/llrt_util/src/style_text.rs
+++ b/modules/llrt_util/src/style_text.rs
@@ -116,7 +116,6 @@ mod tests {
     async fn single_format() {
         test_async_with(|ctx| {
             Box::pin(async move {
-                llrt_stream_web::init(&ctx).unwrap();
                 crate::init(&ctx).unwrap();
                 ModuleEvaluator::eval_rust::<UtilModule>(ctx.clone(), "util")
                     .await
@@ -146,7 +145,6 @@ mod tests {
     async fn array_of_formats_nests() {
         test_async_with(|ctx| {
             Box::pin(async move {
-                llrt_stream_web::init(&ctx).unwrap();
                 crate::init(&ctx).unwrap();
                 ModuleEvaluator::eval_rust::<UtilModule>(ctx.clone(), "util")
                     .await
@@ -176,7 +174,6 @@ mod tests {
     async fn unknown_format_throws() {
         test_async_with(|ctx| {
             Box::pin(async move {
-                llrt_stream_web::init(&ctx).unwrap();
                 crate::init(&ctx).unwrap();
                 ModuleEvaluator::eval_rust::<UtilModule>(ctx.clone(), "util")
                     .await

--- a/modules/llrt_util/src/tests.rs
+++ b/modules/llrt_util/src/tests.rs
@@ -8,8 +8,43 @@ fn eval_async<'js>(ctx: &rquickjs::Ctx<'js>, js: &str) -> rquickjs::Result<Promi
 
 fn init(ctx: &rquickjs::Ctx<'_>) {
     BasePrimordials::init(ctx).unwrap();
-    llrt_stream_web::init(ctx).unwrap();
     crate::init(ctx).unwrap();
+}
+
+#[tokio::test]
+async fn streams_ignore_global_transform_stream() {
+    test_async_with(|ctx| {
+        BasePrimordials::init(&ctx).unwrap();
+        llrt_stream_web::init(&ctx).unwrap();
+        ctx.globals()
+            .set(
+                "TransformStream",
+                rquickjs::Value::new_undefined(ctx.clone()),
+            )
+            .unwrap();
+        crate::init(&ctx).unwrap();
+
+        Box::pin(async move {
+            eval_async(
+                &ctx,
+                r#"
+                const encoder = new TextEncoderStream();
+                const decoder = new TextDecoderStream();
+                if (!encoder.readable || !encoder.writable) {
+                    throw new Error("invalid encoder streams");
+                }
+                if (!decoder.readable || !decoder.writable) {
+                    throw new Error("invalid decoder streams");
+                }
+            "#,
+            )
+            .unwrap()
+            .into_future::<()>()
+            .await
+            .unwrap();
+        })
+    })
+    .await;
 }
 
 #[tokio::test]

--- a/modules/llrt_util/src/tests.rs
+++ b/modules/llrt_util/src/tests.rs
@@ -1,0 +1,97 @@
+use llrt_test::test_async_with;
+use rquickjs::Promise;
+
+fn eval_async<'js>(ctx: &rquickjs::Ctx<'js>, js: &str) -> rquickjs::Result<Promise<'js>> {
+    ctx.eval(format!("(async () => {{ {js} }})()"))
+}
+
+fn init(ctx: &rquickjs::Ctx<'_>) {
+    llrt_stream_web::init(ctx).unwrap();
+    crate::init(ctx).unwrap();
+}
+
+#[tokio::test]
+async fn encoder_stream_encodes_chunk() {
+    test_async_with(|ctx| {
+        init(&ctx);
+        Box::pin(async move {
+            eval_async(
+                &ctx,
+                r#"
+                const es = new TextEncoderStream();
+                const writer = es.writable.getWriter();
+                const reader = es.readable.getReader();
+
+                writer.write("hi");
+                writer.close();
+
+                const { value, done } = await reader.read();
+                if (done) throw new Error("expected a chunk");
+                if (!(value instanceof Uint8Array)) throw new Error("expected Uint8Array");
+                if (value.join(",") !== "104,105") throw new Error("got: " + value.join(","));
+            "#,
+            )
+            .unwrap()
+            .into_future::<()>()
+            .await
+            .unwrap();
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn decoder_stream_decodes_split_utf8_char() {
+    test_async_with(|ctx| {
+        init(&ctx);
+        Box::pin(async move {
+            eval_async(
+                &ctx,
+                r#"
+                const ds = new TextDecoderStream();
+                const writer = ds.writable.getWriter();
+                const reader = ds.readable.getReader();
+
+                const euro = new Uint8Array([0xe2, 0x82, 0xac]);
+                writer.write(euro.slice(0, 1));
+                writer.write(euro.slice(1));
+                writer.close();
+
+                let result = "";
+                while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    result += value;
+                }
+                if (result !== "\u20ac") throw new Error("got: " + result);
+            "#,
+            )
+            .unwrap()
+            .into_future::<()>()
+            .await
+            .unwrap();
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn decoder_stream_encoding_getter() {
+    test_async_with(|ctx| {
+        init(&ctx);
+        Box::pin(async move {
+            eval_async(
+                &ctx,
+                r#"
+                const ds = new TextDecoderStream("utf-8");
+                if (ds.encoding !== "utf-8") throw new Error("got: " + ds.encoding);
+            "#,
+            )
+            .unwrap()
+            .into_future::<()>()
+            .await
+            .unwrap();
+        })
+    })
+    .await;
+}

--- a/modules/llrt_util/src/text_decoder.rs
+++ b/modules/llrt_util/src/text_decoder.rs
@@ -91,17 +91,17 @@ impl<'js> TextDecoder {
     }
 
     #[qjs(get)]
-    fn encoding(&self) -> &str {
+    pub(crate) fn encoding(&self) -> &str {
         self.encoder.as_label()
     }
 
     #[qjs(get)]
-    fn fatal(&self) -> bool {
+    pub(crate) fn fatal(&self) -> bool {
         self.fatal
     }
 
     #[qjs(get, rename = "ignoreBOM")]
-    fn ignore_bom(&self) -> bool {
+    pub(crate) fn ignore_bom(&self) -> bool {
         self.ignore_bom
     }
 

--- a/modules/llrt_util/src/text_decoder_stream.rs
+++ b/modules/llrt_util/src/text_decoder_stream.rs
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::sync::{Arc, Mutex};
+
+use llrt_utils::{bytes::ObjectBytes, primordials::Primordial};
+use rquickjs::{
+    atom::PredefinedAtom, function::Opt, prelude::This, Ctx, Function, Object, Result, Value,
+};
+
+use crate::{text_decoder::TextDecoder, UtilPrimordials};
+
+#[rquickjs::class]
+#[derive(rquickjs::class::Trace, rquickjs::JsLifetime)]
+pub struct TextDecoderStream<'js> {
+    #[qjs(skip_trace)]
+    encoding: String,
+    #[qjs(skip_trace)]
+    fatal: bool,
+    #[qjs(skip_trace)]
+    ignore_bom: bool,
+    readable: Value<'js>,
+    writable: Value<'js>,
+}
+
+#[rquickjs::methods(rename_all = "camelCase")]
+impl<'js> TextDecoderStream<'js> {
+    #[qjs(constructor)]
+    pub fn new(ctx: Ctx<'js>, label: Opt<String>, options: Opt<Object<'js>>) -> Result<Self> {
+        let decoder = TextDecoder::new(ctx.clone(), label, options)?;
+        let encoding = decoder.encoding().to_owned();
+        let fatal = decoder.fatal();
+        let ignore_bom = decoder.ignore_bom();
+        let decoder = Arc::new(Mutex::new(decoder));
+
+        let transform_decoder = decoder.clone();
+        let transform = Function::new(ctx.clone(), move |ctx, chunk, controller| {
+            transform(&transform_decoder, ctx, chunk, controller)
+        })?;
+
+        let flush_decoder = decoder.clone();
+        let flush = Function::new(ctx.clone(), move |ctx, controller| {
+            flush(&flush_decoder, ctx, controller)
+        })?;
+
+        let transformer = Object::new(ctx.clone())?;
+        transformer.set("transform", transform)?;
+        transformer.set("flush", flush)?;
+
+        let transform_stream_ctor = &UtilPrimordials::get(&ctx)?.constructor_transform_stream;
+        let stream: Object = transform_stream_ctor.construct((transformer,))?;
+
+        Ok(Self {
+            encoding,
+            fatal,
+            ignore_bom,
+            readable: stream.get("readable")?,
+            writable: stream.get("writable")?,
+        })
+    }
+
+    #[qjs(get)]
+    fn encoding(&self) -> &str {
+        &self.encoding
+    }
+
+    #[qjs(get, rename = "fatal")]
+    fn fatal(&self) -> bool {
+        self.fatal
+    }
+
+    #[qjs(get, rename = "ignoreBOM")]
+    fn ignore_bom(&self) -> bool {
+        self.ignore_bom
+    }
+
+    #[qjs(get)]
+    fn readable(&self) -> Value<'js> {
+        self.readable.clone()
+    }
+
+    #[qjs(get)]
+    fn writable(&self) -> Value<'js> {
+        self.writable.clone()
+    }
+
+    #[qjs(prop, rename = PredefinedAtom::SymbolToStringTag, configurable)]
+    pub fn to_string_tag() -> &'static str {
+        stringify!(TextDecoderStream)
+    }
+}
+
+fn transform<'js>(
+    decoder: &Mutex<TextDecoder>,
+    ctx: Ctx<'js>,
+    chunk: Value<'js>,
+    controller: Object<'js>,
+) -> Result<()> {
+    let bytes = ObjectBytes::from(&ctx, &chunk)?;
+    let opts = Object::new(ctx.clone())?;
+    opts.set("stream", true)?;
+    let text = decoder
+        .lock()
+        .unwrap()
+        .decode(ctx, Opt(Some(bytes)), Opt(Some(opts.into_value())))?;
+    if !text.is_empty() {
+        let enqueue: Function = controller.get("enqueue")?;
+        enqueue.call::<_, ()>((This(controller), text))?;
+    }
+    Ok(())
+}
+
+fn flush<'js>(decoder: &Mutex<TextDecoder>, ctx: Ctx<'js>, controller: Object<'js>) -> Result<()> {
+    let text = decoder.lock().unwrap().decode(ctx, Opt(None), Opt(None))?;
+    if !text.is_empty() {
+        let enqueue: Function = controller.get("enqueue")?;
+        enqueue.call::<_, ()>((This(controller), text))?;
+    }
+    Ok(())
+}

--- a/modules/llrt_util/src/text_decoder_stream.rs
+++ b/modules/llrt_util/src/text_decoder_stream.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::sync::{Arc, Mutex};
 
-use llrt_utils::{bytes::ObjectBytes, primordials::Primordial};
+use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{
     atom::PredefinedAtom, function::Opt, prelude::This, Ctx, Function, Object, Result, Value,
 };
 
-use crate::{text_decoder::TextDecoder, UtilPrimordials};
+use crate::text_decoder::TextDecoder;
 
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace, rquickjs::JsLifetime)]
@@ -46,8 +46,7 @@ impl<'js> TextDecoderStream<'js> {
         transformer.set("transform", transform)?;
         transformer.set("flush", flush)?;
 
-        let transform_stream_ctor = &UtilPrimordials::get(&ctx)?.constructor_transform_stream;
-        let stream: Object = transform_stream_ctor.construct((transformer,))?;
+        let stream = llrt_stream_web::create_transform_stream(&ctx, transformer)?;
 
         Ok(Self {
             encoding,

--- a/modules/llrt_util/src/text_encoder_stream.rs
+++ b/modules/llrt_util/src/text_encoder_stream.rs
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use llrt_utils::primordials::Primordial;
+use rquickjs::{
+    atom::PredefinedAtom, convert::Coerced, prelude::This, Ctx, Function, Object, Result,
+    TypedArray, Value,
+};
+
+use crate::UtilPrimordials;
+
+#[rquickjs::class]
+#[derive(rquickjs::class::Trace, rquickjs::JsLifetime)]
+pub struct TextEncoderStream<'js> {
+    readable: Value<'js>,
+    writable: Value<'js>,
+}
+
+#[rquickjs::methods(rename_all = "camelCase")]
+impl<'js> TextEncoderStream<'js> {
+    #[qjs(constructor)]
+    pub fn new(ctx: Ctx<'js>) -> Result<Self> {
+        let transform = Function::new(ctx.clone(), transform)?;
+        let transformer = Object::new(ctx.clone())?;
+        transformer.set("transform", transform)?;
+
+        let transform_stream_ctor = &UtilPrimordials::get(&ctx)?.constructor_transform_stream;
+        let stream: Object = transform_stream_ctor.construct((transformer,))?;
+
+        Ok(Self {
+            readable: stream.get("readable")?,
+            writable: stream.get("writable")?,
+        })
+    }
+
+    #[qjs(get)]
+    fn encoding(&self) -> &str {
+        "utf-8"
+    }
+
+    #[qjs(get)]
+    fn readable(&self) -> Value<'js> {
+        self.readable.clone()
+    }
+
+    #[qjs(get)]
+    fn writable(&self) -> Value<'js> {
+        self.writable.clone()
+    }
+
+    #[qjs(prop, rename = PredefinedAtom::SymbolToStringTag, configurable)]
+    pub fn to_string_tag() -> &'static str {
+        stringify!(TextEncoderStream)
+    }
+}
+
+fn transform<'js>(ctx: Ctx<'js>, chunk: Coerced<String>, controller: Object<'js>) -> Result<()> {
+    let bytes = TypedArray::new(ctx.clone(), chunk.0.as_bytes())?;
+    let enqueue: Function = controller.get("enqueue")?;
+    enqueue.call::<_, ()>((This(controller), bytes))
+}

--- a/modules/llrt_util/src/text_encoder_stream.rs
+++ b/modules/llrt_util/src/text_encoder_stream.rs
@@ -1,12 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use llrt_utils::primordials::Primordial;
 use rquickjs::{
     atom::PredefinedAtom, convert::Coerced, prelude::This, Ctx, Function, Object, Result,
     TypedArray, Value,
 };
-
-use crate::UtilPrimordials;
 
 #[rquickjs::class]
 #[derive(rquickjs::class::Trace, rquickjs::JsLifetime)]
@@ -23,8 +20,7 @@ impl<'js> TextEncoderStream<'js> {
         let transformer = Object::new(ctx.clone())?;
         transformer.set("transform", transform)?;
 
-        let transform_stream_ctor = &UtilPrimordials::get(&ctx)?.constructor_transform_stream;
-        let stream: Object = transform_stream_ctor.construct((transformer,))?;
+        let stream = llrt_stream_web::create_transform_stream(&ctx, transformer)?;
 
         Ok(Self {
             readable: stream.get("readable")?,

--- a/types/util.d.ts
+++ b/types/util.d.ts
@@ -208,9 +208,51 @@ declare module "util" {
      */
     encodeInto(src: string, dest: Uint8Array): EncodeIntoResult;
   }
+  /**
+   * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextEncoderStream` API.
+   *
+   * ```js
+   * const stream = new TextEncoderStream();
+   * ```
+   *
+   * The `TextEncoderStream` class is also available on the global object.
+   */
+  export class TextEncoderStream {
+    /**
+     * The encoding supported by the `TextEncoderStream` instance. Always set to `'utf-8'`.
+     */
+    readonly encoding: string;
+    readonly readable: ReadableStream;
+    readonly writable: WritableStream;
+  }
+  /**
+   * An implementation of the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/) `TextDecoderStream` API.
+   *
+   * ```js
+   * const stream = new TextDecoderStream();
+   * ```
+   *
+   * The `TextDecoderStream` class is also available on the global object.
+   */
+  export class TextDecoderStream {
+    constructor(
+      encoding?: string,
+      options?: {
+        fatal?: boolean | undefined;
+        ignoreBOM?: boolean | undefined;
+      }
+    );
+    readonly encoding: string;
+    readonly fatal: boolean;
+    readonly ignoreBOM: boolean;
+    readonly readable: ReadableStream;
+    readonly writable: WritableStream;
+  }
   import {
     TextDecoder as _TextDecoder,
+    TextDecoderStream as _TextDecoderStream,
     TextEncoder as _TextEncoder,
+    TextEncoderStream as _TextEncoderStream,
   } from "util";
   global {
     /**
@@ -233,6 +275,26 @@ declare module "util" {
     }
       ? TextEncoder
       : typeof _TextEncoder;
+    /**
+     * `TextDecoderStream` class is a global reference for `import { TextDecoderStream } from 'util'`
+     * https://nodejs.org/api/globals.html#textdecoderstream
+     */
+    var TextDecoderStream: typeof globalThis extends {
+      onmessage: any;
+      TextDecoderStream: infer TextDecoderStream;
+    }
+      ? TextDecoderStream
+      : typeof _TextDecoderStream;
+    /**
+     * `TextEncoderStream` class is a global reference for `import { TextEncoderStream } from 'util'`
+     * https://nodejs.org/api/globals.html#textencoderstream
+     */
+    var TextEncoderStream: typeof globalThis extends {
+      onmessage: any;
+      TextEncoderStream: infer TextEncoderStream;
+    }
+      ? TextEncoderStream
+      : typeof _TextEncoderStream;
   }
 }
 declare module "util" {


### PR DESCRIPTION
### Issue # (if available)

Closes #793

### Description of changes

Adds `TextEncoderStream` and `TextDecoderStream` in Rust, wrapping the existing `TransformStream` with the existing `TextEncoder`/`TextDecoder` logic (`TextDecoder`'s chunked `stream: true` decode handles multi-byte sequences split across chunks). Both are exposed as globals and as `util` exports.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
