### PR TITLE
fix(crypto): align sign and verify with WebCrypto

### DIFF
--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -119,7 +119,7 @@ pbkdf2 = { version = "0.13", default-features = false, optional = true }
 pkcs8 = { version = "0.11", default-features = false, features = [
   "alloc",
 ], optional = true }
-sha1 = { version = "0.11", default-features = false, optional = true }
+sha1 = { version = "0.11", features = ["oid"], default-features = false, optional = true }
 spki = { version = "0.8", features = [
   "alloc",
 ], default-features = false, optional = true }

--- a/modules/llrt_crypto/src/provider/rust/mod.rs
+++ b/modules/llrt_crypto/src/provider/rust/mod.rs
@@ -18,7 +18,7 @@ use cbc::{Decryptor, Encryptor};
 use ctr::{cipher::Array, Ctr128BE, Ctr32BE, Ctr64BE};
 use der::Encode;
 use ecdsa::signature::hazmat::PrehashVerifier;
-use ed25519_dalek::{Signature, Signer, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, VerifyingKey};
 use elliptic_curve::{consts::U12, sec1::ToSec1Point, Generate};
 use hkdf::Hkdf;
 use hmac::{Hmac as HmacImpl, Mac};
@@ -264,7 +264,7 @@ impl CryptoProvider for RustCryptoProvider {
                 .try_into()
                 .map_err(|_| CryptoError::InvalidSignature(None))?,
         );
