### PR TITLE
fix(crypto): improve key import validation and HMAC key length handling

### DIFF
--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -15,7 +15,15 @@ path = "src/lib.rs"
 default = ["crypto-rust"]
 
 # Internal feature: enables DER parsing for SubtleCrypto key import/export
-_subtle-full = ["llrt_json", "const-oid", "der", "pkcs8", "spki"]
+_subtle-full = [
+  "llrt_json",
+  "const-oid",
+  "der",
+  "ed25519-dalek",
+  "pkcs8",
+  "spki",
+  "x25519-dalek",
+]
 
 # Internal feature: enables RustCrypto dependencies for key import/export
 _rustcrypto = [
@@ -26,7 +34,6 @@ _rustcrypto = [
   "cbc",
   "ctr",
   "ecdsa",
-  "ed25519-dalek",
   "elliptic-curve",
   "hkdf",
   "hmac",
@@ -36,7 +43,6 @@ _rustcrypto = [
   "p521",
   "pbkdf2",
   "sha1",
-  "x25519-dalek",
 ]
 
 crypto-rust = ["_rustcrypto"]

--- a/modules/llrt_crypto/src/provider/graviola.rs
+++ b/modules/llrt_crypto/src/provider/graviola.rs
@@ -368,7 +368,11 @@ impl CryptoProvider for GraviolaProvider {
     ) -> Result<super::EcImportResult, CryptoError> {
         Err(CryptoError::UnsupportedAlgorithm)
     }
-    fn import_ec_public_key_spki(&self, _der: &[u8]) -> Result<super::EcImportResult, CryptoError> {
+    fn import_ec_public_key_spki(
+        &self,
+        _der: &[u8],
+        _curve: EllipticCurve,
+    ) -> Result<super::EcImportResult, CryptoError> {
         Err(CryptoError::UnsupportedAlgorithm)
     }
     fn import_ec_private_key_pkcs8(

--- a/modules/llrt_crypto/src/provider/mod.rs
+++ b/modules/llrt_crypto/src/provider/mod.rs
@@ -304,7 +304,11 @@ pub trait CryptoProvider {
         data: &[u8],
         curve: EllipticCurve,
     ) -> Result<EcImportResult, CryptoError>;
-    fn import_ec_public_key_spki(&self, der: &[u8]) -> Result<EcImportResult, CryptoError>;
+    fn import_ec_public_key_spki(
+        &self,
+        der: &[u8],
+        curve: EllipticCurve,
+    ) -> Result<EcImportResult, CryptoError>;
     fn import_ec_private_key_pkcs8(&self, der: &[u8]) -> Result<EcImportResult, CryptoError>;
     fn import_ec_private_key_sec1(
         &self,
@@ -683,8 +687,12 @@ macro_rules! impl_hybrid_provider {
             ) -> Result<EcImportResult, CryptoError> {
                 rust::RustCryptoProvider.import_ec_public_key_sec1(d, c)
             }
-            fn import_ec_public_key_spki(&self, d: &[u8]) -> Result<EcImportResult, CryptoError> {
-                rust::RustCryptoProvider.import_ec_public_key_spki(d)
+            fn import_ec_public_key_spki(
+                &self,
+                d: &[u8],
+                c: EllipticCurve,
+            ) -> Result<EcImportResult, CryptoError> {
+                rust::RustCryptoProvider.import_ec_public_key_spki(d, c)
             }
             fn import_ec_private_key_pkcs8(&self, d: &[u8]) -> Result<EcImportResult, CryptoError> {
                 rust::RustCryptoProvider.import_ec_private_key_pkcs8(d)

--- a/modules/llrt_crypto/src/provider/openssl.rs
+++ b/modules/llrt_crypto/src/provider/openssl.rs
@@ -856,7 +856,11 @@ impl CryptoProvider for OpenSslProvider {
         })
     }
 
-    fn import_ec_public_key_spki(&self, der: &[u8]) -> Result<super::EcImportResult, CryptoError> {
+    fn import_ec_public_key_spki(
+        &self,
+        der: &[u8],
+        _curve: EllipticCurve,
+    ) -> Result<super::EcImportResult, CryptoError> {
         let pkey = PKey::public_key_from_der(der)
             .map_err(|e| CryptoError::InvalidKey(Some(e.to_string().into())))?;
         Ok(super::EcImportResult {

--- a/modules/llrt_crypto/src/provider/ring.rs
+++ b/modules/llrt_crypto/src/provider/ring.rs
@@ -412,7 +412,11 @@ impl CryptoProvider for RingProvider {
     ) -> Result<super::EcImportResult, CryptoError> {
         Err(CryptoError::UnsupportedAlgorithm)
     }
-    fn import_ec_public_key_spki(&self, _der: &[u8]) -> Result<super::EcImportResult, CryptoError> {
+    fn import_ec_public_key_spki(
+        &self,
+        _der: &[u8],
+        _curve: EllipticCurve,
+    ) -> Result<super::EcImportResult, CryptoError> {
         Err(CryptoError::UnsupportedAlgorithm)
     }
     fn import_ec_private_key_pkcs8(

--- a/modules/llrt_crypto/src/provider/rust/mod.rs
+++ b/modules/llrt_crypto/src/provider/rust/mod.rs
@@ -1100,21 +1100,41 @@ impl CryptoProvider for RustCryptoProvider {
     fn import_ec_public_key_sec1(
         &self,
         data: &[u8],
-        _curve: EllipticCurve,
+        curve: EllipticCurve,
     ) -> Result<super::EcImportResult, CryptoError> {
+        let key_data = match curve {
+            EllipticCurve::P256 => {
+                let public_key = p256::PublicKey::from_sec1_bytes(data)
+                    .map_err(|_| CryptoError::InvalidKey(None))?;
+                public_key.to_sec1_point(false).as_bytes().to_vec()
+            },
+            EllipticCurve::P384 => {
+                let public_key = p384::PublicKey::from_sec1_bytes(data)
+                    .map_err(|_| CryptoError::InvalidKey(None))?;
+                public_key.to_sec1_point(false).as_bytes().to_vec()
+            },
+            EllipticCurve::P521 => {
+                let public_key = p521::PublicKey::from_sec1_bytes(data)
+                    .map_err(|_| CryptoError::InvalidKey(None))?;
+                public_key.to_sec1_point(false).as_bytes().to_vec()
+            },
+        };
+
         Ok(super::EcImportResult {
-            key_data: data.to_vec(),
+            key_data,
             is_private: false,
         })
     }
 
-    fn import_ec_public_key_spki(&self, der: &[u8]) -> Result<super::EcImportResult, CryptoError> {
+    fn import_ec_public_key_spki(
+        &self,
+        der: &[u8],
+        curve: EllipticCurve,
+    ) -> Result<super::EcImportResult, CryptoError> {
         let spki = spki::SubjectPublicKeyInfoRef::try_from(der)
             .map_err(|_| CryptoError::InvalidKey(None))?;
-        Ok(super::EcImportResult {
-            key_data: spki.subject_public_key.raw_bytes().to_vec(),
-            is_private: false,
-        })
+        let point = spki.subject_public_key.raw_bytes();
+        self.import_ec_public_key_sec1(point, curve)
     }
 
     fn import_ec_private_key_pkcs8(
@@ -1233,7 +1253,7 @@ impl CryptoProvider for RustCryptoProvider {
         data: &[u8],
     ) -> Result<super::OkpImportResult, CryptoError> {
         if data.len() != 32 {
-            return Err(CryptoError::InvalidKey(None));
+            return Err(CryptoError::InvalidLength);
         }
         Ok(super::OkpImportResult {
             key_data: data.to_vec(),

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -4,7 +4,6 @@
 //! Unified key export implementation using CryptoProvider trait.
 
 use llrt_encoding::bytes_to_b64_url_safe_string;
-use llrt_utils::result::ResultExt;
 use rquickjs::{ArrayBuffer, Class, Ctx, Exception, Object, Result};
 
 use crate::provider::CryptoProvider;
@@ -13,6 +12,7 @@ use crate::CRYPTO_PROVIDER;
 use super::{
     crypto_key::KeyKind,
     key_algorithm::{KeyAlgorithm, KeyFormat},
+    util::ResultDomExt,
     CryptoKey,
 };
 
@@ -72,16 +72,16 @@ fn export_raw(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
         KeyAlgorithm::Aes { .. } | KeyAlgorithm::Hmac { .. } => Ok(key.handle.to_vec()),
         KeyAlgorithm::Ec { curve, .. } => CRYPTO_PROVIDER
             .export_ec_public_key_sec1(&key.handle, *curve, false)
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::Ed25519 => CRYPTO_PROVIDER
             .export_okp_public_key_raw(&key.handle, false)
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::X25519 => CRYPTO_PROVIDER
             .export_okp_public_key_raw(&key.handle, false)
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::Rsa { .. } => CRYPTO_PROVIDER
             .export_rsa_public_key_pkcs1(&key.handle)
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         _ => algorithm_export_error(ctx, &key.name, "raw"),
     }
 }
@@ -96,22 +96,22 @@ fn export_pkcs8(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
     match &key.algorithm {
         KeyAlgorithm::Ec { curve, .. } => CRYPTO_PROVIDER
             .export_ec_private_key_pkcs8(&key.handle, *curve)
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::Ed25519 => CRYPTO_PROVIDER
             .export_okp_private_key_pkcs8(
                 &key.handle,
                 const_oid::db::rfc8410::ID_ED_25519.as_bytes(),
             )
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::X25519 => CRYPTO_PROVIDER
             .export_okp_private_key_pkcs8(
                 &key.handle,
                 const_oid::db::rfc8410::ID_X_25519.as_bytes(),
             )
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::Rsa { .. } => CRYPTO_PROVIDER
             .export_rsa_private_key_pkcs8(&key.handle)
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         _ => algorithm_export_error(ctx, &key.name, "pkcs8"),
     }
 }
@@ -126,16 +126,16 @@ fn export_spki(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
     match &key.algorithm {
         KeyAlgorithm::Ec { curve, .. } => CRYPTO_PROVIDER
             .export_ec_public_key_spki(&key.handle, *curve)
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::Ed25519 => CRYPTO_PROVIDER
             .export_okp_public_key_spki(&key.handle, const_oid::db::rfc8410::ID_ED_25519.as_bytes())
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::X25519 => CRYPTO_PROVIDER
             .export_okp_public_key_spki(&key.handle, const_oid::db::rfc8410::ID_X_25519.as_bytes())
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         KeyAlgorithm::Rsa { .. } => CRYPTO_PROVIDER
             .export_rsa_public_key_spki(&key.handle)
-            .or_throw(ctx),
+            .or_throw_dom(ctx),
         _ => algorithm_export_error(ctx, &key.name, "spki"),
     }
 }
@@ -166,7 +166,7 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
         KeyAlgorithm::Ec { curve, .. } => {
             let jwk = CRYPTO_PROVIDER
                 .export_ec_jwk(&key.handle, *curve, key.kind == KeyKind::Private)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             obj.set("kty", "EC")?;
             obj.set("crv", curve.as_str())?;
             obj.set("x", bytes_to_b64_url_safe_string(&jwk.x))?;
@@ -178,10 +178,11 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
         KeyAlgorithm::Ed25519 => {
             let jwk = CRYPTO_PROVIDER
                 .export_okp_jwk(&key.handle, key.kind == KeyKind::Private, true)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             obj.set("kty", "OKP")?;
             obj.set("crv", "Ed25519")?;
             obj.set("x", bytes_to_b64_url_safe_string(&jwk.x))?;
+            obj.set("alg", "Ed25519")?;
             if let Some(d) = jwk.d {
                 obj.set("d", bytes_to_b64_url_safe_string(&d))?;
             }
@@ -189,7 +190,7 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
         KeyAlgorithm::X25519 => {
             let jwk = CRYPTO_PROVIDER
                 .export_okp_jwk(&key.handle, key.kind == KeyKind::Private, false)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             obj.set("kty", "OKP")?;
             obj.set("crv", "X25519")?;
             obj.set("x", bytes_to_b64_url_safe_string(&jwk.x))?;
@@ -200,7 +201,7 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
         KeyAlgorithm::Rsa { hash, .. } => {
             let jwk = CRYPTO_PROVIDER
                 .export_rsa_jwk(&key.handle, key.kind == KeyKind::Private)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             let alg_suffix = hash.as_numeric_str();
             let alg_prefix = match key.name.as_ref() {
                 "RSASSA-PKCS1-v1_5" => "RS",

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -10,6 +10,8 @@ use der::{
     Decode, Encode,
 };
 #[cfg(feature = "_subtle-full")]
+use ed25519_dalek::SigningKey;
+#[cfg(feature = "_subtle-full")]
 use llrt_encoding::bytes_from_b64_url_safe;
 use llrt_exceptions::DOMException;
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt, str_enum};
@@ -20,11 +22,13 @@ use rquickjs::{
 };
 #[cfg(feature = "_subtle-full")]
 use spki::{AlgorithmIdentifier, ObjectIdentifier};
+#[cfg(feature = "_subtle-full")]
+use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::{hash::HashAlgorithm, provider::parse_rsa_public_exponent};
 
 #[cfg(feature = "_subtle-full")]
-use super::algorithm_mismatch_error;
+use super::{algorithm_mismatch_error, util::DataError};
 use super::{
     algorithm_not_supported_error,
     crypto_key::KeyKind,
@@ -534,9 +538,13 @@ fn from_hmac<'js>(
             "Unsupported HMAC hash algorithm",
         ));
     }
-    let mut length: u16 = obj
-        .get_optional("length")?
-        .unwrap_or_else(|| (hash.block_len() * 8) as u16);
+    let mut length = match obj.get_optional::<_, u16>("length")? {
+        Some(length) => length,
+        None => match mode {
+            KeyAlgorithmMode::Import { .. } => 0,
+            _ => (hash.block_len() * 8) as u16,
+        },
+    };
 
     #[cfg(feature = "_subtle-full")]
     #[inline]
@@ -1062,10 +1070,7 @@ fn import_rsa_key<'js>(
 
     let (modulus_length, public_exponent) = match format {
         KeyFormatData::Jwk(object) => {
-            let kty: String = object.get_required("kty", "keyData")?;
-            if kty != "RSA" {
-                return algorithm_mismatch_error(ctx, algorithm_name);
-            }
+            validate_jwk_kty(ctx, &object, "RSA")?;
 
             if let Some(alg) = object.get_optional::<_, String>("alg")? {
                 let numeric_hash_str = match algorithm_name {
@@ -1082,36 +1087,29 @@ fn import_rsa_key<'js>(
                 }
             }
 
-            let n: String = object.get_required("n", "keyData")?;
-            let e: String = object.get_required("e", "keyData")?;
-            let n_bytes = bytes_from_b64_url_safe(n.as_bytes()).or_throw(ctx)?;
-            let e_bytes = bytes_from_b64_url_safe(e.as_bytes()).or_throw(ctx)?;
+            let n_bytes = get_jwk_required_bytes(ctx, &object, "n")?;
+            let e_bytes = get_jwk_required_bytes(ctx, &object, "e")?;
 
-            let result = if let Some(d) = object.get_optional::<_, String>("d")? {
-                let p: String = object.get_required("p", "keyData")?;
-                let q: String = object.get_required("q", "keyData")?;
-                let dp: String = object.get_required("dp", "keyData")?;
-                let dq: String = object.get_required("dq", "keyData")?;
-                let qi: String = object.get_required("qi", "keyData")?;
+            let d_bytes = get_jwk_optional_bytes(ctx, &object, "d")?;
 
-                let d_bytes = bytes_from_b64_url_safe(d.as_bytes()).or_throw(ctx)?;
-                let p_bytes = bytes_from_b64_url_safe(p.as_bytes()).or_throw(ctx)?;
-                let q_bytes = bytes_from_b64_url_safe(q.as_bytes()).or_throw(ctx)?;
-                let dp_bytes = bytes_from_b64_url_safe(dp.as_bytes()).or_throw(ctx)?;
-                let dq_bytes = bytes_from_b64_url_safe(dq.as_bytes()).or_throw(ctx)?;
-                let qi_bytes = bytes_from_b64_url_safe(qi.as_bytes()).or_throw(ctx)?;
+            let result = if let Some(ref d_bytes) = d_bytes {
+                let p_bytes = get_jwk_required_bytes(ctx, &object, "p")?;
+                let q_bytes = get_jwk_required_bytes(ctx, &object, "q")?;
+                let dp_bytes = get_jwk_required_bytes(ctx, &object, "dp")?;
+                let dq_bytes = get_jwk_required_bytes(ctx, &object, "dq")?;
+                let qi_bytes = get_jwk_required_bytes(ctx, &object, "qi")?;
 
                 let jwk = RsaJwkImport {
                     n: &n_bytes,
                     e: &e_bytes,
-                    d: Some(&d_bytes),
+                    d: Some(d_bytes),
                     p: Some(&p_bytes),
                     q: Some(&q_bytes),
                     dp: Some(&dp_bytes),
                     dq: Some(&dq_bytes),
                     qi: Some(&qi_bytes),
                 };
-                CRYPTO_PROVIDER.import_rsa_jwk(jwk).or_throw(ctx)?
+                CRYPTO_PROVIDER.import_rsa_jwk(jwk).or_throw_dom(ctx)?
             } else {
                 let jwk = RsaJwkImport {
                     n: &n_bytes,
@@ -1123,7 +1121,7 @@ fn import_rsa_key<'js>(
                     dq: None,
                     qi: None,
                 };
-                CRYPTO_PROVIDER.import_rsa_jwk(jwk).or_throw(ctx)?
+                CRYPTO_PROVIDER.import_rsa_jwk(jwk).or_throw_dom(ctx)?
             };
 
             *data = result.key_data;
@@ -1137,7 +1135,7 @@ fn import_rsa_key<'js>(
         KeyFormatData::Raw(object_bytes) => {
             let result = CRYPTO_PROVIDER
                 .import_rsa_public_key_pkcs1(object_bytes.as_bytes(ctx)?)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             *data = result.key_data;
             *kind = KeyKind::Public;
             (result.modulus_length as usize, result.public_exponent)
@@ -1147,7 +1145,7 @@ fn import_rsa_key<'js>(
             validate_oid(pk_info.algorithm.oid)?;
             let result = CRYPTO_PROVIDER
                 .import_rsa_private_key_pkcs8(object_bytes.as_bytes(ctx)?)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             *data = result.key_data;
             *kind = KeyKind::Private;
             (result.modulus_length as usize, result.public_exponent)
@@ -1158,7 +1156,7 @@ fn import_rsa_key<'js>(
             validate_oid(pk_info.algorithm.oid)?;
             let result = CRYPTO_PROVIDER
                 .import_rsa_public_key_spki(object_bytes.as_bytes(ctx)?)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             *data = result.key_data;
             *kind = KeyKind::Public;
             (result.modulus_length as usize, result.public_exponent)
@@ -1182,45 +1180,43 @@ fn import_symmetric_key<'js>(
 
     match format {
         KeyFormatData::Jwk(object) => {
-            let kty: String = object.get_required("kty", "keyData")?;
-            if kty == "oct" {
-                let k: String = object.get_required("k", "keyData")?;
-                let alg: String = object.get_required("alg", "keyData")?;
+            validate_jwk_kty(ctx, &object, "oct")?;
 
-                let prefix = &alg[..1];
+            let k: String = get_jwk_required_string(ctx, &object, "k")?;
+            let alg: String = get_jwk_required_string(ctx, &object, "alg")?;
 
-                match (prefix, hash) {
-                    //HMAC - HS256, HS512 etc
-                    ("H", Some(hash)) => {
-                        if &alg[2..] != hash.as_numeric_str() {
-                            return hash_mismatch_error(ctx, hash);
-                        }
-                    },
-                    //AES - A256KW, A256GCM, A256CRT, A512CBC etc
-                    ("A", None) => {
-                        //extract AES-{suffix}
-                        let aes_variant = &alg[4..];
+            let prefix = &alg[..1];
 
-                        if !algorithm_name.ends_with(aes_variant) {
-                            return algorithm_mismatch_error(ctx, algorithm_name);
-                        }
-                    },
-                    _ => return algorithm_mismatch_error(ctx, algorithm_name),
-                }
+            match (prefix, hash) {
+                //HMAC - HS256, HS512 etc
+                ("H", Some(hash)) => {
+                    if &alg[2..] != hash.as_numeric_str() {
+                        return hash_mismatch_error(ctx, hash);
+                    }
+                },
+                //AES - A256KW, A256GCM, A256CRT, A512CBC etc
+                ("A", None) => {
+                    //extract AES-{suffix}
+                    let aes_variant = &alg[4..];
 
-                *data = bytes_from_b64_url_safe(k.as_bytes()).or_throw(ctx)?;
-                return Ok(data.len() * 8);
+                    if !algorithm_name.ends_with(aes_variant) {
+                        return algorithm_mismatch_error(ctx, algorithm_name);
+                    }
+                },
+                _ => return algorithm_mismatch_error(ctx, algorithm_name),
             }
+
+            *data = bytes_from_b64_url_safe(k.as_bytes()).or_throw(ctx)?;
+            Ok(data.len() * 8)
         },
         KeyFormatData::Raw(object_bytes) => {
             let bytes = object_bytes.into_bytes(ctx)?;
 
             *data = bytes;
-            return Ok(data.len() * 8);
+            Ok(data.len() * 8)
         },
-        _ => {},
+        _ => algorithm_mismatch_error(ctx, algorithm_name),
     }
-    algorithm_mismatch_error(ctx, algorithm_name)
 }
 
 // EC algorithm OID for validation
@@ -1259,47 +1255,23 @@ fn import_ec_key<'js>(
 
     match format {
         KeyFormatData::Jwk(object) => {
-            let kty: String = object.get_required("kty", "keyData")?;
-            if kty != "EC" {
-                return algorithm_mismatch_error(ctx, algorithm_name);
-            }
+            validate_jwk_kty(ctx, &object, "EC")?;
 
-            let jwk_crv: String = object.get_required("crv", "keyData")?;
-            if curve_name != jwk_crv {
-                return Err(DOMException::not_supported_error(
-                    ctx,
-                    ["Key is using a ", curve_name].concat(),
-                ));
-            }
+            validate_jwk_use(ctx, &object, true)?;
 
-            let x: String = object.get_required("x", "keyData")?;
-            let y: String = object.get_required("y", "keyData")?;
-            let mut x_bytes = bytes_from_b64_url_safe(x.as_bytes()).or_throw(ctx)?;
-            let mut y_bytes = bytes_from_b64_url_safe(y.as_bytes()).or_throw(ctx)?;
+            validate_jwk_crv(ctx, &object, curve_name)?;
 
-            // Pad to coordinate length if needed
-            if x_bytes.len() < coord_len {
-                let mut padded = vec![0u8; coord_len - x_bytes.len()];
-                padded.extend_from_slice(&x_bytes);
-                x_bytes = padded;
-            }
-            if y_bytes.len() < coord_len {
-                let mut padded = vec![0u8; coord_len - y_bytes.len()];
-                padded.extend_from_slice(&y_bytes);
-                y_bytes = padded;
-            }
+            let x_bytes = get_jwk_required_bytes(ctx, &object, "x")?;
+            validate_jwk_bytes_len(ctx, algorithm_name, "x coordinate", &x_bytes, coord_len)?;
 
-            let d_bytes = if let Some(d) = object.get_optional::<_, String>("d")? {
-                let mut d_bytes = bytes_from_b64_url_safe(d.as_bytes()).or_throw(ctx)?;
-                if d_bytes.len() < coord_len {
-                    let mut padded = vec![0u8; coord_len - d_bytes.len()];
-                    padded.extend_from_slice(&d_bytes);
-                    d_bytes = padded;
-                }
-                Some(d_bytes)
-            } else {
-                None
-            };
+            let y_bytes = get_jwk_required_bytes(ctx, &object, "y")?;
+            validate_jwk_bytes_len(ctx, algorithm_name, "y coordinate", &y_bytes, coord_len)?;
+
+            let d_bytes = get_jwk_optional_bytes(ctx, &object, "d")?;
+
+            if let Some(ref d_bytes) = d_bytes {
+                validate_jwk_bytes_len(ctx, algorithm_name, "private key", d_bytes, coord_len)?;
+            }
 
             let jwk = EcJwkImport {
                 x: &x_bytes,
@@ -1307,7 +1279,9 @@ fn import_ec_key<'js>(
                 d: d_bytes.as_deref(),
             };
 
-            let result = CRYPTO_PROVIDER.import_ec_jwk(jwk, *curve).or_throw(ctx)?;
+            let result = CRYPTO_PROVIDER
+                .import_ec_jwk(jwk, *curve)
+                .or_throw_dom(ctx)?;
             *data = result.key_data;
             *kind = if result.is_private {
                 KeyKind::Private
@@ -1319,26 +1293,27 @@ fn import_ec_key<'js>(
             let bytes = object_bytes.as_bytes(ctx)?;
             let result = CRYPTO_PROVIDER
                 .import_ec_public_key_sec1(bytes, *curve)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             *data = result.key_data;
             *kind = KeyKind::Public;
         },
         KeyFormatData::Spki(object_bytes) => {
             let spki = spki::SubjectPublicKeyInfoRef::try_from(object_bytes.as_bytes(ctx)?)
-                .or_throw(ctx)?;
+                .or_throw_data_error(ctx)?;
             validate_oid(spki.algorithm.oid)?;
             let result = CRYPTO_PROVIDER
-                .import_ec_public_key_spki(object_bytes.as_bytes(ctx)?)
-                .or_throw(ctx)?;
+                .import_ec_public_key_spki(object_bytes.as_bytes(ctx)?, *curve)
+                .or_throw_dom(ctx)?;
             *data = result.key_data;
             *kind = KeyKind::Public;
         },
         KeyFormatData::Pkcs8(object_bytes) => {
-            let pkcs8 = PrivateKeyInfoRef::try_from(object_bytes.as_bytes(ctx)?).or_throw(ctx)?;
+            let pkcs8 = PrivateKeyInfoRef::try_from(object_bytes.as_bytes(ctx)?)
+                .or_throw_data_error(ctx)?;
             validate_oid(pkcs8.algorithm.oid)?;
             let result = CRYPTO_PROVIDER
                 .import_ec_private_key_pkcs8(object_bytes.as_bytes(ctx)?)
-                .or_throw(ctx)?;
+                .or_throw_dom(ctx)?;
             *data = result.key_data;
             *kind = KeyKind::Private;
         },
@@ -1365,29 +1340,25 @@ fn import_okp_key<'js>(
 
     match format {
         KeyFormatData::Jwk(object) => {
-            let crv: String = object.get_required("crv", "keyData")?;
-            if crv != algorithm_name {
-                return algorithm_mismatch_error(ctx, algorithm_name);
-            }
-            let x: String = object.get_required("x", "keyData")?;
-            let public_key = bytes_from_b64_url_safe(x.as_bytes()).or_throw(ctx)?;
+            validate_jwk_kty(ctx, &object, "OKP")?;
 
-            if public_key.len() != 32 {
-                return Err(DOMException::data_error(
-                    ctx,
-                    [algorithm_name, " public key must be 32 bytes"].concat(),
-                ));
+            validate_jwk_crv(ctx, &object, algorithm_name)?;
+
+            if is_ed25519 {
+                validate_jwk_alg(ctx, &object)?;
             }
 
-            if let Some(d) = object.get_optional::<_, String>("d")? {
-                let private_key = bytes_from_b64_url_safe(d.as_bytes()).or_throw(ctx)?;
+            validate_jwk_use(ctx, &object, is_ed25519)?;
 
-                if private_key.len() != 32 {
-                    return Err(DOMException::data_error(
-                        ctx,
-                        [algorithm_name, " private key must be 32 bytes"].concat(),
-                    ));
-                }
+            let public_key = get_jwk_required_bytes(ctx, &object, "x")?;
+            validate_jwk_bytes_len(ctx, algorithm_name, "public key", &public_key, 32)?;
+
+            let private_key = get_jwk_optional_bytes(ctx, &object, "d")?;
+
+            if let Some(private_key) = private_key {
+                validate_jwk_bytes_len(ctx, algorithm_name, "private key", &private_key, 32)?;
+
+                validate_okp_jwk_key_pair(ctx, &private_key, &public_key, is_ed25519)?;
 
                 if is_ed25519 {
                     // Ed25519 internal representation is the complete PKCS#8 DER.
@@ -1415,7 +1386,7 @@ fn import_okp_key<'js>(
         KeyFormatData::Raw(object_bytes) => {
             let bytes = object_bytes.into_bytes(ctx)?;
             if bytes.len() != 32 {
-                return Err(DOMException::not_supported_error(
+                return Err(DOMException::data_error(
                     ctx,
                     [algorithm_name, " keys must be 32 bytes long"].concat(),
                 ));
@@ -1425,16 +1396,24 @@ fn import_okp_key<'js>(
         },
         KeyFormatData::Spki(object_bytes) => {
             let spki = spki::SubjectPublicKeyInfoRef::try_from(object_bytes.as_bytes(ctx)?)
-                .or_throw(ctx)?;
+                .or_throw_data_error(ctx)?;
             validate_oid(spki.algorithm.oid)?;
-            *data = spki.subject_public_key.raw_bytes().into();
+
+            let public_key = spki.subject_public_key.raw_bytes();
+            if public_key.len() != 32 {
+                return Err(DOMException::data_error(
+                    ctx,
+                    [algorithm_name, " public key must be 32 bytes"].concat(),
+                ));
+            }
+
+            *data = public_key.to_vec();
             *kind = KeyKind::Public;
         },
         KeyFormatData::Pkcs8(object_bytes) => {
             let bytes = object_bytes.into_bytes(ctx)?;
-            let pkcs8 = PrivateKeyInfoRef::try_from(bytes.as_slice()).or_throw(ctx)?;
+            let pkcs8 = PrivateKeyInfoRef::try_from(bytes.as_slice()).or_throw_data_error(ctx)?;
             validate_oid(pkcs8.algorithm.oid)?;
-
             if is_ed25519 {
                 // Ed25519 internal representation is the complete PKCS#8 DER.
                 *data = bytes;
@@ -1444,7 +1423,6 @@ fn import_okp_key<'js>(
                     .or_throw(ctx)?
                     .as_bytes()
                     .to_vec();
-
                 if data.len() != 32 {
                     return Err(DOMException::data_error(
                         ctx,
@@ -1452,11 +1430,135 @@ fn import_okp_key<'js>(
                     ));
                 }
             }
-
             *kind = KeyKind::Private;
         },
     }
 
+    Ok(())
+}
+
+#[cfg(feature = "_subtle-full")]
+fn get_jwk_required_string<'js>(
+    ctx: &Ctx<'js>,
+    object: &Object<'js>,
+    name: &str,
+) -> Result<String> {
+    object
+        .get_required(name, "keyData")
+        .or_throw_data_error(ctx)
+}
+
+#[cfg(feature = "_subtle-full")]
+fn get_jwk_required_bytes<'js>(
+    ctx: &Ctx<'js>,
+    object: &Object<'js>,
+    name: &str,
+) -> Result<Vec<u8>> {
+    let value = get_jwk_required_string(ctx, object, name)?;
+    bytes_from_b64_url_safe(value.as_bytes()).or_throw_data_error(ctx)
+}
+
+#[cfg(feature = "_subtle-full")]
+fn get_jwk_optional_bytes<'js>(
+    ctx: &Ctx<'js>,
+    object: &Object<'js>,
+    name: &str,
+) -> Result<Option<Vec<u8>>> {
+    let value = object.get_optional::<_, String>(name)?;
+    value
+        .map(|value| bytes_from_b64_url_safe(value.as_bytes()).or_throw_data_error(ctx))
+        .transpose()
+}
+
+#[cfg(feature = "_subtle-full")]
+fn validate_jwk_kty<'js>(ctx: &Ctx<'js>, object: &Object<'js>, expected: &str) -> Result<()> {
+    let kty = get_jwk_required_string(ctx, object, "kty")?;
+    if kty != expected {
+        return Err(DOMException::data_error(
+            ctx,
+            ["JWK 'kty' parameter must be '", expected, "'"].concat(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "_subtle-full")]
+fn validate_jwk_crv<'js>(ctx: &Ctx<'js>, object: &Object<'js>, expected: &str) -> Result<()> {
+    let crv = get_jwk_required_string(ctx, object, "crv")?;
+    if crv != expected {
+        return Err(DOMException::data_error(
+            ctx,
+            ["JWK 'crv' parameter must be '", expected, "'"].concat(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "_subtle-full")]
+fn validate_jwk_use(ctx: &Ctx<'_>, object: &Object<'_>, is_ed25519: bool) -> Result<()> {
+    if let Some(use_) = object.get_optional::<_, String>("use")? {
+        let expected = if is_ed25519 { "sig" } else { "enc" };
+        if use_ != expected {
+            return Err(DOMException::data_error(
+                ctx,
+                "JWK 'use' parameter is invalid",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "_subtle-full")]
+fn validate_jwk_alg(ctx: &Ctx<'_>, object: &Object<'_>) -> Result<()> {
+    if let Some(alg) = object.get_optional::<_, String>("alg")? {
+        if alg != "Ed25519" && alg != "EdDSA" {
+            return Err(DOMException::data_error(
+                ctx,
+                "JWK 'alg' parameter is invalid",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "_subtle-full")]
+fn validate_jwk_bytes_len(
+    ctx: &Ctx<'_>,
+    algorithm_name: &str,
+    field: &str,
+    bytes: &[u8],
+    expected: usize,
+) -> Result<()> {
+    if bytes.len() != expected {
+        return Err(DOMException::data_error(
+            ctx,
+            [algorithm_name, " JWK ", field, " has invalid length"].concat(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "_subtle-full")]
+fn validate_okp_jwk_key_pair<'js>(
+    ctx: &Ctx<'js>,
+    private_key: &[u8],
+    public_key: &[u8],
+    is_ed25519: bool,
+) -> Result<()> {
+    let derived_public_key = if is_ed25519 {
+        let secret_key: [u8; 32] = private_key.try_into().or_throw_data_error(ctx)?;
+        SigningKey::from_bytes(&secret_key)
+            .verifying_key()
+            .to_bytes()
+            .to_vec()
+    } else {
+        let secret_key: [u8; 32] = private_key.try_into().or_throw_data_error(ctx)?;
+        let secret = StaticSecret::from(secret_key);
+        PublicKey::from(&secret).as_bytes().to_vec()
+    };
+    if derived_public_key.as_slice() != public_key {
+        return Err(DOMException::data_error(ctx, "JWK key pair is invalid"));
+    }
     Ok(())
 }
 
@@ -1488,4 +1590,19 @@ pub fn hash_mismatch_error<T>(ctx: &Ctx<'_>, hash: &HashAlgorithm) -> Result<T> 
         ctx,
         ["Algorithm hash expected to be ", hash.as_str()].concat(),
     ))
+}
+
+#[cfg(feature = "_subtle-full")]
+trait DataErrorResultExt<T> {
+    fn or_throw_data_error(self, ctx: &Ctx<'_>) -> Result<T>;
+}
+
+#[cfg(feature = "_subtle-full")]
+impl<T, E> DataErrorResultExt<T> for std::result::Result<T, E>
+where
+    E: std::fmt::Display,
+{
+    fn or_throw_data_error(self, ctx: &Ctx<'_>) -> Result<T> {
+        self.map_err(|e| DataError(e.to_string())).or_throw_dom(ctx)
+    }
 }

--- a/modules/llrt_crypto/src/subtle/util.rs
+++ b/modules/llrt_crypto/src/subtle/util.rs
@@ -67,6 +67,16 @@ impl<E: Display> IntoDomException for NotSupportedError<E> {
     }
 }
 
+#[allow(dead_code)]
+pub struct DataError<E>(pub E);
+
+#[allow(dead_code)]
+impl<E: Display> IntoDomException for DataError<E> {
+    fn into_dom_exception(self, ctx: &Ctx, msg: &str) -> Error {
+        DOMException::data_error(ctx, with_message(self.0, msg))
+    }
+}
+
 fn with_message<E: Display>(err: E, msg: &str) -> String {
     if msg.is_empty() {
         err.to_string()

--- a/tests/wpt/WebCryptoAPI.import_export.test.ts
+++ b/tests/wpt/WebCryptoAPI.import_export.test.ts
@@ -1,6 +1,3 @@
 import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
 
-runSuite(import.meta.url, runTestDynamic, [
-  // Enable the remaining import/export WPTs separately as support lands.
-  /^(?!rsa_importKey\.https\.any\.js$)/,
-]);
+runSuite(import.meta.url, runTestDynamic);

--- a/tests/wpt/WebCryptoAPI.wrapKey_unwrapKey.test.ts
+++ b/tests/wpt/WebCryptoAPI.wrapKey_unwrapKey.test.ts
@@ -1,0 +1,8 @@
+import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
+
+runSuite(import.meta.url, runTestDynamic, [
+  [
+    "wrapKey_unwrapKey.https.any.js",
+    ["[setup] Key import/export format must be 'jwk','raw','spki' or 'pkcs8'"], // 'raw-secret' is not supported.
+  ],
+]);


### PR DESCRIPTION
### Issue # (if available)

Fixed #968 

### Description of changes

This PR improves WebCrypto `importKey()` handling for EC and OKP keys and fixes related interoperability issues identified by Web Platform Tests (WPT). We are also simultaneously fixing issues with `wrapKey` and `unwrapKey`, which share components with `importKey`, `exportKey`, `encrypt`, and `decrypt`.

The main changes are:

- Improve JWK validation for EC, Ed25519, and X25519 keys
- Validate EC public keys imported from SEC1 and SPKI formats
- Fix HMAC key length handling during `importKey()`
- Ensure malformed key material is reported with the appropriate `DOMException` type

### Changes

#### JWK validation

Strengthened JWK validation for EC and OKP keys during `importKey()`.

##### EC

The following JWK parameters are now validated:

- `kty` must be `EC`
- `crv` must match the requested named curve
- `use` must be compatible with the key type
- `x` and `y` must be present and have the expected length
- `d`, when present, must have the expected length

For EC private JWKs, the existing provider import path is used after the JWK structure and parameter validation.

##### Ed25519 / X25519

Added validation for:

- `kty` (`OKP`)
- `crv`
- `use`
- `alg` for Ed25519
- `x` length
- `d` length

For private JWKs, the public key derived from the private key is also compared with the supplied `x` parameter to reject invalid key pairs.

Ed25519 and X25519 retain their respective internal representations after validation.

#### EC public key import

Improved EC public key import for SEC1 and SPKI formats.

`import_ec_public_key_sec1()` now:

- Parses SEC1 encoded public points using the curve-specific RustCrypto implementation
- Rejects invalid EC points as `CryptoError::InvalidKey`
- Normalizes the imported public key to an uncompressed SEC1 point

`import_ec_public_key_spki()` now:

- Parses the SubjectPublicKeyInfo structure
- Extracts the contained SEC1 public point
- Reuses the SEC1 import/validation path

This also avoids duplicating EC point validation between SPKI and SEC1 imports.

#### HMAC key length handling

Fixed the default HMAC key length used by `importKey()`.

Previously, the default `length` handling could incorrectly use the hash block size during HMAC key import.

For `KeyAlgorithmMode::Import`, the initial length is now `0` when the `length` parameter is omitted, allowing the imported key length to be determined from the supplied key material rather than incorrectly defaulting to the hash block length.

The existing behavior for other HMAC operations remains unchanged.

#### Error handling

Adjusted JWK validation and key parsing so malformed key data is reported using the appropriate WebCrypto `DOMException`, particularly `DataError` for invalid JWK parameters and key material.

This includes cases such as:

- Missing required JWK parameters
- Invalid `kty` / `crv`
- Invalid `use` / `alg`
- Invalid coordinate or key lengths
- Invalid EC/OKP key pairs
- Invalid encoded EC public keys

### Tests

The changes were validated against the relevant WebCrypto WPT `import_export` tests, including:

- EC `importKey()` failure cases for ECDH
- EC `importKey()` failure cases for ECDSA
- Ed25519 JWK and raw/SPKI import cases
- X25519 JWK and raw/SPKI import cases

The previously failing JWK import/export tests now pass, including both invalid-parameter and valid JWK cases.
Furthermore, this modification did not cause any regressions in the `jose` TAP tests.

### Motivation

These changes improve compatibility with the WebCrypto API behavior expected by WPT and make the key import paths more strict about validating key metadata and key material before passing it to the underlying crypto provider.


Please note that this description was generated by AI.

---

### Checklist

- [x] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [x] Added relevant type info in `types/` directory
- [x] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
