### PR TITLE
fix(stream): preserve pipe option access order

### DIFF
--- a/modules/llrt_stream_web/src/readable/stream/pipe.rs
+++ b/modules/llrt_stream_web/src/readable/stream/pipe.rs
@@ -678,8 +678,8 @@ impl<'js> FromJs<'js> for StreamPipeOptions<'js> {
         };
 
         let prevent_abort = get_bool("preventAbort")?;
-        let prevent_close = get_bool("preventClose")?;
         let prevent_cancel = get_bool("preventCancel")?;
+        let prevent_close = get_bool("preventClose")?;
 
         let signal = match obj.get_value_or_undefined::<_, Value<'js>>("signal")? {
             Some(signal) => Some(

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -8,7 +8,6 @@ fetch/api/basic > should pass mode-same-origin.any.js tests
 fetch/api/basic > should pass referrer.any.js tests
 fetch/api/basic > should pass request-headers-case.any.js tests
 fetch/api/basic > should pass request-referrer.any.js tests
-streams/piping > should pass throwing-options.any.js tests
 streams/transferable > should pass transform-stream-members.any.js tests
 streams/transform-streams > should pass strategies.any.js tests
 streams/transform-streams > should pass terminate.any.js tests


### PR DESCRIPTION
### Issue # (if available)

No issue filed. This small conformance bug was identified through the committed Streams WPT failure baseline.

### Description of changes

Read `StreamPipeOptions` members in Web IDL's required lexicographical order:

1. `preventAbort`
2. `preventCancel`
3. `preventClose`
4. `signal`

Previously, LLRT read `preventClose` before `preventCancel`. That observable ordering caused user-defined getters and proxies to run out of order, execute unnecessarily, or be skipped when a getter threw.

The existing `streams/piping/throwing-options.any.js` WPT covers the behavior, including rejected-promise delivery for `pipeTo()` and synchronous throwing for `pipeThrough()`. The patch removes its expected-failure baseline entry now that it passes.

Web IDL requires dictionary members to be ordered lexicographically by their identifiers: https://webidl.spec.whatwg.org/#idl-dictionaries

### Validation

- Pinned piping WPT: 11/12 before, 12/12 after
- Eight-case getter/error matrix: 2/8 before, 8/8 after
- Five repeated piping WPT runs: 5/5 passed
- All bundled Streams WPT: 50 passed, 3 existing failures; generated report matched the updated Streams baseline
- `env RUSTUP_TOOLCHAIN=1.95.0 make fix`
- `env RUSTUP_TOOLCHAIN=1.95.0 make check`
- `cargo +1.95.0 test -p llrt_stream_web` — 12 passed
- `cargo +1.95.0 fmt --all -- --check`
- Fork CI WPT job passes

### Checklist

- [x] Regression coverage is provided by the existing upstream WPT
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure the code adds no warnings with `make check`
- [x] Type changes are not required
- [x] Documentation changes are not required

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