-        Ok(public_key.verify(data, &signature).is_ok())
+        Ok(public_key.verify_strict(data, &signature).is_ok())
     }
 
     fn rsa_pss_sign(
@@ -279,6 +279,9 @@ impl CryptoProvider for RustCryptoProvider {
             .map_err(|_| CryptoError::InvalidKey(None))?;
 
         match hash_alg {
+            HashAlgorithm::Sha1 => private_key
+                .sign_with_rng(&mut rng, Pss::<Sha1>::new_with_salt(salt_length), digest)
+                .map_err(|_| CryptoError::SigningFailed(None)),
             HashAlgorithm::Sha256 => private_key
                 .sign_with_rng(&mut rng, Pss::<Sha256>::new_with_salt(salt_length), digest)
                 .map_err(|_| CryptoError::SigningFailed(None)),
@@ -304,6 +307,9 @@ impl CryptoProvider for RustCryptoProvider {
             .map_err(|_| CryptoError::InvalidKey(None))?;
 
         match hash_alg {
+            HashAlgorithm::Sha1 => Ok(public_key
+                .verify(Pss::<Sha1>::new_with_salt(salt_length), digest, signature)
+                .is_ok()),
             HashAlgorithm::Sha256 => Ok(public_key
                 .verify(Pss::<Sha256>::new_with_salt(salt_length), digest, signature)
                 .is_ok()),
@@ -328,6 +334,9 @@ impl CryptoProvider for RustCryptoProvider {
             .map_err(|_| CryptoError::InvalidKey(None))?;
 
         match hash_alg {
+            HashAlgorithm::Sha1 => private_key
+                .sign_with_rng(&mut rng, Pkcs1v15Sign::new::<Sha1>(), digest)
+                .map_err(|_| CryptoError::SigningFailed(None)),
             HashAlgorithm::Sha256 => private_key
                 .sign_with_rng(&mut rng, Pkcs1v15Sign::new::<Sha256>(), digest)
                 .map_err(|_| CryptoError::SigningFailed(None)),
@@ -352,6 +361,9 @@ impl CryptoProvider for RustCryptoProvider {
             .map_err(|_| CryptoError::InvalidKey(None))?;
 
         match hash_alg {
+            HashAlgorithm::Sha1 => Ok(public_key
+                .verify(Pkcs1v15Sign::new::<Sha1>(), digest, signature)
+                .is_ok()),
             HashAlgorithm::Sha256 => Ok(public_key
                 .verify(Pkcs1v15Sign::new::<Sha256>(), digest, signature)
                 .is_ok()),

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -356,6 +356,7 @@ fn from_ed25519<'js>(
                 data,
                 const_oid::db::rfc8410::ID_ED_25519,
                 algorithm_name,
+                true,
             )?;
             Ok(Some(*kind))
         } else {
@@ -408,6 +409,7 @@ fn from_x25519<'js>(
                 data,
                 const_oid::db::rfc8410::ID_X_25519,
                 algorithm_name,
+                false,
             )?;
             Ok(Some(*kind))
         } else {
@@ -1352,6 +1354,7 @@ fn import_okp_key<'js>(
     data: &mut Vec<u8>,
     oid: ObjectIdentifier,
     algorithm_name: &str,
+    is_ed25519: bool,
 ) -> Result<()> {
     let validate_oid = |other_oid: const_oid::ObjectIdentifier| -> Result<()> {
         if other_oid != oid {
@@ -1406,10 +1409,17 @@ fn import_okp_key<'js>(
             *kind = KeyKind::Public;
         },
         KeyFormatData::Pkcs8(object_bytes) => {
-            let pkcs8 = PrivateKeyInfoRef::try_from(object_bytes.as_bytes(ctx)?).or_throw(ctx)?;
+            let bytes = object_bytes.into_bytes(ctx)?;
+            let pkcs8 = PrivateKeyInfoRef::try_from(bytes.as_slice()).or_throw(ctx)?;
             validate_oid(pkcs8.algorithm.oid)?;
-            let private_key = OctetString::from_der(pkcs8.private_key.as_bytes()).or_throw(ctx)?;
-            *data = private_key.as_bytes().to_vec();
+            *data = if is_ed25519 {
+                bytes
+            } else {
+                OctetString::from_der(pkcs8.private_key.as_bytes())
+                    .or_throw(ctx)?
+                    .as_bytes()
+                    .to_vec()
+            };
             *kind = KeyKind::Private;
         },
     };
@@ -1428,6 +1438,7 @@ pub fn extract_sha_hash<'js>(ctx: &Ctx<'js>, obj: &Object<'js>) -> Result<HashAl
             "hash must be a string or an object",
         ));
     }?;
+    let hash = normalize_algorithm_name(&hash);
     HashAlgorithm::from_strict_str(hash.as_str()).or_throw_dom(ctx)
 }
 

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -99,11 +99,11 @@ pub fn rsa_hash_digest<'a>(
     };
     if !matches!(
         hash,
-        HashAlgorithm::Sha256 | HashAlgorithm::Sha384 | HashAlgorithm::Sha512
+        HashAlgorithm::Sha1 | HashAlgorithm::Sha256 | HashAlgorithm::Sha384 | HashAlgorithm::Sha512
     ) {
         return Err(Exception::throw_message(
             ctx,
-            "Only Sha-256, Sha-384 or Sha-512 is supported for RSA",
+            "Only SHA-1, SHA-256, SHA-384 or SHA-512 is supported for RSA",
         ));
     }
 
@@ -140,7 +140,7 @@ pub fn to_name_and_maybe_object<'js>(
 }
 
 pub fn normalize_algorithm_name(name: &str) -> String {
-    let name = name.trim().to_ascii_uppercase();
+    let name = name.to_ascii_uppercase();
     match name.as_str() {
         "ED25519" => "Ed25519".to_string(),
         "RSASSA-PKCS1-V1_5" => "RSASSA-PKCS1-v1_5".to_string(),

--- a/modules/llrt_crypto/src/subtle/sign.rs
+++ b/modules/llrt_crypto/src/subtle/sign.rs
@@ -23,6 +23,9 @@ pub fn subtle_sign<'js>(
     key: Class<'js, CryptoKey<'js>>,
     data: ObjectBytes<'js>,
 ) -> impl Future<Output = Result<ArrayBuffer<'js>>> + 'js {
+    // Keep preparation outside the async block: Rust async function bodies are deferred until
+    // polled, while WebCrypto requires call-time algorithm normalization and input snapshotting.
+    // Retaining the Result lets preparation failures reject the rquickjs-created Promise.
     let prepared = prepare_sign(&ctx, algorithm, key, data);
 
     async move {

--- a/modules/llrt_crypto/src/subtle/sign.rs
+++ b/modules/llrt_crypto/src/subtle/sign.rs
@@ -1,27 +1,57 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use std::future::Future;
+
 use crate::provider::{CryptoProvider, HmacProvider};
-use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
-use rquickjs::{ArrayBuffer, Class, Ctx, Result};
+use llrt_utils::bytes::ObjectBytes;
+use rquickjs::{ArrayBuffer, Class, Ctx, FromJs, Result, Value};
 
 use crate::CRYPTO_PROVIDER;
 
 use super::{
-    algorithm_mismatch_error, crypto_key::CryptoKey, key_algorithm::KeyAlgorithm, rsa_hash_digest,
+    algorithm_invalid_access_error,
+    crypto_key::{CryptoKey, KeyKind},
+    key_algorithm::KeyAlgorithm,
+    rsa_hash_digest,
     sign_algorithm::SigningAlgorithm,
+    util::ResultDomExt,
 };
 
-pub async fn subtle_sign<'js>(
+pub fn subtle_sign<'js>(
     ctx: Ctx<'js>,
-    algorithm: SigningAlgorithm,
+    algorithm: Value<'js>,
     key: Class<'js, CryptoKey<'js>>,
     data: ObjectBytes<'js>,
-) -> Result<ArrayBuffer<'js>> {
-    let key = key.borrow();
-    key.check_validity("sign").or_throw(&ctx)?;
+) -> impl Future<Output = Result<ArrayBuffer<'js>>> + 'js {
+    let prepared = prepare_sign(&ctx, algorithm, key, data);
 
-    let bytes = sign(&ctx, &algorithm, &key, data.as_bytes(&ctx)?)?;
-    ArrayBuffer::new(ctx, bytes)
+    async move {
+        let (algorithm, key, data) = prepared?;
+        let key = key.borrow();
+        if key.name.as_ref() != algorithm.name() {
+            return algorithm_invalid_access_error(&ctx, algorithm.name());
+        }
+        key.check_validity("sign").or_throw_dom(&ctx)?;
+        let expected_kind = match &algorithm {
+            SigningAlgorithm::Hmac => KeyKind::Secret,
+            _ => KeyKind::Private,
+        };
+        key.check_kind(expected_kind).or_throw_dom(&ctx)?;
+
+        let bytes = sign(&ctx, &algorithm, &key, &data)?;
+        ArrayBuffer::new(ctx, bytes)
+    }
+}
+
+fn prepare_sign<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    key: Class<'js, CryptoKey<'js>>,
+    data: ObjectBytes<'js>,
+) -> Result<(SigningAlgorithm, Class<'js, CryptoKey<'js>>, Vec<u8>)> {
+    let algorithm = SigningAlgorithm::from_js(ctx, algorithm)?;
+    let data = data.as_bytes_opt().unwrap_or_default().to_vec();
+    Ok((algorithm, key, data))
 }
 
 fn sign(
@@ -35,28 +65,28 @@ fn sign(
         SigningAlgorithm::Ecdsa { hash } => {
             let curve = match &key.algorithm {
                 KeyAlgorithm::Ec { curve, .. } => curve,
-                _ => return algorithm_mismatch_error(ctx, "ECDSA"),
+                _ => return algorithm_invalid_access_error(ctx, "ECDSA"),
             };
 
             let digest = crate::subtle::digest::digest(hash, data);
 
             crate::CRYPTO_PROVIDER
                 .ecdsa_sign(*curve, handle, &digest)
-                .or_throw(ctx)?
+                .or_throw_dom(ctx)?
         },
         SigningAlgorithm::Ed25519 => {
             if !matches!(&key.algorithm, KeyAlgorithm::Ed25519) {
-                return algorithm_mismatch_error(ctx, "Ed25519");
+                return algorithm_invalid_access_error(ctx, "Ed25519");
             }
             crate::CRYPTO_PROVIDER
                 .ed25519_sign(handle, data)
-                .or_throw(ctx)?
+                .or_throw_dom(ctx)?
         },
         SigningAlgorithm::Hmac => {
             let hash = if let KeyAlgorithm::Hmac { hash, .. } = &key.algorithm {
                 hash
             } else {
-                return algorithm_mismatch_error(ctx, "HMAC");
+                return algorithm_invalid_access_error(ctx, "HMAC");
             };
 
             let mut hmac = CRYPTO_PROVIDER.hmac(*hash, handle);
@@ -67,13 +97,13 @@ fn sign(
             let (hash, digest) = rsa_hash_digest(ctx, key, data, "RSA-PSS")?;
             crate::CRYPTO_PROVIDER
                 .rsa_pss_sign(&key.handle, digest.as_ref(), *salt_length as usize, *hash)
-                .or_throw(ctx)?
+                .or_throw_dom(ctx)?
         },
         SigningAlgorithm::RsassaPkcs1v15 => {
             let (hash, digest) = rsa_hash_digest(ctx, key, data, "RSASSA-PKCS1-v1_5")?;
             crate::CRYPTO_PROVIDER
                 .rsa_pkcs1v15_sign(&key.handle, digest.as_ref(), *hash)
-                .or_throw(ctx)?
+                .or_throw_dom(ctx)?
         },
     })
 }

--- a/modules/llrt_crypto/src/subtle/sign_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/sign_algorithm.rs
@@ -6,7 +6,8 @@ use rquickjs::{Ctx, FromJs, Result, Value};
 use crate::hash::HashAlgorithm;
 
 use super::{
-    algorithm_not_supported_error, key_algorithm::extract_sha_hash, to_name_and_maybe_object,
+    algorithm_not_supported_error, key_algorithm::extract_sha_hash, normalize_algorithm_name,
+    to_name_and_maybe_object,
 };
 
 #[derive(Debug)]
@@ -21,6 +22,7 @@ pub enum SigningAlgorithm {
 impl<'js> FromJs<'js> for SigningAlgorithm {
     fn from_js(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
         let (name, obj) = to_name_and_maybe_object(ctx, value)?;
+        let name = normalize_algorithm_name(&name);
 
         let algorithm = match name.as_str() {
             "Ed25519" => SigningAlgorithm::Ed25519,
@@ -39,5 +41,17 @@ impl<'js> FromJs<'js> for SigningAlgorithm {
             _ => return algorithm_not_supported_error(ctx),
         };
         Ok(algorithm)
+    }
+}
+
+impl SigningAlgorithm {
+    pub fn name(&self) -> &'static str {
+        match self {
+            SigningAlgorithm::Ecdsa { .. } => "ECDSA",
+            SigningAlgorithm::Ed25519 => "Ed25519",
+            SigningAlgorithm::RsaPss { .. } => "RSA-PSS",
+            SigningAlgorithm::RsassaPkcs1v15 => "RSASSA-PKCS1-v1_5",
+            SigningAlgorithm::Hmac => "HMAC",
+        }
     }
 }

--- a/modules/llrt_crypto/src/subtle/verify.rs
+++ b/modules/llrt_crypto/src/subtle/verify.rs
@@ -25,10 +25,18 @@ pub fn subtle_verify<'js>(
     signature: ObjectBytes<'js>,
     data: ObjectBytes<'js>,
 ) -> impl Future<Output = Result<bool>> + 'js {
+    // Keep preparation outside the async block: Rust async function bodies are deferred until
+    // polled, while WebCrypto requires call-time algorithm normalization and input snapshotting.
+    // Retaining the Result lets preparation failures reject the rquickjs-created Promise.
     let prepared = prepare_verify(&ctx, algorithm, key, signature, data);
 
     async move {
-        let (algorithm, key, signature, data) = prepared?;
+        let PreparedVerify {
+            algorithm,
+            key,
+            signature,
+            data,
+        } = prepared?;
         let key = key.borrow();
         if key.name.as_ref() != algorithm.name() {
             return algorithm_invalid_access_error(&ctx, algorithm.name());
@@ -44,12 +52,12 @@ pub fn subtle_verify<'js>(
     }
 }
 
-type PreparedVerify<'js> = (
-    SigningAlgorithm,
-    Class<'js, CryptoKey<'js>>,
-    Vec<u8>,
-    Vec<u8>,
-);
+struct PreparedVerify<'js> {
+    algorithm: SigningAlgorithm,
+    key: Class<'js, CryptoKey<'js>>,
+    signature: Vec<u8>,
+    data: Vec<u8>,
+}
 
 fn prepare_verify<'js>(
     ctx: &Ctx<'js>,
