### PR TITLE
ci: pin the nightly toolchain so upstream regressions don't break every build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ TARGET_darwin_x86_64 = x86_64-apple-darwin
 TARGET_darwin_arm64 = aarch64-apple-darwin
 TARGET_windows_x86_64 = x86_64-pc-windows-gnu
 TARGET_windows_arm64 = aarch64-is-not-yet-supported
-RUST_VERSION = nightly
+# Pinned nightly. LLRT needs nightly for -Z build-std (see .cargo/config.toml),
+# and an unpinned channel means any upstream nightly regression breaks every
+# build. Bump this deliberately after checking the new nightly builds std.
+RUST_VERSION = nightly-2026-08-26
 TOOLCHAIN = +$(RUST_VERSION)
 BUILD_ARG = $(TOOLCHAIN) build -r
 BUILD_DIR = ./target/release

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@ TARGET_darwin_x86_64 = x86_64-apple-darwin
 TARGET_darwin_arm64 = aarch64-apple-darwin
 TARGET_windows_x86_64 = x86_64-pc-windows-gnu
 TARGET_windows_arm64 = aarch64-is-not-yet-supported
-# Pinned nightly. LLRT needs nightly for -Z build-std (see .cargo/config.toml),
-# and an unpinned channel means any upstream nightly regression breaks every
-# build. Bump this deliberately after checking the new nightly builds std.
 RUST_VERSION = nightly-2026-08-26
 TOOLCHAIN = +$(RUST_VERSION)
 BUILD_ARG = $(TOOLCHAIN) build -r

--- a/llrt_modules/src/module/loader.rs
+++ b/llrt_modules/src/module/loader.rs
@@ -101,7 +101,6 @@ pub fn module_hook_load<'js>(ctx: &Ctx<'js>, name: &str) -> Result<(bool, bool, 
     Ok((short_circuit, next_load, source))
 }
 
-#[allow(dependency_on_unit_never_type_fallback)]
 fn call_load_hooks<'js>(
     ctx: &Ctx<'js>,
     hooks: &Rc<Vec<Hook<'js>>>,

--- a/llrt_modules/src/module/resolver.rs
+++ b/llrt_modules/src/module/resolver.rs
@@ -93,7 +93,6 @@ pub fn module_hook_resolve<'js>(ctx: &Ctx<'js>, x: &str, y: &str) -> Result<(boo
     Ok((short_circuit, next_resolve, url))
 }
 
-#[allow(dependency_on_unit_never_type_fallback)]
 fn call_resolve_hooks<'js>(
     ctx: &Ctx<'js>,
     hooks: &Rc<Vec<Hook<'js>>>,


### PR DESCRIPTION
### Issue # (if available)

None — found while investigating the failing builds on #1743.

### Description of changes

Pin `RUST_VERSION` to `nightly-2026-08-26` so an upstream nightly regression can't break every build at once, and drop the `#[allow]` for the now-removed `dependency_on_unit_never_type_fallback` lint (same fix as #1739, needed here to get a green run).

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
