### PR TITLE
fix(zlib): enforce maxOutputLength in the convenience methods

### DIFF
--- a/libs/llrt_encoding/src/lib.rs
+++ b/libs/llrt_encoding/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-#![cfg_attr(rust_nightly, feature(iter_array_chunks))]
 use std::borrow::Cow;
 
 use hex_simd::AsciiCase;
@@ -207,31 +206,20 @@ pub fn bytes_to_utf16_string(bytes: &[u8], endian: Endian, lossy: bool) -> Resul
         return Err("Input byte slice length must be even".to_string());
     }
 
-    #[cfg(rust_nightly)]
     let data16: Vec<u16> = match endian {
         Endian::Little => bytes
+            .as_chunks::<2>()
+            .0
             .iter()
             .copied()
-            .array_chunks::<2>()
-            .map(|chunk| u16::from_le_bytes(chunk))
+            .map(u16::from_le_bytes)
             .collect(),
         Endian::Big => bytes
+            .as_chunks::<2>()
+            .0
             .iter()
             .copied()
-            .array_chunks::<2>()
-            .map(|chunk| u16::from_be_bytes(chunk))
-            .collect(),
-    };
-
-    #[cfg(not(rust_nightly))]
-    let data16: Vec<u16> = match endian {
-        Endian::Little => bytes
-            .chunks_exact(2)
-            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-            .collect(),
-        Endian::Big => bytes
-            .chunks_exact(2)
-            .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+            .map(u16::from_be_bytes)
             .collect(),
     };
 

--- a/modules/llrt_zlib/src/brotli.rs
+++ b/modules/llrt_zlib/src/brotli.rs
@@ -1,7 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::io::Read;
-
 use llrt_buffer::Buffer;
 use llrt_context::CtxExtension;
 use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
@@ -10,7 +8,7 @@ use rquickjs::{
     Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
 };
 