@@ -61,7 +69,12 @@ fn prepare_verify<'js>(
     let algorithm = SigningAlgorithm::from_js(ctx, algorithm)?;
     let signature = signature.as_bytes_opt().unwrap_or_default().to_vec();
     let data = data.as_bytes_opt().unwrap_or_default().to_vec();
-    Ok((algorithm, key, signature, data))
+    Ok(PreparedVerify {
+        algorithm,
+        key,
+        signature,
+        data,
+    })
 }
 
 fn verify(

--- a/modules/llrt_crypto/src/subtle/verify.rs
+++ b/modules/llrt_crypto/src/subtle/verify.rs
@@ -1,33 +1,67 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use crate::provider::{CryptoProvider, HmacProvider};
-use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
-use rquickjs::{Class, Ctx, Result};
+use std::future::Future;
+
+use crate::provider::{CryptoError, CryptoProvider, HmacProvider};
+use llrt_utils::bytes::ObjectBytes;
+use rquickjs::{Class, Ctx, FromJs, Result, Value};
 
 use crate::CRYPTO_PROVIDER;
 
 use super::{
-    algorithm_mismatch_error, crypto_key::CryptoKey, digest, key_algorithm::KeyAlgorithm,
-    rsa_hash_digest, sign_algorithm::SigningAlgorithm,
+    algorithm_invalid_access_error,
+    crypto_key::{CryptoKey, KeyKind},
+    digest,
+    key_algorithm::KeyAlgorithm,
+    rsa_hash_digest,
+    sign_algorithm::SigningAlgorithm,
+    util::ResultDomExt,
 };
 
-pub async fn subtle_verify<'js>(
+pub fn subtle_verify<'js>(
     ctx: Ctx<'js>,
-    algorithm: SigningAlgorithm,
+    algorithm: Value<'js>,
     key: Class<'js, CryptoKey<'js>>,
     signature: ObjectBytes<'js>,
     data: ObjectBytes<'js>,
-) -> Result<bool> {
-    let key = key.borrow();
-    key.check_validity("verify").or_throw(&ctx)?;
+) -> impl Future<Output = Result<bool>> + 'js {
+    let prepared = prepare_verify(&ctx, algorithm, key, signature, data);
 
