### PR TITLE
fix: use byte_length for ReadableByteStream queueTotalSize

### DIFF
--- a/modules/llrt_stream_web/src/readable/byte_controller.rs
+++ b/modules/llrt_stream_web/src/readable/byte_controller.rs
@@ -805,7 +805,6 @@ impl<'js> ReadableByteStreamController<'js> {
         byte_offset: usize,
         byte_length: usize,
     ) {
-        let len = buffer.len();
         // Append a new readable byte stream queue entry with buffer buffer, byte offset byteOffset, and byte length byteLength to controller.[[queue]].
         self.queue.push_back(ReadableByteStreamQueueEntry {
             buffer,
@@ -814,7 +813,7 @@ impl<'js> ReadableByteStreamController<'js> {
         });
 
         // Set controller.[[queueTotalSize]] to controller.[[queueTotalSize]] + byteLength.
-        self.queue_total_size += len;
+        self.queue_total_size += byte_length;
     }
 
     fn readable_byte_stream_controller_process_pull_into_descriptors_using_queue<


### PR DESCRIPTION
### Issue # (if available)

Fixes #1719

### Description of changes

Use the enqueued view's byte_length instead of the full backing buffer length when updating queueTotalSize, fixing a panic when reading streams with subarray views.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._