### PR TITLE
fix(crypto): Allow `Uint8Array` for `wrappedKey` in `crypto.unwrapKey`

### DIFF
--- a/modules/llrt_crypto/src/subtle/wrapping.rs
+++ b/modules/llrt_crypto/src/subtle/wrapping.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use llrt_json::{parse::json_parse, stringify::json_stringify};
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
-use rquickjs::{Array, ArrayBuffer, Class, Ctx, Exception, Result, Value};
+use rquickjs::{Array, ArrayBuffer, Class, Ctx, Result, Value};
 
 use super::{
     crypto_key::CryptoKey,
@@ -51,7 +51,7 @@ pub async fn subtle_wrap_key<'js>(
 //cant take more than 7 args
 pub async fn subtle_unwrap_key<'js>(
     format: KeyFormat,
-    wrapped_key: ArrayBuffer<'js>,
+    wrapped_key: Value<'js>,
     unwrapping_key: Class<'js, CryptoKey<'js>>,
     unwrap_algo: EncryptionAlgorithm,
     unwrapped_key_algo: Value<'js>,
@@ -62,9 +62,8 @@ pub async fn subtle_unwrap_key<'js>(
     let ctx = wrapped_key.ctx().clone();
     unwrapping_key.check_validity("unwrapKey").or_throw(&ctx)?;
 
-    let bytes = wrapped_key
-        .as_bytes()
-        .ok_or_else(|| Exception::throw_message(&ctx, "ArrayBuffer is detached"))?;
+    let bytes = ObjectBytes::from(&ctx, &wrapped_key)?;
+    let bytes = bytes.as_bytes(&ctx)?;
 
     let padding = match format {
         KeyFormat::Jwk => b' ',


### PR DESCRIPTION
### Issue # (if available)

Related #968 

### Description of changes

The summary of the results from running `tap` for `panva/jose` at the current commit (7037af8) is as follows:

```
# pass 194
# skip 0
# todo 0
# fail 27
```

The majority of failures are caused by the following identical error.
```
  message: "Promise rejected during \"A128KW\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"A128KW JWT\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"A192KW\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"A192KW JWT\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"A256KW\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"A256KW JWT\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"https://www.rfc-editor.org/info/rfc7520/#section-5.3 - Key Wrap using PBES2-AES-KeyWrap with AES-CBC-HMAC-SHA2\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"https://www.rfc-editor.org/info/rfc7520/#section-5.4 - Key Agreement with Key Wrapping using ECDH-ES and AES-KeyWrap with AES-GCM\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"https://www.rfc-editor.org/info/rfc7520/#section-5.8 - Key Wrap using AES-KeyWrap with AES-GCM\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"https://www.rfc-editor.org/info/rfc7520/#section-5.10 - Including Additional Authenticated Data\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"https://www.rfc-editor.org/info/rfc7520/#section-5.11 - Protecting Specific Header Fields\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"https://www.rfc-editor.org/info/rfc7520/#section-5.12 - Protecting Content Only\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"PBES2-HS256+A128KW\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"PBES2-HS256+A128KW JWT\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"PBES2-HS384+A192KW\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"PBES2-HS384+A192KW JWT\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"PBES2-HS512+A256KW\": Error converting from js 'object' into type 'ArrayBuffer'"
  message: "Promise rejected during \"PBES2-HS512+A256KW JWT\": Error converting from js 'object' into type 'ArrayBuffer'"
```

The `wrappedKey` parameter of `crypto.unwrapKey` is defined as a `BufferSource`.

https://w3c.github.io/webcrypto/#subtlecrypto-interface
https://webidl.spec.whatwg.org/#BufferSource

In `jose` as well, it is passed as a `Uint8Array` rather than a raw `ArrayBuffer`.

```typescript
// src/lib/key_management.ts
async function aeskwUnwrap(
  alg: string,
  key: types.CryptoKey | Uint8Array,
  encryptedKey: Uint8Array,
): Promise<Uint8Array> {
  const cryptoKey = await aeskwCryptoKey(key, alg, 'unwrapKey')

  // algorithm used is irrelevant
  const cryptoKeyCek = await crypto.subtle.unwrapKey(
    'raw',
    encryptedKey as Uint8Array<ArrayBuffer>,
    cryptoKey,
    'AES-KW',
    { hash: 'SHA-256', name: 'HMAC' },
    true,
    ['sign'],
  )

  return new Uint8Array(await crypto.subtle.exportKey('raw', cryptoKeyCek))
}
```

The execution results of `tap` following this modification are as follows.
```
# pass 213 (+19)
# skip 0
# todo 0
# fail 8 (-19)
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