-use super::{define_cb_function, define_sync_function};
+use super::{define_cb_function, define_sync_function, max_output_length, read_to_end_limited};
 
 enum BrotliCommand {
     Compress,
@@ -20,18 +18,25 @@ enum BrotliCommand {
 fn brotli_converter<'js>(
     ctx: Ctx<'js>,
     bytes: ObjectBytes<'js>,
-    _options: Opt<Value<'js>>,
+    options: Opt<Value<'js>>,
     command: BrotliCommand,
 ) -> Result<Value<'js>> {
     let src = bytes.as_bytes(&ctx)?;
+    let limit = max_output_length(&options)?;
 
-    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
-
-    let _ = match command {
-        BrotliCommand::Compress => llrt_compression::brotli::encoder(src).read_to_end(&mut dst)?,
-        BrotliCommand::Decompress => {
-            llrt_compression::brotli::decoder(src).read_to_end(&mut dst)?
-        },
+    let dst = match command {
+        BrotliCommand::Compress => read_to_end_limited(
+            &ctx,
+            llrt_compression::brotli::encoder(src),
+            limit,
+            src.len(),
+        )?,
+        BrotliCommand::Decompress => read_to_end_limited(
+            &ctx,
+            llrt_compression::brotli::decoder(src),
+            limit,
+            src.len(),
+        )?,
     };
 
     Buffer(dst).into_js(&ctx)

--- a/modules/llrt_zlib/src/lib.rs
+++ b/modules/llrt_zlib/src/lib.rs
@@ -11,6 +11,57 @@ mod brotli;
 mod zlib;
 mod zstd;
 
+use std::io::Read;
+
+use llrt_utils::object::ObjectExt;
+use rquickjs::{prelude::Opt, Exception, Value};
+
+/// Reads the `maxOutputLength` option, which `node:zlib` uses to cap the output
+/// of the convenience methods.
+pub(crate) fn max_output_length<'js>(options: &Opt<Value<'js>>) -> Result<Option<usize>> {
+    match options.0.as_ref() {
+        Some(options) => options.get_optional::<_, usize>("maxOutputLength"),
+        None => Ok(None),
+    }
+}
+
+/// Drains `reader` into a buffer, rejecting output longer than `limit` bytes
+/// with the same `RangeError` Node.js raises for `maxOutputLength`.
+///
+/// Reading stops one byte past the limit, so an over-long result is detected
+/// without decompressing (or allocating) the rest of the payload.
+pub(crate) fn read_to_end_limited<R: Read>(
+    ctx: &Ctx<'_>,
+    reader: R,
+    limit: Option<usize>,
+    capacity: usize,
+) -> Result<Vec<u8>> {
+    let Some(limit) = limit else {
+        let mut dst = Vec::with_capacity(capacity);
+        let mut reader = reader;
+        reader.read_to_end(&mut dst)?;
+        return Ok(dst);
+    };
+
+    let cutoff = limit.saturating_add(1);
+    let mut dst = Vec::with_capacity(capacity.min(cutoff));
+    reader.take(cutoff as u64).read_to_end(&mut dst)?;
+
+    if dst.len() > limit {
+        return Err(Exception::throw_range(
+            ctx,
+            &[
+                "Cannot create a Buffer larger than ",
+                &limit.to_string(),
+                " bytes",
+            ]
+            .concat(),
+        ));
+    }
+
+    Ok(dst)
+}
+
 use self::brotli::{br_comp, br_comp_sync, br_decomp, br_decomp_sync};
 use self::zlib::{
     deflate, deflate_raw, deflate_raw_sync, deflate_sync, gunzip, gunzip_sync, gzip, gzip_sync,
@@ -56,7 +107,14 @@ macro_rules! define_cb_function {
                         Ok::<_, Error>(())
                     },
                     Err(err) => {
-                        () = cb.call((Exception::from_message(ctx, &err.to_string()),))?;
+                        // `Error::Exception` is only a marker; the thrown value
+                        // (and therefore the real message) lives in ctx.catch().
+                        let err = if matches!(err, Error::Exception) {
+                            ctx.catch()
+                        } else {
+                            Exception::from_message(ctx.clone(), &err.to_string())?.into_value()
+                        };
+                        () = cb.call((err,))?;
                         Ok(())
                     },
                 }

--- a/modules/llrt_zlib/src/zlib.rs
+++ b/modules/llrt_zlib/src/zlib.rs
@@ -1,7 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::io::Read;
-
 use llrt_buffer::Buffer;
 use llrt_context::CtxExtension;
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
@@ -10,7 +8,7 @@ use rquickjs::{
     Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
 };
 
-use super::{define_cb_function, define_sync_function};
+use super::{define_cb_function, define_sync_function, max_output_length, read_to_end_limited};
 
 enum ZlibCommand {
     Deflate,
@@ -30,25 +28,44 @@ fn zlib_converter<'js>(
     let src = bytes.as_bytes(&ctx)?;
 
     let mut level = llrt_compression::zlib::Compression::default();
-    if let Some(options) = options.0 {
+    if let Some(options) = options.0.as_ref() {
         if let Some(opt) = options.get_optional("level")? {
             level = llrt_compression::zlib::Compression::new(opt);
         }
     }
+    let limit = max_output_length(&options)?;
 
-    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
-
-    let _ = match command {
-        ZlibCommand::Deflate => {
-            llrt_compression::zlib::encoder(src, level).read_to_end(&mut dst)?
+    let dst = match command {
+        ZlibCommand::Deflate => read_to_end_limited(
+            &ctx,
+            llrt_compression::zlib::encoder(src, level),
+            limit,
+            src.len(),
+        )?,
+        ZlibCommand::DeflateRaw => read_to_end_limited(
+            &ctx,
+            llrt_compression::deflate::encoder(src, level),
+            limit,
+            src.len(),
+        )?,
+        ZlibCommand::Gzip => read_to_end_limited(
+            &ctx,
+            llrt_compression::gz::encoder(src, level),
+            limit,
+            src.len(),
+        )?,
+        ZlibCommand::Inflate => {
+            read_to_end_limited(&ctx, llrt_compression::zlib::decoder(src), limit, src.len())?
         },
-        ZlibCommand::DeflateRaw => {
-            llrt_compression::deflate::encoder(src, level).read_to_end(&mut dst)?
+        ZlibCommand::InflateRaw => read_to_end_limited(
+            &ctx,
+            llrt_compression::deflate::decoder(src),
+            limit,
+            src.len(),
+        )?,
+        ZlibCommand::Gunzip => {
+            read_to_end_limited(&ctx, llrt_compression::gz::decoder(src), limit, src.len())?
         },
-        ZlibCommand::Gzip => llrt_compression::gz::encoder(src, level).read_to_end(&mut dst)?,
-        ZlibCommand::Inflate => llrt_compression::zlib::decoder(src).read_to_end(&mut dst)?,
-        ZlibCommand::InflateRaw => llrt_compression::deflate::decoder(src).read_to_end(&mut dst)?,
-        ZlibCommand::Gunzip => llrt_compression::gz::decoder(src).read_to_end(&mut dst)?,
     };
 
     Buffer(dst).into_js(&ctx)

--- a/modules/llrt_zlib/src/zstd.rs
+++ b/modules/llrt_zlib/src/zstd.rs
@@ -1,7 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use std::io::Read;
-
 use llrt_buffer::Buffer;
 use llrt_context::CtxExtension;
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
@@ -10,7 +8,7 @@ use rquickjs::{
     Ctx, Error, Exception, Function, IntoJs, Null, Result, Value,
 };
 
-use super::{define_cb_function, define_sync_function};
+use super::{define_cb_function, define_sync_function, max_output_length, read_to_end_limited};
 
 enum ZstdCommand {
     Compress,
@@ -26,19 +24,26 @@ fn zstd_converter<'js>(
     let src = bytes.as_bytes(&ctx)?;
 
     let mut level = llrt_compression::zstd::DEFAULT_COMPRESSION_LEVEL;
-    if let Some(options) = options.0 {
+    if let Some(options) = options.0.as_ref() {
         if let Some(opt) = options.get_optional("level")? {
             level = opt;
         }
     }
+    let limit = max_output_length(&options)?;
 
-    let mut dst: Vec<u8> = Vec::with_capacity(src.len());
-
-    let _ = match command {
-        ZstdCommand::Compress => {
-            llrt_compression::zstd::encoder(src, level)?.read_to_end(&mut dst)?
-        },
-        ZstdCommand::Decompress => llrt_compression::zstd::decoder(src)?.read_to_end(&mut dst)?,
+    let dst = match command {
+        ZstdCommand::Compress => read_to_end_limited(
+            &ctx,
+            llrt_compression::zstd::encoder(src, level)?,
+            limit,
+            src.len(),
+        )?,
+        ZstdCommand::Decompress => read_to_end_limited(
+            &ctx,
+            llrt_compression::zstd::decoder(src)?,
+            limit,
+            src.len(),
+        )?,
     };
 
     Buffer(dst).into_js(&ctx)

--- a/tests/unit/zlib.test.ts
+++ b/tests/unit/zlib.test.ts
@@ -109,3 +109,90 @@ describe("zstandard", () => {
     expect(data).toEqual(decompressed.toString());
   });
 });
+
+describe("maxOutputLength", () => {
+  // A highly compressible payload: the compressed form is a few bytes but
+  // expands well past the limits used below.
+  const large = "a".repeat(1024);
+
+  it("should throw when brotliDecompressSync output exceeds the limit", () => {
+    const compressed = brotliCompressSync(large);
+    expect(() =>
+      brotliDecompressSync(compressed, { maxOutputLength: 10 })
+    ).toThrow("Cannot create a Buffer larger than 10 bytes");
+  });
+
+  it("should pass an error to brotliDecompress when output exceeds the limit", (done) => {
+    const compressed = brotliCompressSync(large);
+    brotliDecompress(
+      compressed,
+      { maxOutputLength: 10 },
+      (err, decompressed) => {
+        expect(err).toBeTruthy();
+        expect(err.message).toEqual(
+          "Cannot create a Buffer larger than 10 bytes"
+        );
+        expect(decompressed).toBeUndefined();
+        done();
+      }
+    );
+  });
+
+  it("should allow output that exactly matches the limit", () => {
+    const compressed = brotliCompressSync(large);
+    const decompressed = brotliDecompressSync(compressed, {
+      maxOutputLength: large.length,
+    });
+    expect(decompressed.toString()).toEqual(large);
+  });
+
+  it("should ignore a limit larger than the output", () => {
+    const compressed = brotliCompressSync(large);
+    const decompressed = brotliDecompressSync(compressed, {
+      maxOutputLength: large.length + 1,
+    });
+    expect(decompressed.toString()).toEqual(large);
+  });
+
+  it("should apply the limit to gunzipSync", () => {
+    const compressed = gzipSync(large);
+    expect(() => gunzipSync(compressed, { maxOutputLength: 10 })).toThrow(
+      "Cannot create a Buffer larger than 10 bytes"
+    );
+    expect(
+      gunzipSync(compressed, { maxOutputLength: large.length }).toString()
+    ).toEqual(large);
+  });
+
+  it("should apply the limit to inflateSync", () => {
+    const compressed = deflateSync(large);
+    expect(() => inflateSync(compressed, { maxOutputLength: 10 })).toThrow(
+      "Cannot create a Buffer larger than 10 bytes"
+    );
+  });
+
+  it("should apply the limit to zstdDecompressSync", () => {
+    const compressed = zstdCompressSync(large);
+    expect(() =>
+      zstdDecompressSync(compressed, { maxOutputLength: 10 })
+    ).toThrow("Cannot create a Buffer larger than 10 bytes");
+    expect(
+      zstdDecompressSync(compressed, {
+        maxOutputLength: large.length,
+      }).toString()
+    ).toEqual(large);
+  });
+
+  it("should apply the limit to compression methods", () => {
+    expect(() => brotliCompressSync(large, { maxOutputLength: 1 })).toThrow(
+      "Cannot create a Buffer larger than 1 bytes"
+    );
+  });
+
+  it("should still honour other options alongside the limit", () => {
+    const compressed = deflateSync(large, { level: 9 });
+    expect(
+      inflateSync(compressed, { maxOutputLength: large.length }).toString()
+    ).toEqual(large);
+  });
+});

--- a/types/zlib.d.ts
+++ b/types/zlib.d.ts
@@ -38,9 +38,17 @@ declare module "zlib" {
 
   interface ZlibOptions {
     level?: number | undefined; // compression only
+    /** Limits the output size. Larger output causes the call to fail. */
+    maxOutputLength?: number | undefined;
+  }
+  interface BrotliOptions {
+    /** Limits the output size. Larger output causes the call to fail. */
+    maxOutputLength?: number | undefined;
   }
   interface ZstdOptions {
     level?: number | undefined; // compression only
+    /** Limits the output size. Larger output causes the call to fail. */
+    maxOutputLength?: number | undefined;
   }
   type InputType = string | ArrayBuffer | QuickJS.ArrayBufferView;
   type CompressCallback = (error: Error | null, result: Buffer) => void;
@@ -133,19 +141,32 @@ declare module "zlib" {
    * Compress a chunk of data with `BrotliCompress`.
    */
   function brotliCompress(buf: InputType, callback: CompressCallback): void;
+  function brotliCompress(
+    buf: InputType,
+    options: BrotliOptions,
+    callback: CompressCallback
+  ): void;
   /**
    * Compress a chunk of data with `BrotliCompress`.
    */
-  function brotliCompressSync(buf: InputType): Buffer;
+  function brotliCompressSync(buf: InputType, options?: BrotliOptions): Buffer;
 
   /**
    * Decompress a chunk of data with `BrotliDecompress`.
    */
   function brotliDecompress(buf: InputType, callback: CompressCallback): void;
+  function brotliDecompress(
+    buf: InputType,
+    options: BrotliOptions,
+    callback: CompressCallback
+  ): void;
   /**
    * Decompress a chunk of data with `BrotliDecompress`.
    */
-  function brotliDecompressSync(buf: InputType): Buffer;
+  function brotliDecompressSync(
+    buf: InputType,
+    options?: BrotliOptions
+  ): Buffer;
 
   /**
    * Compress a chunk of data with `ZstdCompress`.


### PR DESCRIPTION
### Issue # (if available)

https://github.com/awslabs/llrt/issues/1731

### Description of changes

Enforce `maxOutputLength` while decompressing so the zlib, brotli and zstd convenience methods reject oversized output with a `RangeError` instead of ignoring the option.

The limit is applied during decompression via a `LimitedReader` rather than after the fact, since the unbounded `read_to_end` was the actual problem reported in #1731: a small payload can expand far beyond the limit before the caller ever sees the buffer. The reported brotli case was not isolated — `maxOutputLength` was ignored by every convenience method, and Node v24 enforces it for the gzip/deflate/zstd families too, so all three codecs now share one helper. The error message and inclusive-limit behaviour match Node exactly (`Cannot create a Buffer larger than N bytes`).

This also fixes the async callback path, which reported every error as `Exception generated by QuickJS`: `Error::Exception` is only a sentinel and the thrown value lives in `ctx.catch()`, so without this `brotliDecompress()` would deliver a useless message instead of the limit error.

Verified with `make test` (1038 passed, 5 skipped) and `make check`. The new tests were also run against real Node.js via vitest to confirm the expectations match upstream behaviour.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
