### PR TITLE
fix(fetch): discard malformed null-body connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-util",
  "itoa",
  "llrt_abort",
  "llrt_buffer",

--- a/modules/llrt_fetch/Cargo.toml
+++ b/modules/llrt_fetch/Cargo.toml
@@ -34,6 +34,7 @@ either = { version = "1", default-features = false }
 http-body = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 hyper = { version = "1", features = ["client"], default-features = false }
+hyper-util = { version = "=0.1.20", features = ["client-legacy"], default-features = false }
 itoa = { version = "1", default-features = false }
 llrt_abort = { version = "0.8.1-beta", path = "../llrt_abort" }
 llrt_buffer = { version = "0.8.1-beta", path = "../llrt_buffer" }

--- a/modules/llrt_fetch/src/fetch.rs
+++ b/modules/llrt_fetch/src/fetch.rs
@@ -5,11 +5,12 @@ use http_body_util::{combinators::BoxBody, Full};
 use hyper::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, AUTHORIZATION, CONTENT_ENCODING,
-        CONTENT_LANGUAGE, CONTENT_LENGTH, CONTENT_LOCATION, CONTENT_TYPE, LOCATION, ORIGIN,
-        USER_AGENT,
+        CONTENT_LANGUAGE, CONTENT_LENGTH, CONTENT_LOCATION, CONTENT_TYPE, IF_MODIFIED_SINCE,
+        IF_NONE_MATCH, LOCATION, ORIGIN, TRANSFER_ENCODING, USER_AGENT,
     },
-    Method, Request, Uri,
+    HeaderMap, Method, Request, Uri, Version,
 };
+use hyper_util::client::legacy::connect::{capture_connection, CaptureConnection};
 use llrt_abort::AbortSignal;
 use llrt_context::CtxExtension;
 use llrt_encoding::bytes_from_b64;
@@ -265,7 +266,9 @@ async fn send_stream<'js>(
     apply_default_headers(&mut req, &detected_headers);
 
     let box_body: BoxBody<Bytes, Infallible> = BoxBody::new(stream_body);
-    let request = req.body(box_body).or_throw(ctx)?;
+    let mut request = req.body(box_body).or_throw(ctx)?;
+    let is_conditional = request_is_conditional(&request);
+    let captured_connection = capture_connection(&mut request);
 
     // Race request against stream error
     let request_fut = client.request(request);
@@ -286,6 +289,8 @@ async fn send_stream<'js>(
         }
     };
 
