### PR TITLE
fix(crypto): validate JWK extractability

### DIFF
--- a/modules/llrt_crypto/src/subtle/import_key.rs
+++ b/modules/llrt_crypto/src/subtle/import_key.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use llrt_exceptions::DOMException;
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt};
 use rquickjs::{Array, Class, Ctx, FromJs, Result, Value};
 
@@ -35,6 +36,14 @@ pub fn import_key<'js>(
     extractable: bool,
     key_usages: Array<'js>,
 ) -> Result<Class<'js, CryptoKey<'js>>> {
+    if extractable {
+        if let KeyFormatData::Jwk(jwk) = &format {
+            if matches!(jwk.get_optional::<_, bool>("ext")?, Some(false)) {
+                return Err(DOMException::data_error(&ctx, "JWK is not extractable"));
+            }
+        }
+    }
+
     let mut kind = KeyKind::Public;
     let mut data = Vec::new();
 

--- a/tests/unit/crypto.subtle.test.ts
+++ b/tests/unit/crypto.subtle.test.ts
@@ -793,6 +793,28 @@ fullCrypto("SubtleCrypto deriveBits/deriveKey", () => {
 });
 
 fullCrypto("SubtileCrypto import/export", () => {
+  it("rejects importing a non-extractable JWK as extractable", async () => {
+    const jwk = {
+      kty: "oct",
+      k: "AAECAwQFBgcICQoLDA0ODw",
+      alg: "A128GCM",
+      ext: false,
+      key_ops: ["encrypt"],
+    };
+
+    try {
+      await crypto.subtle.importKey("jwk", jwk, "AES-GCM", true, ["encrypt"]);
+      throw new Error("importKey unexpectedly succeeded");
+    } catch (error) {
+      expect((error as Error).name).toBe("DataError");
+    }
+
+    const key = await crypto.subtle.importKey("jwk", jwk, "AES-GCM", false, [
+      "encrypt",
+    ]);
+    expect(key.extractable).toBe(false);
+  });
+
   it("should import an RSA public JWK without alg", async () => {
     const algorithm = {
       name: "RSASSA-PKCS1-v1_5",
@@ -970,6 +992,57 @@ fullCrypto("SubtileCrypto import/export", () => {
 });
 
 fullCrypto("SubtileCrypto wrap/unwrap", () => {
+  it("rejects unwrapping a non-extractable JWK as extractable", async () => {
+    const wrappingAlgorithm = {
+      name: "AES-CBC",
+      length: 128,
+      iv: new Uint8Array(16),
+    };
+    const wrappingKey = await crypto.subtle.generateKey(
+      wrappingAlgorithm,
+      false,
+      ["encrypt", "unwrapKey"]
+    );
+    const jwk = {
+      kty: "oct",
+      k: "AAECAwQFBgcICQoLDA0ODw",
+      alg: "A128GCM",
+      ext: false,
+      key_ops: ["encrypt"],
+    };
+    const wrappedKey = await crypto.subtle.encrypt(
+      wrappingAlgorithm,
+      wrappingKey,
+      ENCODER.encode(JSON.stringify(jwk))
+    );
+
+    try {
+      await crypto.subtle.unwrapKey(
+        "jwk",
+        wrappedKey,
+        wrappingKey,
+        wrappingAlgorithm,
+        "AES-GCM",
+        true,
+        ["encrypt"]
+      );
+      throw new Error("unwrapKey unexpectedly succeeded");
+    } catch (error) {
+      expect((error as Error).name).toBe("DataError");
+    }
+
+    const key = await crypto.subtle.unwrapKey(
+      "jwk",
+      wrappedKey,
+      wrappingKey,
+      wrappingAlgorithm,
+      "AES-GCM",
+      false,
+      ["encrypt"]
+    );
+    expect(key.extractable).toBe(false);
+  });
+
   it("should wrap and unwrap keys for all supported algorithms", async () => {
     // Test parameters
     const HASH_ALGORITHMS = ["SHA-1", "SHA-256", "SHA-384", "SHA-512"];


### PR DESCRIPTION
### Issue # (if available)

Related to #968.

### Description of changes

Reject JWK imports when `ext` is `false` but the caller requests an extractable key.

The shared JWK import path previously did not enforce this WebCrypto constraint, allowing `importKey()` or `unwrapKey()` to create an extractable key from material explicitly marked non-extractable. The shared path now rejects that contradiction with a `DataError` for both operations while preserving successful import and unwrap when `extractable` is `false`.

This change is intentionally limited to the `ext`/`extractable` contradiction; validation of `alg`, `key_ops`, `use`, and other JWK metadata remains out of scope.

Relevant standards:

- [Web Cryptography Level 2 — `SubtleCrypto.importKey()`](https://www.w3.org/TR/webcrypto-2/#SubtleCrypto-method-importKey)
- [Web Cryptography Level 2 — algorithm-specific JWK import requirements](https://www.w3.org/TR/webcrypto-2/#aes-gcm-operations-import-key)

Validation:

- `cargo test -p llrt_crypto --all-targets` — 23 passed
- focused LLRT `crypto.subtle` runtime suite — 18 passed
- `cargo clippy -p llrt_crypto --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Prettier check for `tests/unit/crypto.subtle.test.ts`
- `git diff --check`
- complete fork CI matrix passed

### Checklist

- [x] Created focused unit coverage for direct import and unwrap behavior
- [x] Ran targeted Rust and TypeScript formatting checks
- [x] Made sure the code adds no warnings with warning-denied Clippy and the CI `check` job
- [x] Confirmed type changes are not applicable
- [x] Confirmed documentation changes are not required

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
