### PR TITLE
fix(crypto): Fix OKP key representation for Ed25519 and X25519

### DIFF
--- a/modules/llrt_crypto/src/provider/rust/mod.rs
+++ b/modules/llrt_crypto/src/provider/rust/mod.rs
@@ -16,7 +16,10 @@ use aes_gcm::{
 use aes_kw::{KwAes128, KwAes192, KwAes256};
 use cbc::{Decryptor, Encryptor};
 use ctr::{cipher::Array, Ctr128BE, Ctr32BE, Ctr64BE};
-use der::Encode;
+use der::{
+    asn1::{BitStringRef, OctetString, OctetStringRef},
+    Decode, Encode,
+};
 use ecdsa::signature::hazmat::PrehashVerifier;
 use ed25519_dalek::{Signature, Signer, VerifyingKey};
 use elliptic_curve::{consts::U12, sec1::ToSec1Point, Generate};
@@ -1310,10 +1313,34 @@ impl CryptoProvider for RustCryptoProvider {
     fn export_okp_private_key_pkcs8(
         &self,
         key_data: &[u8],
-        _oid: &[u8],
+        oid: &[u8],
     ) -> Result<Vec<u8>, CryptoError> {
-        // key_data is already PKCS8
-        Ok(key_data.to_vec())
+        // Ed25519: key_data is already PKCS#8.
+        if oid == const_oid::db::rfc8410::ID_ED_25519.as_bytes() {
+            return Ok(key_data.to_vec());
+        }
+        // X25519: key_data is the raw 32-byte private scalar.
+        if oid == const_oid::db::rfc8410::ID_X_25519.as_bytes() {
+            if key_data.len() != 32 {
+                return Err(CryptoError::InvalidKey(None));
+            }
+
+            // RFC 8410 requires the privateKey field to contain
+            // an encoded OCTET STRING containing the 32-byte scalar.
+            let inner = OctetStringRef::new(key_data).map_err(|_| CryptoError::InvalidKey(None))?;
+            let inner_der = inner.to_der().map_err(|_| CryptoError::InvalidKey(None))?;
+            let pk_info = pkcs8::PrivateKeyInfoRef {
+                algorithm: spki::AlgorithmIdentifier {
+                    oid: const_oid::db::rfc8410::ID_X_25519,
+                    parameters: None,
+                },
+                private_key: OctetStringRef::new(&inner_der)
+                    .map_err(|_| CryptoError::InvalidKey(None))?,
+                public_key: None,
+            };
+            return pk_info.to_der().map_err(|_| CryptoError::InvalidKey(None));
+        }
+        Err(CryptoError::InvalidKey(None))
     }
 
     fn import_rsa_jwk(
@@ -1518,10 +1545,6 @@ impl CryptoProvider for RustCryptoProvider {
             // Private key - for Ed25519 we need PKCS8, for X25519 we store raw
             if is_ed25519 {
                 // Ed25519: construct PKCS8 from raw private key
-                use der::{
-                    asn1::{BitStringRef, OctetStringRef},
-                    Encode,
-                };
                 let pk_info = pkcs8::PrivateKeyInfoRef {
                     algorithm: spki::AlgorithmIdentifier {
                         oid: const_oid::db::rfc8410::ID_ED_25519,
@@ -1565,20 +1588,29 @@ impl CryptoProvider for RustCryptoProvider {
     ) -> Result<super::OkpJwkExport, CryptoError> {
         if is_private {
             if is_ed25519 {
-                // Ed25519: key_data is PKCS8
-                use der::Decode;
+                // Ed25519: key_data is complete PKCS#8 DER.
                 let pk_info = pkcs8::PrivateKeyInfoRef::from_der(key_data)
                     .map_err(|_| CryptoError::InvalidKey(None))?;
-                let d = pk_info.private_key.as_bytes();
+                let d = OctetString::from_der(pk_info.private_key.as_bytes())
+                    .map_err(|_| CryptoError::InvalidKey(None))?
+                    .as_bytes()
+                    .to_vec();
+
+                if d.len() != 32 {
+                    return Err(CryptoError::InvalidKey(None));
+                }
+
                 let x = pk_info
                     .public_key
                     .ok_or(CryptoError::InvalidKey(None))?
                     .raw_bytes()
                     .to_vec();
-                Ok(super::OkpJwkExport {
-                    x,
-                    d: Some(d.to_vec()),
-                })
+
+                if x.len() != 32 {
+                    return Err(CryptoError::InvalidKey(None));
+                }
+
+                Ok(super::OkpJwkExport { x, d: Some(d) })
             } else {
                 // X25519: key_data is raw 32-byte secret
                 let secret = x25519_dalek::StaticSecret::from(

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 #[cfg(feature = "_subtle-full")]
 use der::{
-    asn1::{OctetString, OctetStringRef},
+    asn1::{BitStringRef, OctetString, OctetStringRef},
     Decode, Encode,
 };
 #[cfg(feature = "_subtle-full")]
@@ -1372,18 +1372,40 @@ fn import_okp_key<'js>(
             let x: String = object.get_required("x", "keyData")?;
             let public_key = bytes_from_b64_url_safe(x.as_bytes()).or_throw(ctx)?;
 
+            if public_key.len() != 32 {
+                return Err(DOMException::data_error(
+                    ctx,
+                    [algorithm_name, " public key must be 32 bytes"].concat(),
+                ));
+            }
+
             if let Some(d) = object.get_optional::<_, String>("d")? {
                 let private_key = bytes_from_b64_url_safe(d.as_bytes()).or_throw(ctx)?;
 
-                let pk_info = PrivateKeyInfoRef::new(
-                    AlgorithmIdentifier {
-                        oid,
-                        parameters: None,
-                    },
-                    OctetStringRef::new(private_key.as_slice()).or_throw(ctx)?,
-                );
+                if private_key.len() != 32 {
+                    return Err(DOMException::data_error(
+                        ctx,
+                        [algorithm_name, " private key must be 32 bytes"].concat(),
+                    ));
+                }
 
-                *data = pk_info.to_der().or_throw(ctx)?;
+                if is_ed25519 {
+                    // Ed25519 internal representation is the complete PKCS#8 DER.
+                    let inner = OctetStringRef::new(private_key.as_slice()).or_throw(ctx)?;
+                    let inner_der = inner.to_der().or_throw(ctx)?;
+                    let pk_info = PrivateKeyInfoRef {
+                        algorithm: AlgorithmIdentifier {
+                            oid,
+                            parameters: None,
+                        },
+                        private_key: OctetStringRef::new(&inner_der).or_throw(ctx)?,
+                        public_key: Some(BitStringRef::from_bytes(&public_key).or_throw(ctx)?),
+                    };
+                    *data = pk_info.to_der().or_throw(ctx)?;
+                } else {
+                    // X25519 internal representation is raw 32-byte scalar.
+                    *data = private_key;
+                }
                 *kind = KeyKind::Private;
             } else {
                 *data = public_key;
@@ -1412,17 +1434,29 @@ fn import_okp_key<'js>(
             let bytes = object_bytes.into_bytes(ctx)?;
             let pkcs8 = PrivateKeyInfoRef::try_from(bytes.as_slice()).or_throw(ctx)?;
             validate_oid(pkcs8.algorithm.oid)?;
-            *data = if is_ed25519 {
-                bytes
+
+            if is_ed25519 {
+                // Ed25519 internal representation is the complete PKCS#8 DER.
+                *data = bytes;
             } else {
-                OctetString::from_der(pkcs8.private_key.as_bytes())
+                // X25519 internal representation is the inner OCTET STRING.
+                *data = OctetString::from_der(pkcs8.private_key.as_bytes())
                     .or_throw(ctx)?
                     .as_bytes()
-                    .to_vec()
-            };
+                    .to_vec();
+
+                if data.len() != 32 {
+                    return Err(DOMException::data_error(
+                        ctx,
+                        [algorithm_name, " private key must be 32 bytes"].concat(),
+                    ));
+                }
+            }
+
             *kind = KeyKind::Private;
         },
-    };
+    }
+
     Ok(())
 }
 

--- a/tests/unit/crypto.subtle.test.ts
+++ b/tests/unit/crypto.subtle.test.ts
@@ -1301,6 +1301,99 @@ fullCrypto("SubtileCrypto import/export", () => {
       }
     }
   }, 30000);
+
+  it("should import and export an Ed25519 private JWK", async () => {
+    const algorithm = {
+      name: "Ed25519",
+    };
+
+    const keyPair = (await crypto.subtle.generateKey(algorithm, true, [
+      "sign",
+      "verify",
+    ])) as webcrypto.CryptoKeyPair;
+
+    const privateJwk = await crypto.subtle.exportKey("jwk", keyPair.privateKey);
+
+    expect(privateJwk.kty).toEqual("OKP");
+    expect(privateJwk.crv).toEqual("Ed25519");
+    expect(privateJwk.x).toBeDefined();
+    expect(privateJwk.d).toBeDefined();
+
+    const imported = await crypto.subtle.importKey(
+      "jwk",
+      privateJwk,
+      algorithm,
+      true,
+      ["sign"]
+    );
+
+    const signature = await crypto.subtle.sign(
+      algorithm,
+      imported,
+      ENCODED_DATA
+    );
+
+    expect(
+      await crypto.subtle.verify(
+        algorithm,
+        keyPair.publicKey,
+        signature,
+        ENCODED_DATA
+      )
+    ).toEqual(true);
+
+    const exported = await crypto.subtle.exportKey("jwk", imported);
+
+    expect(exported.kty).toEqual(privateJwk.kty);
+    expect(exported.crv).toEqual(privateJwk.crv);
+    expect(exported.x).toEqual(privateJwk.x);
+    expect(exported.d).toEqual(privateJwk.d);
+  });
+
+  it("should round-trip an Ed25519 private key through PKCS#8", async () => {
+    const algorithm = {
+      name: "Ed25519",
+    };
+
+    const keyPair = (await crypto.subtle.generateKey(algorithm, true, [
+      "sign",
+      "verify",
+    ])) as webcrypto.CryptoKeyPair;
+
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+
+    const imported = await crypto.subtle.importKey(
+      "pkcs8",
+      pkcs8,
+      algorithm,
+      true,
+      ["sign"]
+    );
+
+    const signature = await crypto.subtle.sign(
+      algorithm,
+      imported,
+      ENCODED_DATA
+    );
+
+    expect(
+      await crypto.subtle.verify(
+        algorithm,
+        keyPair.publicKey,
+        signature,
+        ENCODED_DATA
+      )
+    ).toEqual(true);
+
+    const originalJwk = await crypto.subtle.exportKey(
+      "jwk",
+      keyPair.privateKey
+    );
+    const importedJwk = await crypto.subtle.exportKey("jwk", imported);
+
+    expect(importedJwk.x).toEqual(originalJwk.x);
+    expect(importedJwk.d).toEqual(originalJwk.d);
+  });
 });
 
 fullCrypto("SubtileCrypto wrap/unwrap", () => {


### PR DESCRIPTION
### Issue # (if available)

Related #968 

### Description of changes

This PR fixes Ed25519 and X25519 OKP key import/export handling in the WebCrypto implementation.

The main issue was an inconsistency between the internal key representation and the standard JWK / PKCS#8 representations, particularly for Ed25519 private keys. This caused EdDSA-related operations and key round-tripping to fail in downstream consumers such as `jose`.

### Changes

- Fixed Ed25519 private key handling between JWK and PKCS#8 formats.
  - JWK `d` is handled as the 32-byte Ed25519 private key seed.
  - The internal Ed25519 representation remains PKCS#8 DER.
  - Correctly unwrap the nested OCTET STRING when exporting the private key to JWK.
  - Preserve the public key (`x`) contained in the PKCS#8 structure.

- Fixed X25519 private key PKCS#8 export.
  - X25519 uses a raw 32-byte private scalar internally.
  - Properly construct the RFC 8410 PKCS#8 representation with the required nested OCTET STRING.

- Added validation for OKP JWK key sizes.
  - Ed25519/X25519 public keys (`x`) must be 32 bytes.
  - Ed25519/X25519 private keys (`d`) must be 32 bytes.

- Improved OKP PKCS#8 import handling.
  - Ed25519 keeps the complete PKCS#8 DER as its internal representation.
  - X25519 extracts the inner 32-byte private scalar from PKCS#8.

- Verified Ed25519 signing and verification after JWK/PKCS#8 key import.

### Key Representation

The implementation now consistently handles the different representations as follows:

| Algorithm | Format | Internal representation |
|---|---|---|
| Ed25519 | JWK public | Raw 32-byte public key |
| Ed25519 | JWK private | PKCS#8 DER |
| Ed25519 | SPKI | Raw 32-byte public key |
| Ed25519 | PKCS#8 | Complete PKCS#8 DER |
| X25519 | JWK public | Raw 32-byte public key |
| X25519 | JWK private | Raw 32-byte private scalar |
| X25519 | SPKI | Raw 32-byte public key |
| X25519 | PKCS#8 | Raw 32-byte private scalar |

### Validation

The changes were verified against the existing TAP test suite, including Ed25519/EdDSA flows used by `jose`.

All relevant TAP tests now pass.

```
% sh tap/.llrt.sh
TAP version 13
ok 1 jwks.ts > [createRemoteJWKSet] fetches the JWKSet
ok 2 jwks.ts > [createLocalJWKSet] establishes local JWKSet
ok 3 aes.ts > A128GCM
ok 4 aes.ts > A128GCM JWT
ok 5 aes.ts > A192GCM
ok 6 aes.ts > A192GCM JWT
ok 7 aes.ts > A256GCM
ok 8 aes.ts > A256GCM JWT
ok 9 aes.ts > A128CBC-HS256
ok 10 aes.ts > A128CBC-HS256 JWT
ok 11 aes.ts > A192CBC-HS384
ok 12 aes.ts > A192CBC-HS384 JWT
ok 13 aes.ts > A256CBC-HS512
ok 14 aes.ts > A256CBC-HS512 JWT
ok 15 aeskw.ts > A128KW
ok 16 aeskw.ts > A128KW JWT
ok 17 aeskw.ts > A192KW
ok 18 aeskw.ts > A192KW JWT
ok 19 aeskw.ts > A256KW
ok 20 aeskw.ts > A256KW JWT
ok 21 aeskw.ts > A128GCMKW
ok 22 aeskw.ts > A128GCMKW JWT
ok 23 aeskw.ts > A192GCMKW
ok 24 aeskw.ts > A192GCMKW JWT
ok 25 aeskw.ts > A256GCMKW
ok 26 aeskw.ts > A256GCMKW JWT
ok 27 jws cookbook > https://www.rfc-editor.org/info/rfc7520/#section-4.1 - RSA v1.5 Signature
ok 28 jws cookbook > https://www.rfc-editor.org/info/rfc8037/#appendix-A.4 - Ed25519 Signing
ok 29 jws cookbook > https://www.rfc-editor.org/info/rfc7520/#section-4.2 - RSA-PSS Signature
ok 30 jws cookbook > https://www.rfc-editor.org/info/rfc7520/#section-4.3 - ECDSA Signature
ok 31 jws cookbook > https://www.rfc-editor.org/info/rfc7520/#section-4.4 - HMAC-SHA2 Integrity Protection
ok 32 jws cookbook > https://www.rfc-editor.org/info/rfc7520/#section-4.6 - Protecting Specific Header Fields
ok 33 jws cookbook > https://www.rfc-editor.org/info/rfc7520/#section-4.7 - Protecting Content Only
ok 34 jws cookbook > https://www.rfc-editor.org/info/rfc7797/#section-4.1 - { "b64": false } JSON only
ok 35 jws cookbook > [not supported] ietf-cose-dilithium - ML-DSA-44
ok 36 jws cookbook > [not supported] ietf-cose-dilithium - ML-DSA-65
ok 37 jws cookbook > [not supported] ietf-cose-dilithium - ML-DSA-87
ok 38 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.2 - Key Encryption using RSA-OAEP with AES-GCM
ok 39 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.3 - Key Wrap using PBES2-AES-KeyWrap with AES-CBC-HMAC-SHA2
ok 40 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.4 - Key Agreement with Key Wrapping using ECDH-ES and AES-KeyWrap with AES-GCM
ok 41 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.5 - Key Agreement using ECDH-ES with AES-CBC-HMAC-SHA2
ok 42 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.6 - Direct Encryption using AES-GCM
ok 43 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.7 - Key Wrap using AES-GCM KeyWrap with AES-CBC-HMAC-SHA2
ok 44 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.8 - Key Wrap using AES-KeyWrap with AES-GCM
ok 45 jwe cookbook > [not supported] https://www.rfc-editor.org/info/rfc7520/#section-5.9 - Compressed Content
ok 46 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.10 - Including Additional Authenticated Data
ok 47 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.11 - Protecting Specific Header Fields
ok 48 jwe cookbook > https://www.rfc-editor.org/info/rfc7520/#section-5.12 - Protecting Content Only
ok 49 ecdh.ts > ECDH-ES P-256
ok 50 ecdh.ts > ECDH-ES P-256 JWT
ok 51 ecdh.ts > ECDH-ES P-384
ok 52 ecdh.ts > ECDH-ES P-384 JWT
ok 53 ecdh.ts > ECDH-ES P-521
ok 54 ecdh.ts > ECDH-ES P-521 JWT
ok 55 ecdh.ts > ECDH-ES X25519
ok 56 ecdh.ts > ECDH-ES X25519 JWT
ok 57 general.ts > General JWE with multiple recipients
ok 58 general.ts > General JWS with multiple signatures
ok 59 generate_options.ts > secret CryptoKey extractable: default (false)
ok 60 generate_options.ts > secret CryptoKey extractable: true
ok 61 generate_options.ts > secret CryptoKey extractable: false
ok 62 generate_options.ts > CryptoKeyPair extractable: default (false)
ok 63 generate_options.ts > CryptoKeyPair extractable: true
ok 64 generate_options.ts > CryptoKeyPair extractable: false
ok 65 generate_options.ts > RSA modulusLength default (2048)
ok 66 generate_options.ts > RSA modulusLength 2048
ok 67 generate_options.ts > RSA modulusLength 3072
ok 68 hmac.ts > HS256
ok 69 hmac.ts > HS256 w/ non-digest output length secrets
ok 70 hmac.ts > HS256 JWT
ok 71 hmac.ts > HS384
ok 72 hmac.ts > HS384 w/ non-digest output length secrets
ok 73 hmac.ts > HS384 JWT
ok 74 hmac.ts > HS512
ok 75 hmac.ts > HS512 w/ non-digest output length secrets
ok 76 hmac.ts > HS512 JWT
ok 77 jwk.ts > ECDH-ES P-256 Private JWK Import
ok 78 jwk.ts > ECDH-ES P-384 Private JWK Import
ok 79 jwk.ts > ECDH-ES P-521 Private JWK Import
ok 80 jwk.ts > ECDH-ES X25519 Private JWK Import
ok 81 jwk.ts > Ed25519 Private JWK Import
ok 82 jwk.ts > EdDSA Ed25519 Private JWK Import
ok 83 jwk.ts > ES256 Private JWK Import
ok 84 jwk.ts > ES384 Private JWK Import
ok 85 jwk.ts > ES512 Private JWK Import
ok 86 jwk.ts > PS256 Private JWK Import
ok 87 jwk.ts > PS384 Private JWK Import
ok 88 jwk.ts > PS512 Private JWK Import
ok 89 jwk.ts > RS256 Private JWK Import
ok 90 jwk.ts > RS384 Private JWK Import
ok 91 jwk.ts > RS512 Private JWK Import
ok 92 jwk.ts > RSA-OAEP-256 Private JWK Import
ok 93 jwk.ts > RSA-OAEP-384 Private JWK Import
ok 94 jwk.ts > RSA-OAEP-512 Private JWK Import
ok 95 jwk.ts > RSA-OAEP Private JWK Import
ok 96 jwk.ts > [not supported] ML-DSA-44 Private JWK Import
ok 97 jwk.ts > [not supported] ML-DSA-65 Private JWK Import
ok 98 jwk.ts > [not supported] ML-DSA-87 Private JWK Import
ok 99 jwk.ts > ECDH-ES P-256 Public JWK Import
ok 100 jwk.ts > ECDH-ES P-384 Public JWK Import
ok 101 jwk.ts > ECDH-ES P-521 Public JWK Import
ok 102 jwk.ts > ECDH-ES X25519 Public JWK Import
ok 103 jwk.ts > Ed25519 Public JWK Import
ok 104 jwk.ts > EdDSA Ed25519 Public JWK Import
ok 105 jwk.ts > ES256 Public JWK Import
ok 106 jwk.ts > ES384 Public JWK Import
ok 107 jwk.ts > ES512 Public JWK Import
ok 108 jwk.ts > PS256 Public JWK Import
ok 109 jwk.ts > PS384 Public JWK Import
ok 110 jwk.ts > PS512 Public JWK Import
ok 111 jwk.ts > RS256 Public JWK Import
ok 112 jwk.ts > RS384 Public JWK Import
ok 113 jwk.ts > RS512 Public JWK Import
ok 114 jwk.ts > RSA-OAEP-256 Public JWK Import
ok 115 jwk.ts > RSA-OAEP-384 Public JWK Import
ok 116 jwk.ts > RSA-OAEP-512 Public JWK Import
ok 117 jwk.ts > RSA-OAEP Public JWK Import
ok 118 jwk.ts > [not supported] ML-DSA-44 Public JWK Import
ok 119 jwk.ts > [not supported] ML-DSA-65 Public JWK Import
ok 120 jwk.ts > [not supported] ML-DSA-87 Public JWK Import
ok 121 jws.ts > Ed25519
ok 122 jws.ts > Ed25519 JWT
ok 123 jws.ts > EdDSA
ok 124 jws.ts > EdDSA JWT
ok 125 jws.ts > ES256
ok 126 jws.ts > ES256 JWT
ok 127 jws.ts > ES384
ok 128 jws.ts > ES384 JWT
ok 129 jws.ts > ES512
ok 130 jws.ts > ES512 JWT
ok 131 jws.ts > PS256
ok 132 jws.ts > PS256 JWT
ok 133 jws.ts > PS384
ok 134 jws.ts > PS384 JWT
ok 135 jws.ts > PS512
ok 136 jws.ts > PS512 JWT
ok 137 jws.ts > RS256
ok 138 jws.ts > RS256 JWT
ok 139 jws.ts > RS384
ok 140 jws.ts > RS384 JWT
ok 141 jws.ts > RS512
ok 142 jws.ts > RS512 JWT
ok 143 jws.ts > [not supported] ML-DSA-44
ok 144 jws.ts > [not supported] ML-DSA-65
ok 145 jws.ts > [not supported] ML-DSA-87
ok 146 pbes2.ts > PBES2-HS256+A128KW
ok 147 pbes2.ts > PBES2-HS256+A128KW JWT
ok 148 pbes2.ts > PBES2-HS384+A192KW
ok 149 pbes2.ts > PBES2-HS384+A192KW JWT
ok 150 pbes2.ts > PBES2-HS512+A256KW
ok 151 pbes2.ts > PBES2-HS512+A256KW JWT
ok 152 pem.ts > ES256 PKCS8 Private Key Import
ok 153 pem.ts > ES256 SPKI Public Key Import
ok 154 pem.ts > ES256 X.509 Certificate Import
ok 155 pem.ts > ES384 PKCS8 Private Key Import
ok 156 pem.ts > ES384 SPKI Public Key Import
ok 157 pem.ts > ES384 X.509 Certificate Import
ok 158 pem.ts > ES512 PKCS8 Private Key Import
ok 159 pem.ts > ES512 SPKI Public Key Import
ok 160 pem.ts > ES512 X.509 Certificate Import
ok 161 pem.ts > PS256 PKCS8 Private Key Import
ok 162 pem.ts > PS256 SPKI Public Key Import
ok 163 pem.ts > PS256 X.509 Certificate Import
ok 164 pem.ts > PS384 PKCS8 Private Key Import
ok 165 pem.ts > PS384 SPKI Public Key Import
ok 166 pem.ts > PS384 X.509 Certificate Import
ok 167 pem.ts > PS512 PKCS8 Private Key Import
ok 168 pem.ts > PS512 SPKI Public Key Import
ok 169 pem.ts > PS512 X.509 Certificate Import
ok 170 pem.ts > RS256 PKCS8 Private Key Import
ok 171 pem.ts > RS256 SPKI Public Key Import
ok 172 pem.ts > RS256 X.509 Certificate Import
ok 173 pem.ts > RS384 PKCS8 Private Key Import
ok 174 pem.ts > RS384 SPKI Public Key Import
ok 175 pem.ts > RS384 X.509 Certificate Import
ok 176 pem.ts > RS512 PKCS8 Private Key Import
ok 177 pem.ts > RS512 SPKI Public Key Import
ok 178 pem.ts > RS512 X.509 Certificate Import
ok 179 pem.ts > RSA-OAEP-256 PKCS8 Private Key Import
ok 180 pem.ts > RSA-OAEP-256 SPKI Public Key Import
ok 181 pem.ts > RSA-OAEP-256 X.509 Certificate Import
ok 182 pem.ts > RSA-OAEP-384 PKCS8 Private Key Import
ok 183 pem.ts > RSA-OAEP-384 SPKI Public Key Import
ok 184 pem.ts > RSA-OAEP-384 X.509 Certificate Import
ok 185 pem.ts > RSA-OAEP-512 PKCS8 Private Key Import
ok 186 pem.ts > RSA-OAEP-512 SPKI Public Key Import
ok 187 pem.ts > RSA-OAEP-512 X.509 Certificate Import
ok 188 pem.ts > RSA-OAEP PKCS8 Private Key Import
ok 189 pem.ts > RSA-OAEP SPKI Public Key Import
ok 190 pem.ts > RSA-OAEP X.509 Certificate Import
ok 191 pem.ts > ECDH-ES P-256 PKCS8 Private Key Import
ok 192 pem.ts > ECDH-ES P-256 SPKI Public Key Import
ok 193 pem.ts > ECDH-ES P-256 X.509 Certificate Import
ok 194 pem.ts > ECDH-ES P-384 PKCS8 Private Key Import
ok 195 pem.ts > ECDH-ES P-384 SPKI Public Key Import
ok 196 pem.ts > ECDH-ES P-384 X.509 Certificate Import
ok 197 pem.ts > ECDH-ES P-521 PKCS8 Private Key Import
ok 198 pem.ts > ECDH-ES P-521 SPKI Public Key Import
ok 199 pem.ts > ECDH-ES P-521 X.509 Certificate Import
ok 200 pem.ts > ECDH-ES X25519 PKCS8 Private Key Import
ok 201 pem.ts > ECDH-ES X25519 SPKI Public Key Import
ok 202 pem.ts > Ed25519 PKCS8 Private Key Import
ok 203 pem.ts > Ed25519 SPKI Public Key Import
ok 204 pem.ts > Ed25519 X.509 Certificate Import
ok 205 pem.ts > EdDSA Ed25519 PKCS8 Private Key Import
ok 206 pem.ts > EdDSA Ed25519 SPKI Public Key Import
ok 207 pem.ts > EdDSA Ed25519 X.509 Certificate Import
ok 208 pem.ts > [not supported] ML-DSA-44 PKCS8 Private Key Import
ok 209 pem.ts > [not supported] ML-DSA-44 SPKI Public Key Import
ok 210 pem.ts > [not supported] ML-DSA-65 PKCS8 Private Key Import
ok 211 pem.ts > [not supported] ML-DSA-65 SPKI Public Key Import
ok 212 pem.ts > [not supported] ML-DSA-87 PKCS8 Private Key Import
ok 213 pem.ts > [not supported] ML-DSA-87 SPKI Public Key Import
ok 214 rsaes.ts > RSA-OAEP
ok 215 rsaes.ts > RSA-OAEP JWT
ok 216 rsaes.ts > RSA-OAEP-256
ok 217 rsaes.ts > RSA-OAEP-256 JWT
ok 218 rsaes.ts > RSA-OAEP-384
ok 219 rsaes.ts > RSA-OAEP-384 JWT
ok 220 rsaes.ts > RSA-OAEP-512
ok 221 rsaes.ts > RSA-OAEP-512 JWT
1..221
# pass 221
# skip 0
# todo 0
# fail 0
```

Please note that this description was generated by AI.

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
