### PR TITLE
fix(buffer): Improved Blob compatibility

### DIFF
--- a/modules/llrt_buffer/src/blob.rs
+++ b/modules/llrt_buffer/src/blob.rs
@@ -10,6 +10,7 @@ use llrt_stream_web::{
 use llrt_utils::{
     array_buffer::shared_array_buffer_view,
     bytes::{get_lossy_string, ObjectBytes},
+    object::not_a_object_error,
     primordials::Primordial,
     result::ResultExt,
     string::get_coerced_defined_string,
@@ -227,10 +228,7 @@ impl<'js> Blob<'js> {
     ) -> Result<Self> {
         if let Some(options) = options.0.as_ref() {
             if !options.is_null() && !options.is_undefined() && options.as_object().is_none() {
-                return Err(Exception::throw_type(
-                    &ctx,
-                    "Failed to construct 'Blob': options is not an object",
-                ));
+                return Err(not_a_object_error(&ctx, "options"));
             }
         }
 

--- a/modules/llrt_buffer/src/blob.rs
+++ b/modules/llrt_buffer/src/blob.rs
@@ -225,15 +225,18 @@ impl<'js> Blob<'js> {
         parts: Opt<Value<'js>>,
         options: Opt<Value<'js>>,
     ) -> Result<Self> {
+        if let Some(options) = options.0.as_ref() {
+            if !options.is_null() && !options.is_undefined() && options.as_object().is_none() {
+                return Err(Exception::throw_type(
+                    &ctx,
+                    "Failed to construct 'Blob': options is not an object",
+                ));
+            }
+        }
+
         let mut endings = EndingType::Transparent;
-        let mut mime_type = String::new();
-
-        if let Some(options) = options.0 {
+        if let Some(options) = options.0.as_ref() {
             if let Some(opts) = options.as_object() {
-                if let Some(x) = opts.get::<_, Option<Coerced<String>>>("type")? {
-                    mime_type = normalize_type(x.to_string());
-                }
-
                 if opts.contains_key("endings")? {
                     if let Some(parsed) = parse_endings(&ctx, opts.get("endings")?)? {
                         endings = parsed;
@@ -247,6 +250,16 @@ impl<'js> Blob<'js> {
         } else {
             Vec::new()
         };
+
+        let mut mime_type = String::new();
+        if let Some(options) = options.0.as_ref() {
+            if let Some(opts) = options.as_object() {
+                if let Some(x) = opts.get::<_, Option<Coerced<String>>>("type")? {
+                    mime_type = normalize_type(x.to_string());
+                }
+            }
+        }
+
         // Transfer Vec ownership to JS — QuickJS calls the drop callback when
         // the ArrayBuffer is GC'd, so no extra Rust-side copy.
         let data = ArrayBuffer::new(ctx, bytes)?;

--- a/tests/wpt/FileAPI.blob.test.ts
+++ b/tests/wpt/FileAPI.blob.test.ts
@@ -1,3 +1,10 @@
 import { runSuite, runTestDynamic } from "./FileAPI.harness.js";
 
-runSuite(import.meta.url, runTestDynamic);
+runSuite(import.meta.url, runTestDynamic, [
+  [
+    "Blob-constructor.any.js",
+    [
+      "[Passing a FrozenArray as the blobParts array should work (FrozenArray<MessagePort>).] MessageChannel is not defined",
+    ],
+  ],
+]);

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -1,4 +1,3 @@
-FileAPI/blob > should pass Blob-constructor.any.js tests
 WebCryptoAPI > should pass historical.any.js tests
 fetch/api/basic > should pass conditional-get.any.js tests
 fetch/api/basic > should pass header-value-combining.any.js tests


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

We skipped the tests utilizing `MessageChannel` that were acting as blockers in the Blob WPT suite. As a result, we detected a new incompatibility and implemented improvements to address it.

The specific improvements are as follows.

- The options had to be read in lexicographic order.
- In the constructor sequence, the `endings` are first retrieved from the options, and the parts are processed according to the retrieved `endings`. Subsequently, it was necessary to retrieve `type` from the options.
- The option needed to allow for an `object(Property bag)`, `null`, or `undefined`.

Ultimately, the following error was resolved.

#### FileAPI/blob > should pass Blob-constructor.any.js tests:

```
Error: [options properties should be accessed in lexicographic order.] assert_array_equals: expected property 0 to be "endings" but got "type" (expected array ["endings", "type"] got ["type", "endings"])
Error: [Arguments should be evaluated from left to right.] assert_unreached: type getter should not be called. Reached unreachable code
Error: [Passing 123 for options should throw] assert_throws_js: Blob constructor should throw with invalid property bag function "() => new Blob([], arg)" did not throw
Error: [Passing null (index 0) for options should use the defaults.] promise_test: Unhandled rejection with value: object "TypeError: Failed to construct 'Blob': options is not an object"
Error: [Passing undefined (index 1) for options should use the defaults.] promise_test: Unhandled rejection with value: object "TypeError: Failed to construct 'Blob': options is not an object"
```

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
