### PR TITLE
fix(crypto): support string encryption algorithm identifiers

### DIFF
--- a/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
@@ -33,8 +33,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
 
         match name.as_str() {
             "AES-CBC" => {
-                let obj =
-                    obj.map_err(|_| Exception::throw_type(ctx, "algorithm is not an object"))?;
+                let obj = obj?;
                 let iv = obj
                     .get_required::<_, ObjectBytes>("iv", "algorithm")?
                     .into_bytes(ctx)?
@@ -50,8 +49,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 Ok(EncryptionAlgorithm::AesCbc { iv })
             },
             "AES-CTR" => {
-                let obj =
-                    obj.map_err(|_| Exception::throw_type(ctx, "algorithm is not an object"))?;
+                let obj = obj?;
                 let counter = obj
                     .get_required::<_, ObjectBytes>("counter", "algorithm")?
                     .into_bytes(ctx)?
@@ -69,8 +67,7 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 Ok(EncryptionAlgorithm::AesCtr { counter, length })
             },
             "AES-GCM" => {
-                let obj =
-                    obj.map_err(|_| Exception::throw_type(ctx, "algorithm is not an object"))?;
+                let obj = obj?;
                 let iv = obj
                     .get_required::<_, ObjectBytes>("iv", "algorithm")?
                     .into_bytes(ctx)?

--- a/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
@@ -4,7 +4,7 @@ use llrt_exceptions::DOMException;
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt};
 use rquickjs::{Ctx, Exception, FromJs, Result, Value};
 
-use super::algorithm_not_supported_error;
+use super::{algorithm_not_supported_error, normalize_algorithm_name, to_name_and_maybe_object};
 
 #[derive(Debug)]
 pub enum EncryptionAlgorithm {
@@ -28,12 +28,13 @@ pub enum EncryptionAlgorithm {
 
 impl<'js> FromJs<'js> for EncryptionAlgorithm {
     fn from_js(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
-        let obj = value.into_object_or_throw(ctx, "algorithm")?;
-
-        let name: String = obj.get_required("name", "algorithm")?;
+        let (name, obj) = to_name_and_maybe_object(ctx, value)?;
+        let name = normalize_algorithm_name(&name);
 
         match name.as_str() {
             "AES-CBC" => {
+                let obj =
+                    obj.map_err(|_| Exception::throw_type(ctx, "algorithm is not an object"))?;
                 let iv = obj
                     .get_required::<_, ObjectBytes>("iv", "algorithm")?
                     .into_bytes(ctx)?
@@ -49,6 +50,8 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 Ok(EncryptionAlgorithm::AesCbc { iv })
             },
             "AES-CTR" => {
+                let obj =
+                    obj.map_err(|_| Exception::throw_type(ctx, "algorithm is not an object"))?;
                 let counter = obj
                     .get_required::<_, ObjectBytes>("counter", "algorithm")?
                     .into_bytes(ctx)?
@@ -66,6 +69,8 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 Ok(EncryptionAlgorithm::AesCtr { counter, length })
             },
             "AES-GCM" => {
+                let obj =
+                    obj.map_err(|_| Exception::throw_type(ctx, "algorithm is not an object"))?;
                 let iv = obj
                     .get_required::<_, ObjectBytes>("iv", "algorithm")?
                     .into_bytes(ctx)?
@@ -99,11 +104,14 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                 })
             },
             "RSA-OAEP" => {
-                let label = obj
-                    .get_optional::<_, ObjectBytes>("label")?
-                    .map(|bytes| bytes.into_bytes(ctx))
-                    .transpose()?
-                    .map(|vec| vec.into_boxed_slice());
+                let label = if let Ok(obj) = obj {
+                    obj.get_optional::<_, ObjectBytes>("label")?
+                        .map(|bytes| bytes.into_bytes(ctx))
+                        .transpose()?
+                        .map(|vec| vec.into_boxed_slice())
+                } else {
+                    None
+                };
 
                 Ok(EncryptionAlgorithm::RsaOaep { label })
             },

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -440,7 +440,7 @@ fn from_x25519<'js>(
 fn from_aes<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
-    obj: std::result::Result<Object<'js>, &str>,
+    obj: Result<Object<'js>>,
     algorithm_name: &str,
     usages: &Array<'js>,
     private_usages: &mut Vec<String>,
@@ -451,7 +451,7 @@ fn from_aes<'js>(
     fn import<'js>(
         ctx: &Ctx<'js>,
         mode: KeyAlgorithmMode<'_, 'js>,
-        obj: std::result::Result<Object<'js>, &str>,
+        obj: Result<Object<'js>>,
         algorithm_name: &str,
     ) -> Result<(u16, Option<KeyKind>)> {
         if let KeyAlgorithmMode::Import { data, format, kind } = mode {
@@ -459,7 +459,7 @@ fn from_aes<'js>(
                 import_symmetric_key(ctx, format, kind, data, algorithm_name, None)? as u16;
             Ok((length, Some(*kind)))
         } else {
-            let length: u16 = obj.or_throw(ctx)?.get_required("length", "algorithm")?;
+            let length: u16 = obj?.get_required("length", "algorithm")?;
             Ok((length, None))
         }
     }
@@ -467,12 +467,12 @@ fn from_aes<'js>(
     #[cfg(not(feature = "_subtle-full"))]
     #[inline]
     fn import<'js>(
-        ctx: &Ctx<'js>,
+        _ctx: &Ctx<'js>,
         _mode: KeyAlgorithmMode<'_, 'js>,
-        obj: std::result::Result<Object<'js>, &str>,
+        obj: Result<Object<'js>>,
         _algorithm_name: &str,
     ) -> Result<(u16, Option<KeyKind>)> {
-        let length: u16 = obj.or_throw(ctx)?.get_required("length", "algorithm")?;
+        let length: u16 = obj?.get_required("length", "algorithm")?;
         Ok((length, None))
     }
 
@@ -515,13 +515,13 @@ fn from_aes<'js>(
 fn from_hmac<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
-    obj: std::result::Result<Object<'js>, &str>,
+    obj: Result<Object<'js>>,
     algorithm_name: &str,
     usages: &Array<'js>,
     private_usages: &mut Vec<String>,
     public_usages: &mut Vec<String>,
 ) -> Result<KeyAlgorithm> {
-    let obj = obj.or_throw(ctx)?;
+    let obj = obj?;
     let hash = extract_sha_hash(ctx, &obj)?;
     if !matches!(
         hash,
@@ -586,13 +586,13 @@ fn from_hmac<'js>(
 fn from_rsa<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
-    obj: std::result::Result<Object<'js>, &str>,
+    obj: Result<Object<'js>>,
     algorithm_name: &str,
     usages: &Array<'js>,
     private_usages: &mut Vec<String>,
     public_usages: &mut Vec<String>,
 ) -> Result<KeyAlgorithm> {
-    let obj = obj.or_throw(ctx)?;
+    let obj = obj?;
     let hash = extract_sha_hash(ctx, &obj)?;
     let is_generate = mode == KeyAlgorithmMode::Generate;
 
@@ -674,7 +674,7 @@ fn from_rsa<'js>(
 fn from_hkdf<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
-    obj: std::result::Result<Object<'js>, &str>,
+    obj: Result<Object<'js>>,
     algorithm_name: &str,
     usages: &Array<'js>,
     private_usages: &mut Vec<String>,
@@ -685,7 +685,7 @@ fn from_hkdf<'js>(
     fn import<'js>(
         ctx: &Ctx<'js>,
         mode: KeyAlgorithmMode<'_, 'js>,
-        obj: std::result::Result<Object<'js>, &str>,
+        obj: Result<Object<'js>>,
         algorithm_name: &str,
     ) -> Result<(KeyAlgorithm, Option<KeyKind>)> {
         match mode {
@@ -694,7 +694,7 @@ fn from_hkdf<'js>(
                 Ok((KeyAlgorithm::HkdfImport, Some(*kind)))
             },
             KeyAlgorithmMode::Derive => {
-                let obj = obj.or_throw(ctx)?;
+                let obj = obj?;
                 Ok((
                     KeyAlgorithm::Derive(KeyDerivation::for_hkdf_object(ctx, obj)?),
                     None,
@@ -709,12 +709,12 @@ fn from_hkdf<'js>(
     fn import<'js>(
         ctx: &Ctx<'js>,
         mode: KeyAlgorithmMode<'_, 'js>,
-        obj: std::result::Result<Object<'js>, &str>,
+        obj: Result<Object<'js>>,
         _algorithm_name: &str,
     ) -> Result<(KeyAlgorithm, Option<KeyKind>)> {
         match mode {
             KeyAlgorithmMode::Derive => {
-                let obj = obj.or_throw(ctx)?;
+                let obj = obj?;
                 Ok((
                     KeyAlgorithm::Derive(KeyDerivation::for_hkdf_object(ctx, obj)?),
                     None,
@@ -741,7 +741,7 @@ fn from_hkdf<'js>(
 fn from_pbkdf2<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
-    obj: std::result::Result<Object<'js>, &str>,
+    obj: Result<Object<'js>>,
     algorithm_name: &str,
     usages: &Array<'js>,
     private_usages: &mut Vec<String>,
@@ -752,7 +752,7 @@ fn from_pbkdf2<'js>(
     fn import<'js>(
         ctx: &Ctx<'js>,
         mode: KeyAlgorithmMode<'_, 'js>,
-        obj: std::result::Result<Object<'js>, &str>,
+        obj: Result<Object<'js>>,
         algorithm_name: &str,
     ) -> Result<(KeyAlgorithm, Option<KeyKind>)> {
         match mode {
@@ -761,7 +761,7 @@ fn from_pbkdf2<'js>(
                 Ok((KeyAlgorithm::Pbkdf2Import, Some(*kind)))
             },
             KeyAlgorithmMode::Derive => {
-                let obj = obj.or_throw(ctx)?;
+                let obj = obj?;
                 Ok((
                     KeyAlgorithm::Derive(KeyDerivation::for_pbkf2_object(&ctx, obj)?),
                     None,
@@ -776,12 +776,12 @@ fn from_pbkdf2<'js>(
     fn import<'js>(
         ctx: &Ctx<'js>,
         mode: KeyAlgorithmMode<'_, 'js>,
-        obj: std::result::Result<Object<'js>, &str>,
+        obj: Result<Object<'js>>,
         _algorithm_name: &str,
     ) -> Result<(KeyAlgorithm, Option<KeyKind>)> {
         match mode {
             KeyAlgorithmMode::Derive => {
-                let obj = obj.or_throw(ctx)?;
+                let obj = obj?;
                 Ok((
                     KeyAlgorithm::Derive(KeyDerivation::for_pbkf2_object(&ctx, obj)?),
                     None,
@@ -979,7 +979,7 @@ impl KeyAlgorithm {
     fn from_ec<'js>(
         ctx: &Ctx<'js>,
         #[allow(unused_variables)] mode: KeyAlgorithmMode<'_, 'js>,
-        obj: std::result::Result<Object<'js>, &str>,
+        obj: Result<Object<'js>>,
         #[allow(unused_variables)] algorithm_name: &str,
         algorithm: EcAlgorithm,
         key_usages: &Array<'js>,
@@ -987,7 +987,7 @@ impl KeyAlgorithm {
         public_usages: &mut Vec<String>,
         key_usage_algorithm: KeyUsageAlgorithm,
     ) -> Result<KeyAlgorithm> {
-        let obj = obj.or_throw(ctx)?;
+        let obj = obj?;
         let curve_name: String = obj.get_required("namedCurve", "algorithm")?;
         let curve = EllipticCurve::try_from(curve_name.as_str())
             .map_err(NotSupportedError)

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -49,7 +49,7 @@ use key_algorithm::KeyAlgorithm;
 
 use llrt_exceptions::DOMException;
 use llrt_utils::{object::ObjectExt, str_enum};
-use rquickjs::{atom::PredefinedAtom, Ctx, Exception, Object, Result, Value};
+use rquickjs::{atom::PredefinedAtom, Ctx, Error, Exception, Object, Result, Value};
 
 use crate::provider::{CryptoProvider, SimpleDigest};
 
@@ -114,13 +114,17 @@ pub fn rsa_hash_digest<'a>(
     Ok((hash, digest))
 }
 
-pub fn to_name_and_maybe_object<'js, 'a>(
+pub fn to_name_and_maybe_object<'js>(
     ctx: &Ctx<'js>,
     value: Value<'js>,
-) -> Result<(String, std::result::Result<Object<'js>, &'a str>)> {
+) -> Result<(String, Result<Object<'js>>)> {
     let obj;
     let name = if let Some(string) = value.as_string() {
-        obj = Err("Not an object");
+        obj = Err(Error::new_from_js_message(
+            "string",
+            "object",
+            "algorithm is not an object",
+        ));
         string.to_string()?
     } else if let Some(object) = value.into_object() {
         let name = object.get_required("name", "algorithm")?;

--- a/modules/llrt_crypto/src/subtle/sign_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/sign_algorithm.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use llrt_utils::{object::ObjectExt, result::ResultExt};
+use llrt_utils::object::ObjectExt;
 use rquickjs::{Ctx, FromJs, Result, Value};
 
 use crate::hash::HashAlgorithm;
@@ -27,12 +27,12 @@ impl<'js> FromJs<'js> for SigningAlgorithm {
             "HMAC" => SigningAlgorithm::Hmac,
             "RSASSA-PKCS1-v1_5" => SigningAlgorithm::RsassaPkcs1v15,
             "ECDSA" => {
-                let obj = obj.or_throw(ctx)?;
+                let obj = obj?;
                 let hash = extract_sha_hash(ctx, &obj)?;
                 SigningAlgorithm::Ecdsa { hash }
             },
             "RSA-PSS" => {
-                let salt_length = obj.or_throw(ctx)?.get_required("saltLength", "algorithm")?;
+                let salt_length = obj?.get_required("saltLength", "algorithm")?;
 
                 SigningAlgorithm::RsaPss { salt_length }
             },

--- a/tests/unit/crypto.subtle.test.ts
+++ b/tests/unit/crypto.subtle.test.ts
@@ -556,6 +556,40 @@ fullCrypto("SubtleCrypto string AlgorithmIdentifier", () => {
     expect(DECODER.decode(decrypted)).toEqual(TEST_MESSAGE);
   });
 
+  it("should preserve a non-empty RSA-OAEP label from an object", async () => {
+    const { privateKey, publicKey } = (await crypto.subtle.generateKey(
+      {
+        name: "RSA-OAEP",
+        modulusLength: 1024,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      false,
+      ["encrypt", "decrypt"]
+    )) as webcrypto.CryptoKeyPair;
+    const label = ENCODER.encode("LLRT RSA-OAEP label");
+    const encrypted = await crypto.subtle.encrypt(
+      { name: "RSA-OAEP", label },
+      publicKey,
+      ENCODED_DATA
+    );
+
+    await expect(
+      crypto.subtle.decrypt(
+        { name: "RSA-OAEP", label: ENCODER.encode("wrong label") },
+        privateKey,
+        encrypted
+      )
+    ).rejects.toThrow();
+
+    const decrypted = await crypto.subtle.decrypt(
+      { name: "RSA-OAEP", label },
+      privateKey,
+      encrypted
+    );
+    expect(DECODER.decode(decrypted)).toEqual(TEST_MESSAGE);
+  });
+
   it("should still require parameter dictionaries for AES encryption and decryption", async () => {
     for (const name of ["AES-CBC", "AES-CTR", "AES-GCM"]) {
       const key = await crypto.subtle.generateKey(

--- a/tests/unit/crypto.subtle.test.ts
+++ b/tests/unit/crypto.subtle.test.ts
@@ -494,6 +494,86 @@ fullCrypto("SubtleCrypto generateKey/encrypt/decrypt", () => {
   }, 60000);
 });
 
+fullCrypto("SubtleCrypto string AlgorithmIdentifier", () => {
+  it("should wrap and unwrap with a case-insensitive AES-KW string", async () => {
+    const wrappingKey = await crypto.subtle.generateKey(
+      { name: "AES-KW", length: 128 },
+      false,
+      ["wrapKey", "unwrapKey"]
+    );
+    const originalKey = await crypto.subtle.generateKey(
+      { name: "AES-GCM", length: 128 },
+      true,
+      ["encrypt", "decrypt"]
+    );
+
+    const wrappedKey = await crypto.subtle.wrapKey(
+      "raw",
+      originalKey,
+      wrappingKey,
+      "aes-kw"
+    );
+    const unwrappedKey = await crypto.subtle.unwrapKey(
+      "raw",
+      wrappedKey,
+      wrappingKey,
+      "AeS-kW",
+      { name: "AES-GCM", length: 128 },
+      true,
+      ["encrypt", "decrypt"]
+    );
+
+    expect(
+      new Uint8Array(await crypto.subtle.exportKey("raw", unwrappedKey))
+    ).toEqual(
+      new Uint8Array(await crypto.subtle.exportKey("raw", originalKey))
+    );
+  });
+
+  it("should encrypt and decrypt with a case-insensitive RSA-OAEP string", async () => {
+    const { privateKey, publicKey } = (await crypto.subtle.generateKey(
+      {
+        name: "RSA-OAEP",
+        modulusLength: 1024,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      false,
+      ["encrypt", "decrypt"]
+    )) as webcrypto.CryptoKeyPair;
+
+    const encrypted = await crypto.subtle.encrypt(
+      "rsa-oaep",
+      publicKey,
+      ENCODED_DATA
+    );
+    const decrypted = await crypto.subtle.decrypt(
+      "RsA-OaEp",
+      privateKey,
+      encrypted
+    );
+
+    expect(DECODER.decode(decrypted)).toEqual(TEST_MESSAGE);
+  });
+
+  it("should still require parameter dictionaries for AES encryption and decryption", async () => {
+    for (const name of ["AES-CBC", "AES-CTR", "AES-GCM"]) {
+      const key = await crypto.subtle.generateKey(
+        { name, length: 128 },
+        false,
+        ["encrypt", "decrypt"]
+      );
+
+      await expect(
+        crypto.subtle.encrypt(name, key, ENCODED_DATA)
+      ).rejects.toThrow(TypeError);
+      await expect(
+        crypto.subtle.decrypt(name, key, ENCODED_DATA)
+      ).rejects.toThrow(TypeError);
+    }
+  });
+});
+
 fullCrypto("SubtleCrypto deriveBits/deriveKey", () => {
   it("should be processing ECDH algorithm", async () => {
     const keyLengths = [128, 192, 256];


### PR DESCRIPTION
### Issue # (if available)

Related to #968.

### Description of changes

Accept case-insensitive DOMString algorithm identifiers for parameterless AES-KW wrap/unwrap and RSA-OAEP encrypt/decrypt operations.

WebCrypto `AlgorithmIdentifier` accepts either a DOMString or an algorithm dictionary. The encryption parser previously required an object unconditionally, so valid string identifiers failed before AES-KW or RSA-OAEP could be selected. The parser now reuses the existing algorithm-name normalization path and permits omitted parameter objects only for those operations.

AES-CBC, AES-CTR, and AES-GCM continue to reject string-only inputs with `TypeError` because their required parameter dictionaries are absent. Object-based RSA-OAEP labels are also covered to ensure the parser change preserves non-empty label handling.

Relevant standard:

- [Web Cryptography Level 2 — algorithm normalization](https://www.w3.org/TR/webcrypto-2/#algorithm-normalization)

Validation:

- `cargo test -p llrt_crypto` — 23 passed
- focused LLRT `crypto.subtle` runtime suite — 20 passed
- `cargo clippy -p llrt_crypto --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Prettier check for `tests/unit/crypto.subtle.test.ts`
- `git diff --check`
- complete fork CI matrix passed, including the successful rerun of a transient Homebrew setup failure

### Checklist

- [x] Created focused unit coverage for AES-KW, RSA-OAEP, required AES dictionaries, and RSA-OAEP labels
- [x] Ran targeted Rust and TypeScript formatting checks
- [x] Made sure the code adds no warnings with warning-denied Clippy and the CI `check` job
- [x] Confirmed type changes are not applicable
- [x] Confirmed documentation changes are not required

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
