### PR TITLE
fix(stream): preserve TransformStream backpressure

### DIFF
--- a/modules/llrt_stream_web/src/transform/controller.rs
+++ b/modules/llrt_stream_web/src/transform/controller.rs
@@ -156,7 +156,7 @@ pub(super) fn transform_stream_default_controller_enqueue<'js>(
 
     let current_bp = stream_class.borrow().backpressure;
     if has_backpressure != current_bp {
-        transform_stream_set_backpressure(stream_class, true)?;
+        transform_stream_set_backpressure(&ctx, stream_class, true)?;
     }
 
     Ok(())
@@ -207,15 +207,19 @@ pub(super) fn transform_stream_error_writable_and_unblock_write<'js>(
 }
 
 pub(super) fn transform_stream_set_backpressure<'js>(
+    ctx: &Ctx<'js>,
     stream_class: &TransformStreamClass<'js>,
     backpressure: bool,
-) -> Result<()> {
+) -> Result<Promise<'js>> {
+    let new_bp_promise = ResolveablePromise::new(ctx)?;
+    let promise = new_bp_promise.promise.clone();
     let mut stream = stream_class.borrow_mut();
     if let Some(ref bp_promise) = stream.backpressure_change_promise {
         bp_promise.resolve_undefined()?;
     }
+    stream.backpressure_change_promise = Some(new_bp_promise);
     stream.backpressure = backpressure;
-    Ok(())
+    Ok(promise)
 }
 
 pub(super) fn transform_stream_default_controller_perform_transform<'js>(

--- a/modules/llrt_stream_web/src/transform/stream.rs
+++ b/modules/llrt_stream_web/src/transform/stream.rs
@@ -311,18 +311,7 @@ pub(crate) fn source_pull_algorithm<'js>(
     ctx: Ctx<'js>,
     stream_class: &TransformStreamClass<'js>,
 ) -> Result<Promise<'js>> {
-    let mut stream = stream_class.borrow_mut();
-
-    if let Some(ref old_bp) = stream.backpressure_change_promise {
-        old_bp.resolve_undefined()?;
-    }
-
-    let new_bp = ResolveablePromise::new(&ctx)?;
-    let return_promise = new_bp.promise.clone();
-    stream.backpressure_change_promise = Some(new_bp);
-    stream.backpressure = false;
-
-    Ok(return_promise)
+    controller::transform_stream_set_backpressure(&ctx, stream_class, false)
 }
 
 pub(crate) fn source_cancel_algorithm<'js>(

--- a/modules/llrt_stream_web/src/transform/tests.rs
+++ b/modules/llrt_stream_web/src/transform/tests.rs
@@ -117,6 +117,44 @@ async fn one_to_many_expansion() {
 }
 
 #[tokio::test]
+async fn readable_high_water_mark_applies_backpressure() {
+    test_async_with(|ctx| {
+        crate::init(&ctx).unwrap();
+        Box::pin(async move {
+            ctx.eval::<(), _>(
+                r#"
+                globalThis.transformed = [];
+                globalThis.ts = new TransformStream({
+                    transform(chunk, controller) {
+                        transformed.push(chunk);
+                        controller.enqueue(chunk);
+                    }
+                }, undefined, { highWaterMark: 3 });
+                globalThis.writer = ts.writable.getWriter();
+                [0, 1, 2, 3].forEach(chunk => writer.write(chunk));
+            "#,
+            )
+            .unwrap();
+
+            while ctx.execute_pending_job() {}
+            assert_eq!(
+                ctx.eval::<String, _>("transformed.join(',')").unwrap(),
+                "0,1,2"
+            );
+
+            ctx.eval::<(), _>("globalThis.reader = ts.readable.getReader(); reader.read();")
+                .unwrap();
+            while ctx.execute_pending_job() {}
+            assert_eq!(
+                ctx.eval::<String, _>("transformed.join(',')").unwrap(),
+                "0,1,2,3"
+            );
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn flush_on_close() {
     test_async_with(|ctx| {
         crate::init(&ctx).unwrap();


### PR DESCRIPTION
### Issue # (if available)

No issue filed. This focused conformance bug was identified through the committed TransformStream WPT failure baseline.

### Description of changes

Preserve `TransformStream` backpressure when the readable queue reaches its high water mark. Before this change, one additional queued write could transform before the readable side was consumed.

The controller resolved its existing backpressure-change promise when pressure became active but kept that settled promise installed. The next queued write therefore waited on an already-fulfilled promise and transformed immediately, overfilling the readable queue.

This change follows the Streams Standard's `TransformStreamSetBackpressure` operation by resolving the previous promise, installing a fresh pending promise, and then updating the backpressure state. Readable-side pull transitions now use the same shared operation.

Streams Standard: https://streams.spec.whatwg.org/#transform-stream-set-backpressure

### Validation

- Added `readable_high_water_mark_applies_backpressure`; it fails before the fix with `0,1,2,3` transformed and passes after the fix with only `0,1,2` transformed until a read occurs
- `env RUSTUP_TOOLCHAIN=1.95.0 make fix`
- `env RUSTUP_TOOLCHAIN=1.95.0 make check`
- `cargo +1.95.0 test -p llrt_stream_web` — 13 passed
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +nightly build`
- Runtime reproduction matches Node 22: nine chunks transform at readable HWM 9, and the tenth resumes after one read
- Fork CI: all 32 jobs pass, including WPT and the complete platform/crypto matrix

### Scope notes

- Does not address strategy value conversion
- Does not address the separate `controller.terminate()` error-propagation panic

### Checklist

- [x] Added a focused Rust regression test
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure the code adds no warnings with `make check`
- [x] Type changes are not required
- [x] Documentation changes are not required

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
