### PR TITLE
fix(utils): validate ObjectBytes DataView ranges

### DIFF
--- a/libs/llrt_utils/src/bytes.rs
+++ b/libs/llrt_utils/src/bytes.rs
@@ -370,9 +370,10 @@ impl<'js> ObjectBytes<'js> {
             ObjectBytes::F32Array(array) => array.as_bytes(),
             ObjectBytes::F64Array(array) => array.as_bytes(),
             ObjectBytes::U8ClampedArray(array) => array.as_bytes(),
-            ObjectBytes::DataView(ab, offset, length) => {
-                ab.as_bytes().map(|b| &b[*offset..*offset + *length])
-            },
+            ObjectBytes::DataView(ab, offset, length) => ab.as_bytes().and_then(|bytes| {
+                let end = offset.checked_add(*length)?;
+                bytes.get(*offset..end)
+            }),
             ObjectBytes::Vec(bytes) => Some(bytes.as_ref()),
         }
         .ok_or(ERROR_MSG_ARRAY_BUFFER_DETACHED.into())
@@ -558,6 +559,50 @@ impl<'js> ObjectBytes<'js> {
         };
 
         Ok(Some(buffer))
+    }
+}
+
+#[cfg(test)]
+mod object_bytes_tests {
+    use super::{ObjectBytes, ERROR_MSG_ARRAY_BUFFER_DETACHED};
+    use rquickjs::{ArrayBuffer, Context, Runtime};
+
+    #[test]
+    fn data_view_ranges_are_checked() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+
+        ctx.with(|ctx| {
+            let buffer = ArrayBuffer::new_copy(ctx, [1_u8, 2, 3, 4]).unwrap();
+            for (offset, length) in [(3, 2), (usize::MAX, 1)] {
+                let bytes = ObjectBytes::DataView(buffer.clone(), offset, length);
+
+                assert_eq!(
+                    bytes.as_bytes_inner().unwrap_err().as_ref(),
+                    ERROR_MSG_ARRAY_BUFFER_DETACHED
+                );
+            }
+
+            let valid_bytes = ObjectBytes::DataView(buffer, 1, 2);
+            assert_eq!(valid_bytes.as_bytes_inner().unwrap(), &[2, 3]);
+        });
+    }
+
+    #[test]
+    fn data_view_detached_buffer_returns_error() {
+        let rt = Runtime::new().unwrap();
+        let ctx = Context::full(&rt).unwrap();
+
+        ctx.with(|ctx| {
+            let mut buffer = ArrayBuffer::new_copy(ctx, [1_u8, 2, 3, 4]).unwrap();
+            buffer.detach();
+            let bytes = ObjectBytes::DataView(buffer, 0, 4);
+
+            assert_eq!(
+                bytes.as_bytes_inner().unwrap_err().as_ref(),
+                ERROR_MSG_ARRAY_BUFFER_DETACHED
+            );
+        });
     }
 }
 

--- a/libs/llrt_utils/src/bytes.rs
+++ b/libs/llrt_utils/src/bytes.rs
@@ -348,10 +348,9 @@ impl<'js> ObjectBytes<'js> {
         self.as_bytes_inner().or_throw(ctx)
     }
 
-    /// Returns the underlying bytes, or `None` if the buffer is detached.
-    /// Unlike [`as_bytes`], does not raise a JS exception — useful when the
-    /// caller needs to distinguish detachment from other errors (e.g.
-    /// WebIDL-style "treat detached BufferSource as empty").
+    /// Returns the underlying bytes, or `None` if the buffer is detached or
+    /// the DataView range is invalid (including arithmetic overflow). Unlike
+    /// [`as_bytes`], does not raise a JS exception.
     pub fn as_bytes_opt(&self) -> Option<&[u8]> {
         self.as_bytes_inner().ok()
     }


### PR DESCRIPTION
### Issue # (if available)

N/A — focused panic-safety bug fix.

### Description of changes

`ObjectBytes::DataView` previously used unchecked `offset + length` arithmetic and direct slice indexing. Malformed ranges could overflow or panic while extracting bytes.

This change:

- uses checked arithmetic and checked slice access for DataView ranges;
- preserves the existing error mapping for detached buffers and invalid ranges;
- keeps valid ranges as exact, zero-copy borrowed slices;
- adds Rust regressions for out-of-range, overflowed, valid, and detached DataView cases; and
- documents that `as_bytes_opt` can return `None` for detached buffers or invalid DataView ranges.

#### Validation

- `cargo test -p llrt_utils data_view_`
- `cargo test -p llrt_utils`
- `cargo fmt --all -- --check`
- `cargo +stable clippy -p llrt_utils --lib --tests -- -D warnings`
- `git diff --check`
- Fork CI: formatting, Clippy, WPT, build, and module matrix all passed

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [ ] Ran `make fix` to format JS and apply Clippy auto fixes (not run; equivalent focused formatting and strict Clippy checks passed)
- [x] Made sure my code didn't add any additional warnings: `make check` (strict local Clippy and the full fork CI matrix passed)
- [x] Added relevant type info in `types/` directory (not applicable; no JavaScript-visible API or type change)
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other) (`as_bytes_opt` documentation updated)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