-    verify(
-        &ctx,
-        &algorithm,
-        &key,
-        signature.as_bytes(&ctx)?,
-        data.as_bytes(&ctx)?,
-    )
+    async move {
+        let (algorithm, key, signature, data) = prepared?;
+        let key = key.borrow();
+        if key.name.as_ref() != algorithm.name() {
+            return algorithm_invalid_access_error(&ctx, algorithm.name());
+        }
+        key.check_validity("verify").or_throw_dom(&ctx)?;
+        let expected_kind = match &algorithm {
+            SigningAlgorithm::Hmac => KeyKind::Secret,
+            _ => KeyKind::Public,
+        };
+        key.check_kind(expected_kind).or_throw_dom(&ctx)?;
+
+        verify(&ctx, &algorithm, &key, &signature, &data)
+    }
+}
+
+type PreparedVerify<'js> = (
+    SigningAlgorithm,
+    Class<'js, CryptoKey<'js>>,
+    Vec<u8>,
+    Vec<u8>,
+);
+
+fn prepare_verify<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    key: Class<'js, CryptoKey<'js>>,
+    signature: ObjectBytes<'js>,
+    data: ObjectBytes<'js>,
+) -> Result<PreparedVerify<'js>> {
+    let algorithm = SigningAlgorithm::from_js(ctx, algorithm)?;
+    let signature = signature.as_bytes_opt().unwrap_or_default().to_vec();
+    let data = data.as_bytes_opt().unwrap_or_default().to_vec();
+    Ok((algorithm, key, signature, data))
 }
 
 fn verify(
@@ -42,28 +76,28 @@ fn verify(
         SigningAlgorithm::Ecdsa { hash } => {
             let curve = match &key.algorithm {
                 KeyAlgorithm::Ec { curve, .. } => curve,
-                _ => return algorithm_mismatch_error(ctx, "ECDSA"),
+                _ => return algorithm_invalid_access_error(ctx, "ECDSA"),
             };
 
             let digest = digest::digest(hash, data);
 
             crate::CRYPTO_PROVIDER
                 .ecdsa_verify(*curve, handle, signature, &digest)
-                .or_throw(ctx)?
+                .into_verification(ctx)?
         },
         SigningAlgorithm::Ed25519 => {
             if !matches!(&key.algorithm, KeyAlgorithm::Ed25519) {
-                return algorithm_mismatch_error(ctx, "Ed25519");
+                return algorithm_invalid_access_error(ctx, "Ed25519");
             }
 
             crate::CRYPTO_PROVIDER
                 .ed25519_verify(handle, signature, data)
-                .or_throw(ctx)?
+                .into_verification(ctx)?
         },
         SigningAlgorithm::Hmac => {
             let hash = match &key.algorithm {
                 KeyAlgorithm::Hmac { hash, .. } => hash,
-                _ => return algorithm_mismatch_error(ctx, "HMAC"),
+                _ => return algorithm_invalid_access_error(ctx, "HMAC"),
             };
 
             let mut hmac = CRYPTO_PROVIDER.hmac(*hash, handle);
@@ -82,13 +116,26 @@ fn verify(
                     *salt_length as usize,
                     *hash,
                 )
-                .or_throw(ctx)?
+                .into_verification(ctx)?
         },
         SigningAlgorithm::RsassaPkcs1v15 => {
             let (hash, digest) = rsa_hash_digest(ctx, key, data, "RSASSA-PKCS1-v1_5")?;
             crate::CRYPTO_PROVIDER
                 .rsa_pkcs1v15_verify(&key.handle, signature, digest.as_ref(), *hash)
-                .or_throw(ctx)?
+                .into_verification(ctx)?
         },
     })
