### PR TITLE
fix(stream): coerce highWaterMark values

### DIFF
--- a/modules/llrt_stream_web/src/queuing_strategy/mod.rs
+++ b/modules/llrt_stream_web/src/queuing_strategy/mod.rs
@@ -1,5 +1,6 @@
 use rquickjs::{
     class::{JsCell, JsClass, Readable, Trace},
+    convert::Coerced,
     function::{Constructor, Params},
     prelude::This,
     Class, Ctx, Error, Exception, FromJs, Function, JsLifetime, Object, Result, Value,
@@ -12,12 +13,14 @@ use crate::utils::ValueOrUndefined;
 
 mod byte_length;
 mod count;
+#[cfg(test)]
+mod tests;
 
 /// QueuingStrategy is the structure of a user-provided object describing how backpressure should be signalled.
 /// https://streams.spec.whatwg.org/#qs-api
 pub(super) struct QueuingStrategy<'js> {
     // unrestricted double highWaterMark;
-    high_water_mark: Option<Value<'js>>,
+    high_water_mark: Option<f64>,
     // callback QueuingStrategySize = unrestricted double (any chunk);
     pub(super) size: Option<SizeFunction<'js>>,
 }
@@ -29,7 +32,9 @@ impl<'js> FromJs<'js> for QueuingStrategy<'js> {
             .as_object()
             .ok_or_else(|| Error::new_from_js(ty_name, "Object"))?;
 