+    poison_malformed_null_body_connection(&method, is_conditional, &captured_connection, &res);
+
     Response::from_incoming(
         ctx.clone(),
         res,
@@ -301,20 +306,73 @@ async fn send_stream<'js>(
 async fn dispatch<'js>(
     ctx: &Ctx<'js>,
     client: &HyperClient,
-    req: Request<BoxBody<Bytes, Infallible>>,
+    mut req: Request<BoxBody<Bytes, Infallible>>,
     abort_receiver: Option<&mc_oneshot::Receiver<Value<'js>>>,
 ) -> Result<hyper::Response<hyper::body::Incoming>> {
-    if let Some(abort_receiver) = abort_receiver {
+    let method = req.method().clone();
+    let is_conditional = request_is_conditional(&req);
+    let captured_connection = capture_connection(&mut req);
+    let request = client.request(req);
+    tokio::pin!(request);
+
+    let res = if let Some(abort_receiver) = abort_receiver {
         select! {
-            res = client.request(req) => res.map_err(|e| throw_fetch_failed(ctx, e)),
-            reason = abort_receiver.recv() => Err(ctx.throw(reason)),
+            res = &mut request => res.map_err(|e| throw_fetch_failed(ctx, e))?,
+            reason = abort_receiver.recv() => return Err(ctx.throw(reason)),
         }
     } else {
-        client
-            .request(req)
-            .await
-            .map_err(|e| throw_fetch_failed(ctx, e))
+        request.await.map_err(|e| throw_fetch_failed(ctx, e))?
+    };
+
+    poison_malformed_null_body_connection(&method, is_conditional, &captured_connection, &res);
+
+    Ok(res)
+}
+
+fn request_is_conditional<B>(request: &Request<B>) -> bool {
+    request.headers().contains_key(IF_NONE_MATCH)
+        || request.headers().contains_key(IF_MODIFIED_SINCE)
+}
+
+fn poison_malformed_null_body_connection(
+    method: &Method,
+    is_conditional: bool,
+    captured_connection: &CaptureConnection,
+    response: &hyper::Response<hyper::body::Incoming>,
+) {
+    // Hyper can return an HTTP/1 bodyless response to the pool before forbidden
+    // payload bytes arrive, letting the next request consume them as its response.
+    if should_poison_connection(method, is_conditional, response) {
+        if let Some(connection) = captured_connection.connection_metadata().as_ref() {
+            connection.poison();
+        }
     }
+}
+
+fn should_poison_connection<B>(
+    method: &Method,
+    is_conditional: bool,
+    response: &hyper::Response<B>,
+) -> bool {
+    if !matches!(response.version(), Version::HTTP_10 | Version::HTTP_11)
+        || !indicates_possible_payload(response.headers())
+    {
+        return false;
+    }
+
+    match response.status().as_u16() {
+        204 | 205 => true,
+        304 => !matches!(*method, Method::GET | Method::HEAD) || !is_conditional,
+        _ => false,
+    }
+}
+
+fn indicates_possible_payload(headers: &HeaderMap) -> bool {
+    headers.contains_key(TRANSFER_ENCODING)
+        || headers
+            .get(CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value != "0")
 }
 
 // Per WHATWG Fetch, a network/connection failure rejects with exactly
@@ -939,6 +997,72 @@ mod tests {
     use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
 
     use super::*;
+
+    #[test]
+    fn test_should_poison_connection() {
+        fn response(status: u16, name: &str, value: &str) -> hyper::Response<()> {
+            hyper::Response::builder()
+                .status(status)
+                .header(name, value)
+                .body(())
+                .unwrap()
+        }
+
+        fn h2_response(status: u16, name: &str, value: &str) -> hyper::Response<()> {
+            hyper::Response::builder()
+                .status(status)
+                .version(Version::HTTP_2)
+                .header(name, value)
+                .body(())
+                .unwrap()
+        }
+
+        assert!(should_poison_connection(
+            &Method::GET,
+            false,
+            &response(204, "content-length", "11")
+        ));
+        assert!(should_poison_connection(
+            &Method::POST,
+            false,
+            &response(205, "transfer-encoding", "chunked")
+        ));
+        assert!(!should_poison_connection(
+            &Method::GET,
+            false,
+            &response(204, "content-length", "0")
+        ));
+        assert!(!should_poison_connection(
+            &Method::GET,
+            true,
+            &response(304, "content-length", "11")
+        ));
+        assert!(!should_poison_connection(
+            &Method::HEAD,
+            true,
+            &response(304, "content-length", "11")
+        ));
+        assert!(should_poison_connection(
+            &Method::GET,
+            false,
+            &response(304, "content-length", "11")
+        ));
+        assert!(should_poison_connection(
+            &Method::POST,
+            true,
+            &response(304, "content-length", "11")
+        ));
+        assert!(!should_poison_connection(
+            &Method::HEAD,
+            false,
+            &response(200, "content-length", "11")
+        ));
+        assert!(!should_poison_connection(
+            &Method::GET,
+            false,
+            &h2_response(204, "content-length", "11")
+        ));
+    }
 
     #[test]
     fn test_should_change_method() {

--- a/tests/unit/fetch.test.ts
+++ b/tests/unit/fetch.test.ts
@@ -152,6 +152,109 @@ describe("fetch", () => {
     await Promise.all(new Array(10).fill(0).map(() => fetch(url)));
   });
 
+  it("should not reuse malformed null-body response connections", async () => {
+    const sockets = new Set<net.Socket>();
+    let firstSocket: net.Socket | undefined;
+    let connectionCount = 0;
+    let requestCount = 0;
+    const malformedServer = net.createServer((socket) => {
+      sockets.add(socket);
+      connectionCount++;
+      let requestData = "";
+      socket.on("close", () => sockets.delete(socket));
+      socket.on("error", () => {});
+      socket.on("data", (data) => {
+        requestData += data.toString();
+        while (requestData.includes("\r\n\r\n")) {
+          requestData = requestData.slice(requestData.indexOf("\r\n\r\n") + 4);
+          requestCount++;
+          if (requestCount === 1) {
+            firstSocket = socket;
+            socket.write(
+              "HTTP/1.1 204 No Content\r\nContent-Length: 11\r\n\r\n"
+            );
+          } else if (socket === firstSocket) {
+            socket.write(
+              "hello-worldHTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nSECOND",
+              () => socket.end()
+            );
+          } else {
+            firstSocket?.write("hello-world");
+            socket.write(
+              "HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nSECOND",
+              () => socket.end()
+            );
+          }
+        }
+      });
+    });
+
+    await new Promise<void>((resolve) =>
+      malformedServer.listen(0, "127.0.0.1", resolve)
+    );
+    const { port } = malformedServer.address()! as net.AddressInfo;
+    const malformedUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      const first = await fetch(malformedUrl);
+      expect(first.status).toEqual(204);
+      expect(first.body).toBeNull();
+
+      const second = await fetch(malformedUrl);
+      expect(second.status).toEqual(200);
+      expect(await second.text()).toEqual("SECOND");
+      expect(connectionCount).toEqual(2);
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => malformedServer.close(resolve));
+    }
+  });
+
+  it("should reuse valid null-body response connections", async () => {
+    const sockets = new Set<net.Socket>();
+    let connectionCount = 0;
+    let requestCount = 0;
+    const validServer = net.createServer((socket) => {
+      sockets.add(socket);
+      connectionCount++;
+      let requestData = "";
+      socket.on("close", () => sockets.delete(socket));
+      socket.on("error", () => {});
+      socket.on("data", (data) => {
+        requestData += data.toString();
+        while (requestData.includes("\r\n\r\n")) {
+          requestData = requestData.slice(requestData.indexOf("\r\n\r\n") + 4);
+          requestCount++;
+          if (requestCount === 1) {
+            socket.write(
+              "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n"
+            );
+          } else {
+            socket.write(
+              "HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nSECOND",
+              () => socket.end()
+            );
+          }
+        }
+      });
+    });
+
+    await new Promise<void>((resolve) =>
+      validServer.listen(0, "127.0.0.1", resolve)
+    );
+    const { port } = validServer.address()! as net.AddressInfo;
+    const validUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      expect((await fetch(validUrl)).status).toEqual(204);
+      expect(await (await fetch(validUrl)).text()).toEqual("SECOND");
+      expect(connectionCount).toEqual(1);
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => validServer.close(resolve));
+    }
+  });
+
   // Regression test for https://github.com/awslabs/llrt/issues/1482:
   // a connection failure must reject with exactly `TypeError: Failed to fetch`
   // so the AWS SDK retry middleware classifies it as a transient error.


### PR DESCRIPTION
### Issue # (if available)

### Description of changes

Prevent malformed HTTP/1 null-body responses from reentering the fetch connection pool.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory (not applicable)
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other) (not applicable)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