+}
+
+trait VerificationResultExt {
+    fn into_verification(self, ctx: &Ctx<'_>) -> Result<bool>;
+}
+
+impl VerificationResultExt for std::result::Result<bool, CryptoError> {
+    fn into_verification(self, ctx: &Ctx<'_>) -> Result<bool> {
+        match self {
+            Err(CryptoError::InvalidSignature(_)) => Ok(false),
+            result => result.or_throw_dom(ctx),
+        }
+    }
 }

--- a/tests/unit/crypto.subtle.test.ts
+++ b/tests/unit/crypto.subtle.test.ts
@@ -606,9 +606,207 @@ fullCrypto("SubtleCrypto string AlgorithmIdentifier", () => {
       ).rejects.toThrow(TypeError);
     }
   });
+
+  it("should sign and verify with case-insensitive AlgorithmIdentifiers", async () => {
+    const hmacKey = await crypto.subtle.generateKey(
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign", "verify"]
+    );
+    const hmacData = ENCODED_DATA.slice();
+    const expectedHmac = await crypto.subtle.sign("HMAC", hmacKey, hmacData);
+    const pendingHmac = crypto.subtle.sign("hMaC", hmacKey, hmacData);
+    hmacData[0] ^= 0xff;
+    const hmacSignature = await pendingHmac;
+    expect(new Uint8Array(hmacSignature)).toEqual(new Uint8Array(expectedHmac));
+    expect(
+      await crypto.subtle.verify("HmAc", hmacKey, hmacSignature, ENCODED_DATA)
+    ).toBe(true);
+
+    const ed25519 = (await crypto.subtle.generateKey("Ed25519", false, [
+      "sign",
+      "verify",
+    ])) as webcrypto.CryptoKeyPair;
+    const ed25519Signature = await crypto.subtle.sign(
+      "eD25519",
+      ed25519.privateKey,
+      ENCODED_DATA
+    );
+    expect(
+      await crypto.subtle.verify(
+        "ED25519",
+        ed25519.publicKey,
+        ed25519Signature,
+        ENCODED_DATA
+      )
+    ).toBe(true);
+
+    const ecdsa = (await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign", "verify"]
+    )) as webcrypto.CryptoKeyPair;
+    const ecdsaSignature = await crypto.subtle.sign(
+      { name: "eCdSa", hash: "sha-256" },
+      ecdsa.privateKey,
+      ENCODED_DATA
+    );
+    expect(
+      await crypto.subtle.verify(
+        { name: "EcDsA", hash: { name: "sHa-256" } },
+        ecdsa.publicKey,
+        ecdsaSignature,
+        ENCODED_DATA
+      )
+    ).toBe(true);
+
+    const rsassa = (await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 1024,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      false,
+      ["sign", "verify"]
+    )) as webcrypto.CryptoKeyPair;
+    const rsassaSignature = await crypto.subtle.sign(
+      "rsassa-pkcs1-V1_5",
+      rsassa.privateKey,
+      ENCODED_DATA
+    );
+    expect(
+      await crypto.subtle.verify(
+        "RSASSA-pkcs1-v1_5",
+        rsassa.publicKey,
+        rsassaSignature,
+        ENCODED_DATA
+      )
+    ).toBe(true);
+
+    const rsaPss = (await crypto.subtle.generateKey(
+      {
+        name: "RSA-PSS",
+        modulusLength: 1024,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      false,
+      ["sign", "verify"]
+    )) as webcrypto.CryptoKeyPair;
+    const rsaPssSignature = await crypto.subtle.sign(
+      { name: "rsa-pss", saltLength: 32 },
+      rsaPss.privateKey,
+      ENCODED_DATA
+    );
+    expect(
+      await crypto.subtle.verify(
+        { name: "RsA-pSs", saltLength: 32 },
+        rsaPss.publicKey,
+        rsaPssSignature,
+        ENCODED_DATA
+      )
+    ).toBe(true);
+  });
+
+  it("should require signing parameter dictionaries", async () => {
+    const ecdsa = (await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign", "verify"]
+    )) as webcrypto.CryptoKeyPair;
+    const rsaPss = (await crypto.subtle.generateKey(
+      {
+        name: "RSA-PSS",
+        modulusLength: 1024,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      false,
+      ["sign", "verify"]
+    )) as webcrypto.CryptoKeyPair;
+
+    await expect(
+      crypto.subtle.sign("ECDSA", ecdsa.privateKey, ENCODED_DATA)
+    ).rejects.toThrow(TypeError);
+    await expect(
+      crypto.subtle.verify(
+        "ECDSA",
+        ecdsa.publicKey,
+        new Uint8Array(),
+        ENCODED_DATA
+      )
+    ).rejects.toThrow(TypeError);
+    await expect(
+      crypto.subtle.sign("RSA-PSS", rsaPss.privateKey, ENCODED_DATA)
+    ).rejects.toThrow(TypeError);
+    await expect(
+      crypto.subtle.verify(
+        "RSA-PSS",
+        rsaPss.publicKey,
+        new Uint8Array(),
+        ENCODED_DATA
+      )
+    ).rejects.toThrow(TypeError);
+  });
+
+  it("should not trim signing AlgorithmIdentifier names", async () => {
+    const key = await crypto.subtle.generateKey(
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign", "verify"]
+    );
+
+    await expect(
+      crypto.subtle.sign(" HMAC ", key, ENCODED_DATA)
+    ).rejects.toHaveProperty("name", "NotSupportedError");
+    await expect(
+      crypto.subtle.verify(" HMAC ", key, new Uint8Array(), ENCODED_DATA)
+    ).rejects.toHaveProperty("name", "NotSupportedError");
+  });
 });
 
 fullCrypto("SubtleCrypto deriveBits/deriveKey", () => {
+  it("should derive X25519 bits from an imported PKCS8 private key", async () => {
+    // Vectors from WebCryptoAPI/derive_bits_keys/derived_bits_length_vectors.js.
+    const privateKey = await crypto.subtle.importKey(
+      "pkcs8",
+      new Uint8Array([
+        48, 46, 2, 1, 0, 48, 5, 6, 3, 43, 101, 110, 4, 34, 4, 32, 200, 131, 142,
+        118, 208, 87, 223, 183, 216, 201, 90, 105, 225, 56, 22, 10, 221, 99,
+        115, 253, 113, 164, 210, 118, 187, 86, 227, 168, 27, 100, 255, 97,
+      ]),
+      "X25519",
+      false,
+      ["deriveBits"]
+    );
+    const publicKey = await crypto.subtle.importKey(
+      "spki",
+      new Uint8Array([
+        48, 42, 48, 5, 6, 3, 43, 101, 110, 3, 33, 0, 28, 242, 177, 230, 2, 46,
+        197, 55, 55, 30, 215, 245, 62, 84, 250, 17, 84, 216, 62, 152, 235, 100,
+        234, 81, 250, 229, 179, 48, 124, 254, 151, 6,
+      ]),
+      "X25519",
+      false,
+      []
+    );
+
+    const derived = await crypto.subtle.deriveBits(
+      { name: "X25519", public: publicKey },
+      privateKey,
+      256
+    );
+
+    expect(new Uint8Array(derived)).toEqual(
+      new Uint8Array([
+        39, 104, 64, 157, 250, 185, 158, 194, 59, 140, 137, 185, 63, 245, 136,
+        2, 149, 247, 97, 118, 8, 143, 137, 228, 61, 254, 190, 126, 161, 149, 0,
+        8,
+      ])
+    );
+  });
+
   it("should be processing ECDH algorithm", async () => {
     const keyLengths = [128, 192, 256];
     const algorithms = ["AES-CBC", "AES-CTR", "AES-GCM"];

--- a/tests/wpt/WebCryptoAPI.sign_verify.test.ts
+++ b/tests/wpt/WebCryptoAPI.sign_verify.test.ts
@@ -1,0 +1,3 @@
+import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
+
+runSuite(import.meta.url, runTestDynamic);


### PR DESCRIPTION
## Summary

- add focused upstream Web Platform Test coverage for `SubtleCrypto.sign()` and `verify()`
- align signing AlgorithmIdentifier normalization, dictionary handling, key validation, snapshot semantics, and DOMException mapping with WebCrypto
- complete the provider behavior required by the focused Ed25519, HMAC, RSASSA-PKCS1-v1_5, RSA-PSS, and ECDSA vectors

## Motivation

LLRT's sign and verify paths previously normalized algorithms and copied BufferSource inputs only after the returned future began running. That diverged from WebCrypto's call-time normalization and snapshot requirements. The paths also returned generic errors for several key-validation cases, treated invalid signatures as exceptional failures, and lacked provider support needed by upstream RSA SHA-1 and strict Ed25519 verification vectors.

While adding conformance coverage, an OKP representation issue was also exposed: Ed25519 signing requires imported private keys to remain PKCS#8 DER, while X25519 derivation expects the decoded 32-byte secret.

## What Changed

### Focused WPT coverage

- add `tests/wpt/WebCryptoAPI.sign_verify.test.ts`
- run all supported, non-tentative upstream files under `WebCryptoAPI/sign_verify`
- retain the harness's standard exclusion of tentative Ed448, KMAC, and ML-DSA coverage

### Algorithm normalization and preparation

- match signing algorithm names ASCII case-insensitively
- normalize nested ECDSA hash identifiers in both string and object form
- require dictionaries for ECDSA and RSA-PSS parameters
- reject whitespace-padded registry names instead of trimming them
- normalize arguments and snapshot data/signature BufferSources during the JavaScript call while returning failures as rejected promises

### Validation and error behavior

- validate the normalized operation algorithm against the key algorithm
- enforce sign/verify usages and private/public/secret key types
- map failures through the existing DOMException conventions
- resolve invalid signatures to `false` while preserving exceptional provider errors

### Provider compatibility

- preserve imported Ed25519 PKCS#8 DER for signing
- decode imported X25519 PKCS#8 keys to the raw 32-byte secret expected by derivation
- use strict Ed25519 verification for small-order-point rejection
- support SHA-1 for RSA-PSS and RSASSA-PKCS1-v1_5 when explicitly selected by an imported/generated WebCrypto key
- enable SHA-1 OID support required by PKCS#1 v1.5 signatures

## Standards and test sources

- Web Crypto API: [`SubtleCrypto.sign()`](https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign), [`SubtleCrypto.verify()`](https://w3c.github.io/webcrypto/#SubtleCrypto-method-verify), and [algorithm normalization](https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm)
- Web Crypto algorithm definitions: [RSASSA-PKCS1-v1_5](https://w3c.github.io/webcrypto/#rsassa-pkcs1), [RSA-PSS](https://w3c.github.io/webcrypto/#rsa-pss), [ECDSA](https://w3c.github.io/webcrypto/#ecdsa), [Ed25519](https://w3c.github.io/webcrypto/#ed25519), and [HMAC](https://w3c.github.io/webcrypto/#hmac)
- [RFC 8410, Section 7: Private Key Format](https://www.rfc-editor.org/rfc/rfc8410.html#section-7)
- Upstream WPT: [`WebCryptoAPI/sign_verify`](https://github.com/web-platform-tests/wpt/tree/master/WebCryptoAPI/sign_verify) and the [`derived_bits_length_vectors.js`](https://github.com/web-platform-tests/wpt/blob/master/WebCryptoAPI/derive_bits_keys/derived_bits_length_vectors.js) X25519 vector

## Validation

- `cargo +1.97.1 run -- test -d bundle/js/__tests__/wpt WebCryptoAPI.sign_verify` — 6 passed, 0 failed
- `cargo +1.97.1 run -- test -d bundle/js/__tests__/unit crypto.subtle` — 26 passed, 0 failed
- `cargo +1.97.1 run -- test -d bundle/js/__tests__/wpt WebCryptoAPI.derive_bits_keys` — 7 passed, 0 failed
- `cargo +1.97.1 test -p llrt_crypto` — 23 passed, 0 failed
- `cargo +1.97.1 clippy -p llrt_crypto --all-targets -- -D warnings`
- `cargo +1.97.1 fmt --all -- --check`
- `fnm exec --using=22.22.1 -- npx prettier --check tests/unit/crypto.subtle.test.ts tests/wpt/WebCryptoAPI.sign_verify.test.ts`
- `git diff --check`

## Scope Notes

- no WPT expectation baseline was added because all supported focused sign/verify files pass
- no tentative Ed448, KMAC, or ML-DSA implementation is included
- no unrelated crypto refactoring is included
