### PR TITLE
fix(crypto): allow RSA JWK imports without alg

### DIFF
--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -1061,34 +1061,23 @@ fn import_rsa_key<'js>(
     let (modulus_length, public_exponent) = match format {
         KeyFormatData::Jwk(object) => {
             let kty: String = object.get_required("kty", "keyData")?;
-            let alg: String = object.get_required("alg", "keyData")?;
             if kty != "RSA" {
                 return algorithm_mismatch_error(ctx, algorithm_name);
             }
-            let prefix = &alg[..2];
-            let numeric_hash_str = match prefix {
-                "RS" => {
-                    if algorithm_name == "RSA-OAEP" {
-                        if !alg.starts_with(algorithm_name) {
-                            return algorithm_mismatch_error(ctx, algorithm_name);
-                        }
-                        &alg["RSA-OAEP-".len()..]
-                    } else if algorithm_name != "RSASSA-PKCS1-v1_5" {
-                        return algorithm_mismatch_error(ctx, algorithm_name);
-                    } else {
-                        &alg["RS".len()..]
-                    }
-                },
-                "PS" => {
-                    if algorithm_name != "RSA-PSS" {
-                        return algorithm_mismatch_error(ctx, algorithm_name);
-                    }
-                    &alg["PS".len()..]
-                },
-                _ => return algorithm_mismatch_error(ctx, algorithm_name),
-            };
-            if numeric_hash_str != hash.as_numeric_str() {
-                return hash_mismatch_error(ctx, hash);
+
+            if let Some(alg) = object.get_optional::<_, String>("alg")? {
+                let numeric_hash_str = match algorithm_name {
+                    "RSASSA-PKCS1-v1_5" => alg.strip_prefix("RS"),
+                    "RSA-PSS" => alg.strip_prefix("PS"),
+                    "RSA-OAEP" => alg.strip_prefix("RSA-OAEP-"),
+                    _ => None,
+                };
+                let Some(numeric_hash_str) = numeric_hash_str else {
+                    return algorithm_mismatch_error(ctx, algorithm_name);
+                };
+                if numeric_hash_str != hash.as_numeric_str() {
+                    return hash_mismatch_error(ctx, hash);
+                }
             }
 
             let n: String = object.get_required("n", "keyData")?;

--- a/tests/unit/crypto.subtle.test.ts
+++ b/tests/unit/crypto.subtle.test.ts
@@ -793,6 +793,62 @@ fullCrypto("SubtleCrypto deriveBits/deriveKey", () => {
 });
 
 fullCrypto("SubtileCrypto import/export", () => {
+  it("should import an RSA public JWK without alg", async () => {
+    const algorithm = {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 1024,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    };
+    const keyPair = (await crypto.subtle.generateKey(algorithm, true, [
+      "sign",
+      "verify",
+    ])) as webcrypto.CryptoKeyPair;
+    const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+    delete publicJwk.alg;
+    const jwksPublicKey = {
+      ...publicJwk,
+      kid: "cognito-jwks-key-id",
+      use: "sig",
+    };
+
+    const imported = await crypto.subtle.importKey(
+      "jwk",
+      jwksPublicKey,
+      algorithm,
+      true,
+      ["verify"]
+    );
+    const signature = await crypto.subtle.sign(
+      algorithm,
+      keyPair.privateKey,
+      ENCODED_DATA
+    );
+
+    expect(
+      await crypto.subtle.verify(algorithm, imported, signature, ENCODED_DATA)
+    ).toEqual(true);
+
+    await expect(
+      crypto.subtle.importKey(
+        "jwk",
+        { ...jwksPublicKey, alg: "PS256" },
+        algorithm,
+        true,
+        ["verify"]
+      )
+    ).rejects.toThrow();
+    await expect(
+      crypto.subtle.importKey(
+        "jwk",
+        { ...jwksPublicKey, alg: "RS384" },
+        algorithm,
+        true,
+        ["verify"]
+      )
+    ).rejects.toThrow();
+  });
+
   it("should export and import keys", async () => {
     // Test different key algorithms and formats
     // Define reusable constants

--- a/tests/wpt/WebCryptoAPI.import_export.test.ts
+++ b/tests/wpt/WebCryptoAPI.import_export.test.ts
@@ -1,0 +1,6 @@
+import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
+
+runSuite(import.meta.url, runTestDynamic, [
+  // Enable the remaining import/export WPTs separately as support lands.
+  /^(?!rsa_importKey\.https\.any\.js$)/,
+]);


### PR DESCRIPTION
## Summary

- Allow WebCrypto RSA JWK imports when the optional `alg` member is absent.
- Restore compatibility with OIDC/Cognito-style JWKS verification, including the failure reported in panva/jose#802.
- Related to awslabs/llrt#968.

## What Changed

- Treat RSA JWK `alg` as optional during import.
- Preserve strict algorithm-family and hash validation whenever `alg` is present.
- Add a Cognito/JWKS-shaped RSA public-key regression that verifies a real signature and rejects mismatched `PS256` and `RS384` values.
- Enable the upstream WebCrypto `rsa_importKey.https.any.js` WPT.

## Root Cause

RSA JWK import required `keyData.alg` before decoding the key, although WebCrypto specifies that the member may be absent. This caused standards-compliant public JWKS keys to fail with `TypeError: keyData 'alg' property required`.

## Validation

- `cargo fmt --check`
- `cargo +nightly clippy -p llrt_crypto --all-targets --no-deps -- -D warnings`
- `cargo test -p llrt_crypto` — 23 passed
- Focused `crypto.subtle` runtime suite — 16 passed
- Upstream `rsa_importKey.https.any.js` WPT — 1 wrapper passed
- panva/jose compatibility bundle — 185 passed; the local JWKS and RSA JWK import paths pass, with 36 unrelated compatibility failures remaining

## Scope Notes

- String AlgorithmIdentifier support for parameterless AES-KW and RSA-OAEP operations remains a separate follow-up.
- Ed25519/X25519 compatibility is intentionally out of scope.
- No dependency, provider, type, documentation, lockfile, or generated-file changes are included.

## Checklist

- [x] Created unit and WPT regression coverage
- [x] Verified formatting and module-scoped Clippy checks
- [x] Confirmed no type or documentation update is required for this behavior fix