-        let high_water_mark = obj.get_value_or_undefined::<_, Value>("highWaterMark")?;
+        let high_water_mark = obj
+            .get_value_or_undefined::<_, Coerced<f64>>("highWaterMark")?
+            .map(|value| value.0);
         let size = obj.get_value_or_undefined::<_, _>("size")?;
 
         Ok(Self {
@@ -54,7 +59,6 @@ impl<'js> QueuingStrategy<'js> {
                 high_water_mark: Some(high_water_mark),
                 ..
             }) => {
-                let high_water_mark = high_water_mark.as_number().unwrap_or(f64::NAN);
                 // If highWaterMark is NaN or highWaterMark < 0, throw a RangeError exception.
                 if high_water_mark.is_nan() || high_water_mark < 0.0 {
                     Err(Exception::throw_range(ctx, "Invalid highWaterMark"))
@@ -162,10 +166,12 @@ impl<'js> FromJs<'js> for QueueingStrategyInit {
             .ok_or_else(|| Error::new_from_js(ty_name, "Object"))?;
 
         let high_water_mark = obj
-            .get_value_or_undefined("highWaterMark")?
+            .get_value_or_undefined::<_, Coerced<f64>>("highWaterMark")?
             .ok_or_else(|| Error::new_from_js(ty_name, "QueueingStrategyInit"))?;
 
-        Ok(Self { high_water_mark })
+        Ok(Self {
+            high_water_mark: high_water_mark.0,
+        })
     }
 }
 

--- a/modules/llrt_stream_web/src/queuing_strategy/tests.rs
+++ b/modules/llrt_stream_web/src/queuing_strategy/tests.rs
@@ -1,0 +1,158 @@
+use llrt_test::test_sync_with;
+
+#[tokio::test]
+async fn high_water_mark_uses_javascript_number_conversion() {
+    test_sync_with(|ctx| {
+        crate::init(&ctx)?;
+        ctx.eval::<(), _>(
+            r#"
+            const converted = {
+                valueOf() {
+                    return "7.5";
+                },
+            };
+
+            const observed = [];
+            new ReadableStream({
+                start(controller) {
+                    observed.push(controller.desiredSize);
+                },
+            }, { highWaterMark: converted });
+            observed.push(
+                new WritableStream({}, { highWaterMark: converted })
+                    .getWriter().desiredSize,
+            );
+
+            const transform = new TransformStream({
+                start(controller) {
+                    observed.push(controller.desiredSize);
+                },
+            }, { highWaterMark: converted }, { highWaterMark: converted });
+            observed.push(transform.writable.getWriter().desiredSize);
+
+            observed.push(
+                new CountQueuingStrategy({ highWaterMark: converted }).highWaterMark,
+                new ByteLengthQueuingStrategy({ highWaterMark: converted }).highWaterMark,
+            );
+
+            if (observed.length !== 6 || observed.some(value => value !== 7.5)) {
+                throw new Error(`Unexpected highWaterMark values: ${observed}`);
+            }
+
+            const primitiveConversions = [
+                [false, 0],
+                [true, 1],
+                ["2.25", 2.25],
+            ];
+            for (const [input, expected] of primitiveConversions) {
+                const strategy = new CountQueuingStrategy({ highWaterMark: input });
+                if (strategy.highWaterMark !== expected) {
+                    throw new Error(`${String(input)} converted to ${strategy.highWaterMark}`);
+                }
+            }
+            "#,
+        )
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn high_water_mark_conversion_order_and_errors_are_observable() {
+    test_sync_with(|ctx| {
+        crate::init(&ctx)?;
+        ctx.eval::<(), _>(
+            r#"
+            const order = [];
+            new WritableStream({}, {
+                get highWaterMark() {
+                    order.push("get highWaterMark");
+                    return {
+                        valueOf() {
+                            order.push("convert highWaterMark");
+                            return 1;
+                        },
+                    };
+                },
+                get size() {
+                    order.push("get size");
+                    return undefined;
+                },
+            });
+
+            const expectedOrder =
+                "get highWaterMark,convert highWaterMark,get size";
+            if (order.join() !== expectedOrder) {
+                throw new Error(`Unexpected conversion order: ${order}`);
+            }
+
+            const expectedError = new Error("number conversion failed");
+            const throwingValue = {
+                valueOf() {
+                    throw expectedError;
+                },
+            };
+            const factories = [
+                () => new ReadableStream({}, { highWaterMark: throwingValue }),
+                () => new WritableStream({}, { highWaterMark: throwingValue }),
+                () => new TransformStream({}, { highWaterMark: throwingValue }),
+                () => new TransformStream({}, {}, { highWaterMark: throwingValue }),
+                () => new CountQueuingStrategy({ highWaterMark: throwingValue }),
+                () => new ByteLengthQueuingStrategy({ highWaterMark: throwingValue }),
+            ];
+
+            for (const factory of factories) {
+                try {
+                    factory();
+                    throw new Error("Expected number conversion to throw");
+                } catch (error) {
+                    if (error !== expectedError) {
+                        throw new Error(`Unexpected conversion error: ${error}`);
+                    }
+                }
+            }
+
+            for (const input of [1n, Symbol("highWaterMark")]) {
+                try {
+                    new CountQueuingStrategy({ highWaterMark: input });
+                    throw new Error("Expected ToNumber to reject the value");
+                } catch (error) {
+                    if (!(error instanceof TypeError)) {
+                        throw new Error(`Expected TypeError, got ${error}`);
+                    }
+                }
+            }
+            "#,
+        )
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn invalid_converted_stream_high_water_marks_throw_range_error() {
+    test_sync_with(|ctx| {
+        crate::init(&ctx)?;
+        ctx.eval::<(), _>(
+            r#"
+            for (const highWaterMark of ["-1", "not a number"]) {
+                const factories = [
+                    () => new ReadableStream({}, { highWaterMark }),
+                    () => new WritableStream({}, { highWaterMark }),
+                    () => new TransformStream({}, { highWaterMark }),
+                    () => new TransformStream({}, {}, { highWaterMark }),
+                ];
+                for (const factory of factories) {
+                    try {
+                        factory();
+                        throw new Error("Expected invalid highWaterMark to throw");
+                    } catch (error) {
+                        if (!(error instanceof RangeError)) {
+                            throw new Error(`Expected RangeError, got ${error}`);
+                        }
+                    }
+                }
+            }
+            "#,
+        )
+    })
+    .await;
+}


### PR DESCRIPTION
### Issue # (if available)

N/A — focused Web Streams conformance fix.

### Description of changes

Convert queuing-strategy `highWaterMark` members according to their Web IDL `unrestricted double` type before Streams validation.

The Streams Standard defines `QueuingStrategy.highWaterMark` and `QueuingStrategyInit.highWaterMark` as `unrestricted double`. Web IDL therefore requires JavaScript `ToNumber` conversion while the dictionary is read. LLRT previously retained a raw JavaScript value for general stream strategies and later accepted it only when it was already a number. The built-in count and byte-length strategies similarly used non-coercing Rust conversion.

As a result, valid inputs such as these were rejected instead of converted:

```js
new WritableStream({}, { highWaterMark: "4" });
new CountQueuingStrategy({ highWaterMark: true });

const highWaterMark = {
  valueOf() {
    return "7.5";
  },
};
new TransformStream({}, { highWaterMark }, { highWaterMark });
```

This change converts the member during dictionary parsing and stores the resulting `f64`. It applies consistently to:

- `ReadableStream`
- `WritableStream`
- both `TransformStream` strategies
- `CountQueuingStrategy`
- `ByteLengthQueuingStrategy`

Existing stream validation remains unchanged and runs after conversion. For example, `"-1"` converts to `-1` and then throws `RangeError`, while `"not a number"` converts to `NaN` and then throws `RangeError`. BigInt and Symbol values throw `TypeError` through `ToNumber`, and exceptions thrown by user-defined conversion hooks are preserved.

The conversion now also occurs at the Web IDL dictionary boundary, before the later `size` member is read, preserving the observable lexicographical member-processing order.

Relevant standards:

- [Streams Standard — `QueuingStrategy`](https://streams.spec.whatwg.org/#dictdef-queuingstrategy)
- [Streams Standard — `ExtractHighWaterMark`](https://streams.spec.whatwg.org/#validate-and-normalize-high-water-mark)
- [Web IDL — `unrestricted double` conversion](https://webidl.spec.whatwg.org/#es-unrestricted-double)
- [Web IDL — dictionary conversion order](https://webidl.spec.whatwg.org/#es-dictionary)

#### WPT coverage

The behavior corresponds directly to existing upstream Web Platform Tests:

- [`streams/queuing-strategies.any.js`](https://github.com/web-platform-tests/wpt/blob/master/streams/queuing-strategies.any.js) checks `unrestricted double` conversion for `CountQueuingStrategy` and `ByteLengthQueuingStrategy`.
- [`streams/transform-streams/strategies.any.js`](https://github.com/web-platform-tests/wpt/blob/master/streams/transform-streams/strategies.any.js) checks object-to-number conversion for both readable and writable TransformStream strategies.

Focused Rust regressions exercise those conversions across all six LLRT entry points, conversion and property-access ordering, exact propagation of user-thrown errors, BigInt/Symbol rejection, and post-conversion range validation.

The file-granular `wpt_errors.txt` baseline is intentionally unchanged; the TransformStream strategies file also covers behavior outside this focused conversion patch.

#### Validation

- Before the implementation, the new focused regression ran 1 passed / 2 failed against the upstream base.
- `cargo test -p llrt_stream_web` — 16 passed
- `cargo clippy -p llrt_stream_web --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

### Scope notes

- This does not change queuing-strategy `size()` conversion or error propagation.
- This does not change the existing rules that reject negative or NaN stream high water marks and permit positive infinity.
- No JavaScript-visible type declarations or documentation require changes.

### Checklist

- [x] Created focused Rust unit tests covering the changed behavior
- [ ] Ran `make fix` (not run; equivalent formatting and strict module-scoped Clippy checks passed)
- [x] Made sure the code adds no warnings with warning-denied Clippy
- [x] Added relevant type info in `types/` directory (not applicable; no type surface changed)
- [x] Updated documentation if needed (not applicable; behavior now matches the existing standards)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
