### PR TITLE
Modern Algorithms for the Web Cryptography API

### DIFF
--- a/API.md
+++ b/API.md
@@ -188,23 +188,41 @@ Lightweight and fast hash classes for LLRT.
 
 ## crypto.subtle
 
-[subtle.decrypt](https://nodejs.org/api/webcrypto.html#subtledecryptalgorithm-key-data)
+[subtle.decrypt](https://w3c.github.io/webcrypto/#SubtleCrypto-method-decrypt)
 
-[subtle.deriveBits](https://nodejs.org/api/webcrypto.html#subtlederivebitsalgorithm-basekey-length)
+[subtle.decapsulateBits](https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-decapsulateBits)
 
-[subtle.digest](https://nodejs.org/api/webcrypto.html#subtledigestalgorithm-data)
+[subtle.decapsulateKey](https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-decapsulateKey)
 
-[subtle.encrypt](https://nodejs.org/api/webcrypto.html#subtleencryptalgorithm-key-data)
+[subtle.deriveBits](https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits)
 
-[subtle.exportKey](https://nodejs.org/api/webcrypto.html#subtleexportkeyformat-key)
+[subtle.deriveKey](https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveKey)
 
-[subtle.generateKey](https://nodejs.org/api/webcrypto.html#subtlegeneratekeyalgorithm-extractable-keyusages)
+[subtle.digest](https://w3c.github.io/webcrypto/#SubtleCrypto-method-digest)
 
-[subtle.importKey](https://nodejs.org/api/webcrypto.html#subtleimportkeyformat-keydata-algorithm-extractable-keyusages)
+[subtle.encapsulateBits](https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-encapsulateBits)
 
-[subtle.sign](https://nodejs.org/api/webcrypto.html#subtlesignalgorithm-key-data)
+[subtle.encapsulateKey](https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-encapsulateKey)
 
-[subtle.verify](https://nodejs.org/api/webcrypto.html#subtleverifyalgorithm-key-signature-datah)
+[subtle.encrypt](https://w3c.github.io/webcrypto/#SubtleCrypto-method-encrypt)
+
+[subtle.exportKey](https://w3c.github.io/webcrypto/#SubtleCrypto-method-exportKey)
+
+[subtle.generateKey](https://w3c.github.io/webcrypto/#SubtleCrypto-method-generateKey)
+
+[subtle.getPublicKey](https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey)
+
+[subtle.importKey](https://w3c.github.io/webcrypto/#SubtleCrypto-method-importKey)
+
+[subtle.sign](https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign)
+
+[subtle.unwrapKey](https://w3c.github.io/webcrypto/#SubtleCrypto-method-unwrapKey)
+
+[subtle.verify](https://w3c.github.io/webcrypto/#SubtleCrypto-method-verify)
+
+[subtle.wrapKey](https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey)
+
+[SubtleCrypto.supports](https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-supports)
 
 ## dgram
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common",
+ "rand_core",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +1923,7 @@ dependencies = [
  "llrt_utils",
  "md-5",
  "ml-dsa",
+ "ml-kem",
  "once_cell",
  "openssl",
  "openssl-sys",
@@ -2487,6 +2498,21 @@ dependencies = [
  "pkcs8",
  "shake",
  "signature",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "const-oid",
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8",
+ "rand_core",
+ "sha3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cshake"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6250a2d96a09edbe8e75ed29c87d05512ee2cbb24c7e8c684657f7930ffd3c6"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "ctr"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,6 +1878,7 @@ dependencies = [
  "const-oid",
  "crc32c",
  "crc32fast",
+ "cshake",
  "ctr",
  "ctutils",
  "der",
@@ -1876,6 +1888,7 @@ dependencies = [
  "graviola",
  "hkdf",
  "hmac",
+ "keccak",
  "llrt_buffer",
  "llrt_context",
  "llrt_encoding",
@@ -1899,6 +1912,7 @@ dependencies = [
  "sha1",
  "sha3",
  "spki",
+ "sponge-cursor",
  "x25519-dalek",
 ]
 
@@ -3481,6 +3495,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1897,7 @@ dependencies = [
  "rquickjs",
  "rsa",
  "sha1",
+ "sha3",
  "spki",
  "x25519-dalek",
 ]
@@ -3332,6 +3343,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "ctutils",
  "subtle",
  "typenum",
  "zeroize",
@@ -1911,6 +1912,7 @@ dependencies = [
  "llrt_test",
  "llrt_utils",
  "md-5",
+ "ml-dsa",
  "once_cell",
  "openssl",
  "openssl-sys",
@@ -2469,6 +2471,33 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8",
+ "shake",
+ "signature",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -3391,6 +3420,17 @@ checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest",
  "keccak",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,8 +336,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher",
  "cpufeatures",
  "rand_core",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
 ]
 
 [[package]]
@@ -1875,6 +1888,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "cbc",
+ "chacha20poly1305",
  "const-oid",
  "crc32c",
  "crc32fast",
@@ -2786,6 +2800,16 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures",
+ "universal-hash",
+]
 
 [[package]]
 name = "polyval"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
  "zeroize",
 ]
 
@@ -2933,6 +2934,7 @@ checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
  "primefield",
+ "serdect",
  "wnaf",
 ]
 

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -32,8 +32,11 @@ _modern-webcrypto = [
   "keccak",
   "ml-dsa",
   "ml-kem",
+  "p256",
+  "p384",
   "sha3",
   "sponge-cursor",
+  "x25519-dalek",
 ]
 
 # Internal feature: enables RustCrypto dependencies for key import/export
@@ -135,11 +138,13 @@ rsa = { version = "0.10.0-rc.18", features = [
   "encoding",
 ], default-features = false, optional = true }
 p256 = { version = "0.14", features = [
+  "alloc",
   "ecdh",
   "ecdsa",
   "pkcs8",
 ], default-features = false, optional = true }
 p384 = { version = "0.14.0-rc.15", features = [
+  "alloc",
   "ecdh",
   "ecdsa",
   "pkcs8",

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -25,6 +25,9 @@ _subtle-full = [
   "x25519-dalek",
 ]
 
+# Internal feature: enables modern Web Cryptography algorithms
+_modern-webcrypto = ["sha3"]
+
 # Internal feature: enables RustCrypto dependencies for key import/export
 _rustcrypto = [
   "_subtle-full",
@@ -45,12 +48,12 @@ _rustcrypto = [
   "sha1",
 ]
 
-crypto-rust = ["_rustcrypto"]
-crypto-ring = ["ring"]
-crypto-ring-rust = ["ring", "_rustcrypto"]
-crypto-graviola = ["graviola"]
-crypto-graviola-rust = ["graviola", "_rustcrypto"]
-crypto-openssl = ["openssl-sys", "openssl", "_subtle-full"]
+crypto-rust = ["_rustcrypto", "_modern-webcrypto"]
+crypto-ring = ["ring", "_modern-webcrypto"]
+crypto-ring-rust = ["ring", "_rustcrypto", "_modern-webcrypto"]
+crypto-graviola = ["graviola", "_modern-webcrypto"]
+crypto-graviola-rust = ["graviola", "_rustcrypto", "_modern-webcrypto"]
+crypto-openssl = ["openssl-sys", "openssl", "_subtle-full", "_modern-webcrypto"]
 
 [dependencies]
 crc32c = { version = "0.6", default-features = false }
@@ -127,6 +130,7 @@ pkcs8 = { version = "0.11", default-features = false, features = [
   "alloc",
 ], optional = true }
 sha1 = { version = "0.11", features = ["oid"], default-features = false, optional = true }
+sha3 = { version = "0.11.0-rc.8", default-features = false, optional = true }
 spki = { version = "0.8", features = [
   "alloc",
 ], default-features = false, optional = true }

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -123,12 +123,12 @@ elliptic-curve = { version = "0.14", features = [
 hkdf = { version = "0.13", default-features = false, optional = true }
 hmac = { version = "0.13", default-features = false, optional = true }
 keccak = { version = "0.2", default-features = false, optional = true }
-ml-dsa = { version = "0.1.1", features = [
+ml-dsa = { version = "0.1", features = [
   "alloc",
   "pkcs8",
   "rand_core",
 ], default-features = false, optional = true }
-ml-kem = { version = "0.3.2", features = [
+ml-kem = { version = "0.3", features = [
   "alloc",
   "pkcs8",
 ], default-features = false, optional = true }
@@ -160,7 +160,7 @@ pkcs8 = { version = "0.11", default-features = false, features = [
 ], optional = true }
 sponge-cursor = { version = "0.1", default-features = false, optional = true }
 sha1 = { version = "0.11", features = ["oid"], default-features = false, optional = true }
-sha3 = { version = "0.11.0-rc.8", default-features = false, optional = true }
+sha3 = { version = "0.11", default-features = false, optional = true }
 spki = { version = "0.8", features = [
   "alloc",
 ], default-features = false, optional = true }

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -26,7 +26,13 @@ _subtle-full = [
 ]
 
 # Internal feature: enables modern Web Cryptography algorithms
-_modern-webcrypto = ["cshake", "keccak", "sha3", "sponge-cursor"]
+_modern-webcrypto = [
+  "chacha20poly1305",
+  "cshake",
+  "keccak",
+  "sha3",
+  "sponge-cursor",
+]
 
 # Internal feature: enables RustCrypto dependencies for key import/export
 _rustcrypto = [
@@ -85,6 +91,9 @@ aes-kw = { version = "0.3", features = [
   "oid",
 ], default-features = false, optional = true }
 cbc = { version = "0.2", features = ["alloc"], optional = true }
+chacha20poly1305 = { version = "0.11", features = [
+  "alloc",
+], default-features = false, optional = true }
 cshake = { version = "0.2", features = [
   "alloc",
 ], default-features = false, optional = true }

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -26,7 +26,7 @@ _subtle-full = [
 ]
 
 # Internal feature: enables modern Web Cryptography algorithms
-_modern-webcrypto = ["sha3"]
+_modern-webcrypto = ["cshake", "keccak", "sha3", "sponge-cursor"]
 
 # Internal feature: enables RustCrypto dependencies for key import/export
 _rustcrypto = [
@@ -85,6 +85,9 @@ aes-kw = { version = "0.3", features = [
   "oid",
 ], default-features = false, optional = true }
 cbc = { version = "0.2", features = ["alloc"], optional = true }
+cshake = { version = "0.2", features = [
+  "alloc",
+], default-features = false, optional = true }
 const-oid = { version = "0.10", features = [
   "db",
 ], default-features = false, optional = true }
@@ -105,6 +108,7 @@ elliptic-curve = { version = "0.14", features = [
 ], default-features = false, optional = true }
 hkdf = { version = "0.13", default-features = false, optional = true }
 hmac = { version = "0.13", default-features = false, optional = true }
+keccak = { version = "0.2", default-features = false, optional = true }
 rsa = { version = "0.10.0-rc.18", features = [
   "std",
   "sha2",
@@ -129,6 +133,7 @@ pbkdf2 = { version = "0.13", default-features = false, optional = true }
 pkcs8 = { version = "0.11", default-features = false, features = [
   "alloc",
 ], optional = true }
+sponge-cursor = { version = "0.1", default-features = false, optional = true }
 sha1 = { version = "0.11", features = ["oid"], default-features = false, optional = true }
 sha3 = { version = "0.11.0-rc.8", default-features = false, optional = true }
 spki = { version = "0.8", features = [

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -31,6 +31,7 @@ _modern-webcrypto = [
   "cshake",
   "keccak",
   "ml-dsa",
+  "ml-kem",
   "sha3",
   "sponge-cursor",
 ]
@@ -123,6 +124,10 @@ ml-dsa = { version = "0.1.1", features = [
   "alloc",
   "pkcs8",
   "rand_core",
+], default-features = false, optional = true }
+ml-kem = { version = "0.3.2", features = [
+  "alloc",
+  "pkcs8",
 ], default-features = false, optional = true }
 rsa = { version = "0.10.0-rc.18", features = [
   "std",

--- a/modules/llrt_crypto/Cargo.toml
+++ b/modules/llrt_crypto/Cargo.toml
@@ -30,6 +30,7 @@ _modern-webcrypto = [
   "chacha20poly1305",
   "cshake",
   "keccak",
+  "ml-dsa",
   "sha3",
   "sponge-cursor",
 ]
@@ -118,6 +119,11 @@ elliptic-curve = { version = "0.14", features = [
 hkdf = { version = "0.13", default-features = false, optional = true }
 hmac = { version = "0.13", default-features = false, optional = true }
 keccak = { version = "0.2", default-features = false, optional = true }
+ml-dsa = { version = "0.1.1", features = [
+  "alloc",
+  "pkcs8",
+  "rand_core",
+], default-features = false, optional = true }
 rsa = { version = "0.10.0-rc.18", features = [
   "std",
   "sha2",

--- a/modules/llrt_crypto/src/lib.rs
+++ b/modules/llrt_crypto/src/lib.rs
@@ -51,9 +51,10 @@ use rquickjs::{
 };
 pub use subtle::CryptoKey;
 use subtle::{
-    subtle_decrypt, subtle_derive_bits, subtle_derive_key, subtle_digest, subtle_encrypt,
-    subtle_export_key, subtle_generate_key, subtle_import_key, subtle_sign, subtle_unwrap_key,
-    subtle_verify, subtle_wrap_key, SubtleCrypto,
+    subtle_decapsulate_bits, subtle_decapsulate_key, subtle_decrypt, subtle_derive_bits,
+    subtle_derive_key, subtle_digest, subtle_encapsulate_bits, subtle_encapsulate_key,
+    subtle_encrypt, subtle_export_key, subtle_generate_key, subtle_import_key, subtle_sign,
+    subtle_unwrap_key, subtle_verify, subtle_wrap_key, SubtleCrypto,
 };
 
 use self::{
@@ -290,11 +291,21 @@ pub fn init(ctx: &Ctx<'_>) -> Result<()> {
     Class::<CryptoKey>::define(&globals)?;
 
     let subtle = Class::instance(ctx.clone(), SubtleCrypto {})?;
+    subtle.set(
+        "decapsulateBits",
+        Func::from(Async(subtle_decapsulate_bits)),
+    )?;
+    subtle.set("decapsulateKey", Func::from(Async(subtle_decapsulate_key)))?;
     subtle.set("decrypt", Func::from(Async(subtle_decrypt)))?;
     subtle.set("deriveKey", Func::from(Async(subtle_derive_key)))?;
     subtle.set("deriveBits", Func::from(Async(subtle_derive_bits)))?;
     subtle.set("digest", Func::from(Async(subtle_digest)))?;
     subtle.set("encrypt", Func::from(Async(subtle_encrypt)))?;
+    subtle.set(
+        "encapsulateBits",
+        Func::from(Async(subtle_encapsulate_bits)),
+    )?;
+    subtle.set("encapsulateKey", Func::from(Async(subtle_encapsulate_key)))?;
     subtle.set("exportKey", Func::from(Async(subtle_export_key)))?;
     subtle.set("generateKey", Func::from(Async(subtle_generate_key)))?;
     subtle.set("importKey", Func::from(Async(subtle_import_key)))?;

--- a/modules/llrt_crypto/src/provider/mod.rs
+++ b/modules/llrt_crypto/src/provider/mod.rs
@@ -134,9 +134,25 @@ pub trait SimpleDigest: Send {
 }
 
 pub const MAX_HMAC_KEY_LENGTH_BITS: u32 = 1024;
-
 pub(crate) fn hmac_length_is_byte_aligned(length_bits: u32) -> bool {
     length_bits.is_multiple_of(8)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MlDsaVariant {
+    MlDsa44,
+    MlDsa65,
+    MlDsa87,
+}
+
+impl MlDsaVariant {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::MlDsa44 => "ML-DSA-44",
+            Self::MlDsa65 => "ML-DSA-65",
+            Self::MlDsa87 => "ML-DSA-87",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/modules/llrt_crypto/src/provider/mod.rs
+++ b/modules/llrt_crypto/src/provider/mod.rs
@@ -32,6 +32,9 @@ mod openssl;
 #[cfg(any(feature = "crypto-ring", feature = "crypto-ring-rust"))]
 mod ring;
 
+#[cfg(feature = "_modern-webcrypto")]
+pub(crate) mod modern;
+
 #[cfg(feature = "_rustcrypto")]
 mod rust;
 

--- a/modules/llrt_crypto/src/provider/mod.rs
+++ b/modules/llrt_crypto/src/provider/mod.rs
@@ -155,6 +155,23 @@ impl MlDsaVariant {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MlKemVariant {
+    MlKem512,
+    MlKem768,
+    MlKem1024,
+}
+
+impl MlKemVariant {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::MlKem512 => "ML-KEM-512",
+            Self::MlKem768 => "ML-KEM-768",
+            Self::MlKem1024 => "ML-KEM-1024",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 pub enum AesMode {

--- a/modules/llrt_crypto/src/provider/mod.rs
+++ b/modules/llrt_crypto/src/provider/mod.rs
@@ -172,6 +172,62 @@ impl MlKemVariant {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HybridKemVariant {
+    MlKem768P256,
+    MlKem768X25519,
+    MlKem1024P384,
+}
+
+impl HybridKemVariant {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::MlKem768P256 => "MLKEM768-P256",
+            Self::MlKem768X25519 => "MLKEM768-X25519",
+            Self::MlKem1024P384 => "MLKEM1024-P384",
+        }
+    }
+
+    pub const fn ml_kem_variant(self) -> MlKemVariant {
+        match self {
+            Self::MlKem768P256 | Self::MlKem768X25519 => MlKemVariant::MlKem768,
+            Self::MlKem1024P384 => MlKemVariant::MlKem1024,
+        }
+    }
+
+    pub const fn public_key_length(self) -> usize {
+        match self {
+            Self::MlKem768P256 => 1249,
+            Self::MlKem768X25519 => 1216,
+            Self::MlKem1024P384 => 1665,
+        }
+    }
+
+    pub const fn ciphertext_length(self) -> usize {
+        match self {
+            Self::MlKem768P256 => 1153,
+            Self::MlKem768X25519 => 1120,
+            Self::MlKem1024P384 => 1665,
+        }
+    }
+
+    pub const fn pq_public_key_length(self) -> usize {
+        match self.ml_kem_variant() {
+            MlKemVariant::MlKem768 => 1184,
+            MlKemVariant::MlKem1024 => 1568,
+            MlKemVariant::MlKem512 => unreachable!(),
+        }
+    }
+
+    pub const fn pq_ciphertext_length(self) -> usize {
+        match self.ml_kem_variant() {
+            MlKemVariant::MlKem768 => 1088,
+            MlKemVariant::MlKem1024 => 1568,
+            MlKemVariant::MlKem512 => unreachable!(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 pub enum AesMode {

--- a/modules/llrt_crypto/src/provider/mod.rs
+++ b/modules/llrt_crypto/src/provider/mod.rs
@@ -40,6 +40,7 @@ mod rust;
 
 use crate::hash::HashAlgorithm;
 use crate::subtle::EllipticCurve;
+use llrt_utils::str_enum;
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -145,15 +146,12 @@ pub enum MlDsaVariant {
     MlDsa87,
 }
 
-impl MlDsaVariant {
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::MlDsa44 => "ML-DSA-44",
-            Self::MlDsa65 => "ML-DSA-65",
-            Self::MlDsa87 => "ML-DSA-87",
-        }
-    }
-}
+str_enum!(
+    MlDsaVariant,
+    MlDsa44 => "ML-DSA-44",
+    MlDsa65 => "ML-DSA-65",
+    MlDsa87 => "ML-DSA-87"
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MlKemVariant {
@@ -162,15 +160,12 @@ pub enum MlKemVariant {
     MlKem1024,
 }
 
-impl MlKemVariant {
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::MlKem512 => "ML-KEM-512",
-            Self::MlKem768 => "ML-KEM-768",
-            Self::MlKem1024 => "ML-KEM-1024",
-        }
-    }
-}
+str_enum!(
+    MlKemVariant,
+    MlKem512 => "ML-KEM-512",
+    MlKem768 => "ML-KEM-768",
+    MlKem1024 => "ML-KEM-1024"
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HybridKemVariant {
@@ -179,15 +174,14 @@ pub enum HybridKemVariant {
     MlKem1024P384,
 }
 
-impl HybridKemVariant {
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::MlKem768P256 => "MLKEM768-P256",
-            Self::MlKem768X25519 => "MLKEM768-X25519",
-            Self::MlKem1024P384 => "MLKEM1024-P384",
-        }
-    }
+str_enum!(
+    HybridKemVariant,
+    MlKem768P256 => "MLKEM768-P256",
+    MlKem768X25519 => "MLKEM768-X25519",
+    MlKem1024P384 => "MLKEM1024-P384"
+);
 
+impl HybridKemVariant {
     pub const fn ml_kem_variant(self) -> MlKemVariant {
         match self {
             Self::MlKem768P256 | Self::MlKem768X25519 => MlKemVariant::MlKem768,

--- a/modules/llrt_crypto/src/provider/modern.rs
+++ b/modules/llrt_crypto/src/provider/modern.rs
@@ -404,7 +404,9 @@ fn shake256(input: &[u8], output_length: usize) -> Vec<u8> {
 }
 
 fn p256_private_key(seed: &[u8]) -> Result<p256::SecretKey, CryptoError> {
-    seed.chunks_exact(32)
+    seed.as_chunks::<32>()
+        .0
+        .iter()
         .find_map(|candidate| p256::SecretKey::from_slice(candidate).ok())
         .ok_or(CryptoError::OperationFailed(Some(
             "P-256 rejection sampling failed".into(),
@@ -412,7 +414,9 @@ fn p256_private_key(seed: &[u8]) -> Result<p256::SecretKey, CryptoError> {
 }
 
 fn p384_private_key(seed: &[u8]) -> Result<p384::SecretKey, CryptoError> {
-    seed.chunks_exact(48)
+    seed.as_chunks::<48>()
+        .0
+        .iter()
         .find_map(|candidate| p384::SecretKey::from_slice(candidate).ok())
         .ok_or(CryptoError::OperationFailed(Some(
             "P-384 rejection sampling failed".into(),

--- a/modules/llrt_crypto/src/provider/modern.rs
+++ b/modules/llrt_crypto/src/provider/modern.rs
@@ -5,8 +5,31 @@ use chacha20poly1305::{
     aead::{Aead, Payload},
     ChaCha20Poly1305, KeyInit, Nonce,
 };
+use ml_dsa::{
+    pkcs8::{
+        der::AnyRef, spki::AssociatedAlgorithmIdentifier, DecodePrivateKey, DecodePublicKey,
+        EncodePrivateKey, EncodePublicKey,
+    },
+    Keypair, MlDsa44, MlDsa65, MlDsa87, MlDsaParams, Seed, Signature, SigningKey, VerifyingKey,
+};
 
-use super::CryptoError;
+use super::{CryptoError, MlDsaVariant};
+
+trait MlDsaParameterSet: MlDsaParams + AssociatedAlgorithmIdentifier<Params = AnyRef<'static>> {}
+
+impl MlDsaParameterSet for MlDsa44 {}
+impl MlDsaParameterSet for MlDsa65 {}
+impl MlDsaParameterSet for MlDsa87 {}
+
+macro_rules! dispatch_ml_dsa {
+    ($variant:expr, $function:ident $(, $argument:expr)* $(,)?) => {
+        match $variant {
+            MlDsaVariant::MlDsa44 => $function::<MlDsa44>($($argument),*),
+            MlDsaVariant::MlDsa65 => $function::<MlDsa65>($($argument),*),
+            MlDsaVariant::MlDsa87 => $function::<MlDsa87>($($argument),*),
+        }
+    };
+}
 
 pub(crate) fn chacha20_poly1305_encrypt(
     key: &[u8],
@@ -46,4 +69,168 @@ pub(crate) fn chacha20_poly1305_decrypt(
             },
         )
         .map_err(|_| CryptoError::DecryptionFailed(None))
+}
+
+fn ml_dsa_signing_key<P: MlDsaParameterSet>(seed: &[u8]) -> Result<SigningKey<P>, CryptoError> {
+    let seed = Seed::try_from(seed).map_err(|_| CryptoError::InvalidKey(None))?;
+    Ok(SigningKey::from_seed(&seed))
+}
+
+fn ml_dsa_verifying_key<P: MlDsaParameterSet>(
+    public_key: &[u8],
+) -> Result<VerifyingKey<P>, CryptoError> {
+    let encoded = ml_dsa::EncodedVerifyingKey::<P>::try_from(public_key)
+        .map_err(|_| CryptoError::InvalidKey(None))?;
+    Ok(VerifyingKey::decode(&encoded))
+}
+
+fn generate_ml_dsa_key_for<P: MlDsaParameterSet>() -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+    let seed = crate::random_byte_array(32);
+    let signing_key = ml_dsa_signing_key::<P>(&seed)?;
+    let public_key = signing_key.verifying_key().encode().to_vec();
+    Ok((seed, public_key))
+}
+
+pub(crate) fn generate_ml_dsa_key(
+    variant: MlDsaVariant,
+) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+    dispatch_ml_dsa!(variant, generate_ml_dsa_key_for)
+}
+
+fn ml_dsa_public_key_for<P: MlDsaParameterSet>(seed: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    Ok(ml_dsa_signing_key::<P>(seed)?
+        .verifying_key()
+        .encode()
+        .to_vec())
+}
+
+pub(crate) fn ml_dsa_public_key(
+    variant: MlDsaVariant,
+    seed: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_dsa!(variant, ml_dsa_public_key_for, seed)
+}
+
+fn ml_dsa_sign_for<P: MlDsaParameterSet>(
+    seed: &[u8],
+    data: &[u8],
+    context: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let signing_key = ml_dsa_signing_key::<P>(seed)?;
+    let mut rng = rand::rng();
+    signing_key
+        .expanded_key()
+        .sign_randomized(data, context, &mut rng)
+        .map(|signature| signature.encode().to_vec())
+        .map_err(|_| CryptoError::SigningFailed(None))
+}
+
+pub(crate) fn ml_dsa_sign(
+    variant: MlDsaVariant,
+    seed: &[u8],
+    data: &[u8],
+    context: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_dsa!(variant, ml_dsa_sign_for, seed, data, context)
+}
+
+fn ml_dsa_verify_for<P: MlDsaParameterSet>(
+    public_key: &[u8],
+    signature: &[u8],
+    data: &[u8],
+    context: &[u8],
+) -> Result<bool, CryptoError> {
+    let verifying_key = ml_dsa_verifying_key::<P>(public_key)?;
+    let signature =
+        Signature::<P>::try_from(signature).map_err(|_| CryptoError::InvalidSignature(None))?;
+    Ok(verifying_key.verify_with_context(data, context, &signature))
+}
+
+pub(crate) fn ml_dsa_verify(
+    variant: MlDsaVariant,
+    public_key: &[u8],
+    signature: &[u8],
+    data: &[u8],
+    context: &[u8],
+) -> Result<bool, CryptoError> {
+    dispatch_ml_dsa!(
+        variant,
+        ml_dsa_verify_for,
+        public_key,
+        signature,
+        data,
+        context,
+    )
+}
+
+fn import_ml_dsa_public_key_for<P: MlDsaParameterSet>(
+    data: &[u8],
+    spki: bool,
+) -> Result<Vec<u8>, CryptoError> {
+    let key = if spki {
+        VerifyingKey::<P>::from_public_key_der(data).map_err(|_| CryptoError::InvalidKey(None))?
+    } else {
+        ml_dsa_verifying_key::<P>(data)?
+    };
+    Ok(key.encode().to_vec())
+}
+
+pub(crate) fn import_ml_dsa_public_key(
+    variant: MlDsaVariant,
+    data: &[u8],
+    spki: bool,
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_dsa!(variant, import_ml_dsa_public_key_for, data, spki)
+}
+
+fn import_ml_dsa_private_key_for<P: MlDsaParameterSet>(
+    data: &[u8],
+    pkcs8: bool,
+) -> Result<Vec<u8>, CryptoError> {
+    let key = if pkcs8 {
+        SigningKey::<P>::from_pkcs8_der(data).map_err(|_| CryptoError::InvalidKey(None))?
+    } else {
+        ml_dsa_signing_key::<P>(data)?
+    };
+    Ok(key.to_seed().to_vec())
+}
+
+pub(crate) fn import_ml_dsa_private_key(
+    variant: MlDsaVariant,
+    data: &[u8],
+    pkcs8: bool,
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_dsa!(variant, import_ml_dsa_private_key_for, data, pkcs8)
+}
+
+fn export_ml_dsa_public_key_spki_for<P: MlDsaParameterSet>(
+    public_key: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    ml_dsa_verifying_key::<P>(public_key)?
+        .to_public_key_der()
+        .map(|document| document.as_bytes().to_vec())
+        .map_err(|_| CryptoError::InvalidKey(None))
+}
+
+pub(crate) fn export_ml_dsa_public_key_spki(
+    variant: MlDsaVariant,
+    public_key: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_dsa!(variant, export_ml_dsa_public_key_spki_for, public_key,)
+}
+
+fn export_ml_dsa_private_key_pkcs8_for<P: MlDsaParameterSet>(
+    seed: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    ml_dsa_signing_key::<P>(seed)?
+        .to_pkcs8_der()
+        .map(|document| document.as_bytes().to_vec())
+        .map_err(|_| CryptoError::InvalidKey(None))
+}
+
+pub(crate) fn export_ml_dsa_private_key_pkcs8(
+    variant: MlDsaVariant,
+    seed: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_dsa!(variant, export_ml_dsa_private_key_pkcs8_for, seed,)
 }

--- a/modules/llrt_crypto/src/provider/modern.rs
+++ b/modules/llrt_crypto/src/provider/modern.rs
@@ -18,7 +18,7 @@ use ml_kem::{
     B32 as MlKemRandomness,
 };
 
-use super::{CryptoError, MlDsaVariant, MlKemVariant};
+use super::{CryptoError, HybridKemVariant, MlDsaVariant, MlKemVariant};
 
 trait MlDsaParameterSet: MlDsaParams + AssociatedAlgorithmIdentifier<Params = AnyRef<'static>> {}
 
@@ -378,4 +378,310 @@ pub(crate) fn export_ml_kem_private_key_pkcs8(
             .map(|document| document.as_bytes().to_vec())
             .map_err(|_| CryptoError::InvalidKey(None))
     })
+}
+
+enum TraditionalPrivateKey {
+    P256(p256::SecretKey),
+    X25519(x25519_dalek::StaticSecret),
+    P384(p384::SecretKey),
+}
+
+struct HybridKeyPair {
+    pq_seed: Vec<u8>,
+    traditional_private_key: TraditionalPrivateKey,
+    traditional_public_key: Vec<u8>,
+    public_key: Vec<u8>,
+}
+
+fn shake256(input: &[u8], output_length: usize) -> Vec<u8> {
+    use sha3::digest::{ExtendableOutput, Update, XofReader};
+
+    let mut output = vec![0; output_length];
+    let mut hash = sha3::Shake256::default();
+    hash.update(input);
+    hash.finalize_xof().read(&mut output);
+    output
+}
+
+fn p256_private_key(seed: &[u8]) -> Result<p256::SecretKey, CryptoError> {
+    seed.chunks_exact(32)
+        .find_map(|candidate| p256::SecretKey::from_slice(candidate).ok())
+        .ok_or(CryptoError::OperationFailed(Some(
+            "P-256 rejection sampling failed".into(),
+        )))
+}
+
+fn p384_private_key(seed: &[u8]) -> Result<p384::SecretKey, CryptoError> {
+    seed.chunks_exact(48)
+        .find_map(|candidate| p384::SecretKey::from_slice(candidate).ok())
+        .ok_or(CryptoError::OperationFailed(Some(
+            "P-384 rejection sampling failed".into(),
+        )))
+}
+
+fn derive_hybrid_key_pair(
+    variant: HybridKemVariant,
+    seed: &[u8],
+) -> Result<HybridKeyPair, CryptoError> {
+    if seed.len() != 32 {
+        return Err(CryptoError::InvalidKey(None));
+    }
+    let traditional_seed_length = match variant {
+        HybridKemVariant::MlKem768P256 => 128,
+        HybridKemVariant::MlKem768X25519 => 32,
+        HybridKemVariant::MlKem1024P384 => 48,
+    };
+    let expanded = shake256(seed, 64 + traditional_seed_length);
+    let (pq_seed, traditional_seed) = expanded.split_at(64);
+    let pq_public_key = ml_kem_public_key(variant.ml_kem_variant(), pq_seed)?;
+
+    let (traditional_private_key, traditional_public_key) = match variant {
+        HybridKemVariant::MlKem768P256 => {
+            let private_key = p256_private_key(traditional_seed)?;
+            let public_key = private_key.public_key().to_sec1_bytes().to_vec();
+            (TraditionalPrivateKey::P256(private_key), public_key)
+        },
+        HybridKemVariant::MlKem768X25519 => {
+            let private_key = x25519_dalek::StaticSecret::from(
+                <[u8; 32]>::try_from(traditional_seed)
+                    .map_err(|_| CryptoError::OperationFailed(None))?,
+            );
+            let public_key = x25519_dalek::PublicKey::from(&private_key)
+                .as_bytes()
+                .to_vec();
+            (TraditionalPrivateKey::X25519(private_key), public_key)
+        },
+        HybridKemVariant::MlKem1024P384 => {
+            let private_key = p384_private_key(traditional_seed)?;
+            let public_key = private_key.public_key().to_sec1_bytes().to_vec();
+            (TraditionalPrivateKey::P384(private_key), public_key)
+        },
+    };
+
+    let mut public_key = pq_public_key;
+    public_key.extend_from_slice(&traditional_public_key);
+    Ok(HybridKeyPair {
+        pq_seed: pq_seed.to_vec(),
+        traditional_private_key,
+        traditional_public_key,
+        public_key,
+    })
+}
+
+fn hybrid_kem_combiner(
+    variant: HybridKemVariant,
+    pq_shared_key: &[u8],
+    traditional_shared_key: &[u8],
+    traditional_ciphertext: &[u8],
+    traditional_public_key: &[u8],
+) -> Vec<u8> {
+    use sha3::Digest;
+
+    let label: &[u8] = match variant {
+        HybridKemVariant::MlKem768P256 => b"MLKEM768-P256",
+        HybridKemVariant::MlKem768X25519 => b"\\.//^\\",
+        HybridKemVariant::MlKem1024P384 => b"MLKEM1024-P384",
+    };
+    let mut input = Vec::with_capacity(
+        pq_shared_key.len()
+            + traditional_shared_key.len()
+            + traditional_ciphertext.len()
+            + traditional_public_key.len()
+            + label.len(),
+    );
+    input.extend_from_slice(pq_shared_key);
+    input.extend_from_slice(traditional_shared_key);
+    input.extend_from_slice(traditional_ciphertext);
+    input.extend_from_slice(traditional_public_key);
+    input.extend_from_slice(label);
+    sha3::Sha3_256::digest(input).to_vec()
+}
+
+fn traditional_encapsulate(
+    variant: HybridKemVariant,
+    public_key: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+    match variant {
+        HybridKemVariant::MlKem768P256 => {
+            let recipient = p256::PublicKey::from_sec1_bytes(public_key)
+                .map_err(|_| CryptoError::InvalidKey(None))?;
+            let ephemeral = p256_private_key(&crate::random_byte_array(128))?;
+            let ciphertext = ephemeral.public_key().to_sec1_bytes().to_vec();
+            let shared_key = p256::elliptic_curve::ecdh::diffie_hellman(
+                ephemeral.to_nonzero_scalar(),
+                recipient.as_affine(),
+            )
+            .raw_secret_bytes()
+            .to_vec();
+            Ok((ciphertext, shared_key))
+        },
+        HybridKemVariant::MlKem768X25519 => {
+            let recipient = x25519_dalek::PublicKey::from(
+                <[u8; 32]>::try_from(public_key).map_err(|_| CryptoError::InvalidKey(None))?,
+            );
+            let ephemeral = x25519_dalek::StaticSecret::from(
+                <[u8; 32]>::try_from(crate::random_byte_array(32))
+                    .map_err(|_| CryptoError::OperationFailed(None))?,
+            );
+            let ciphertext = x25519_dalek::PublicKey::from(&ephemeral)
+                .as_bytes()
+                .to_vec();
+            let shared_key = ephemeral.diffie_hellman(&recipient);
+            if shared_key.as_bytes().iter().all(|byte| *byte == 0) {
+                return Err(CryptoError::OperationFailed(None));
+            }
+            Ok((ciphertext, shared_key.as_bytes().to_vec()))
+        },
+        HybridKemVariant::MlKem1024P384 => {
+            let recipient = p384::PublicKey::from_sec1_bytes(public_key)
+                .map_err(|_| CryptoError::InvalidKey(None))?;
+            let ephemeral = p384_private_key(&crate::random_byte_array(48))?;
+            let ciphertext = ephemeral.public_key().to_sec1_bytes().to_vec();
+            let shared_key = p384::elliptic_curve::ecdh::diffie_hellman(
+                ephemeral.to_nonzero_scalar(),
+                recipient.as_affine(),
+            )
+            .raw_secret_bytes()
+            .to_vec();
+            Ok((ciphertext, shared_key))
+        },
+    }
+}
+
+fn traditional_decapsulate(
+    private_key: &TraditionalPrivateKey,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    match private_key {
+        TraditionalPrivateKey::P256(private_key) => {
+            let public_key = p256::PublicKey::from_sec1_bytes(ciphertext)
+                .map_err(|_| CryptoError::OperationFailed(None))?;
+            Ok(p256::elliptic_curve::ecdh::diffie_hellman(
+                private_key.to_nonzero_scalar(),
+                public_key.as_affine(),
+            )
+            .raw_secret_bytes()
+            .to_vec())
+        },
+        TraditionalPrivateKey::X25519(private_key) => {
+            let public_key = x25519_dalek::PublicKey::from(
+                <[u8; 32]>::try_from(ciphertext).map_err(|_| CryptoError::OperationFailed(None))?,
+            );
+            let shared_key = private_key.diffie_hellman(&public_key);
+            if shared_key.as_bytes().iter().all(|byte| *byte == 0) {
+                return Err(CryptoError::OperationFailed(None));
+            }
+            Ok(shared_key.as_bytes().to_vec())
+        },
+        TraditionalPrivateKey::P384(private_key) => {
+            let public_key = p384::PublicKey::from_sec1_bytes(ciphertext)
+                .map_err(|_| CryptoError::OperationFailed(None))?;
+            Ok(p384::elliptic_curve::ecdh::diffie_hellman(
+                private_key.to_nonzero_scalar(),
+                public_key.as_affine(),
+            )
+            .raw_secret_bytes()
+            .to_vec())
+        },
+    }
+}
+
+pub(crate) fn generate_hybrid_kem_key(
+    variant: HybridKemVariant,
+) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+    let seed = crate::random_byte_array(32);
+    let public_key = derive_hybrid_key_pair(variant, &seed)?.public_key;
+    Ok((seed, public_key))
+}
+
+pub(crate) fn hybrid_kem_public_key(
+    variant: HybridKemVariant,
+    seed: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    Ok(derive_hybrid_key_pair(variant, seed)?.public_key)
+}
+
+pub(crate) fn import_hybrid_kem_public_key(
+    variant: HybridKemVariant,
+    data: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    if data.len() != variant.public_key_length() {
+        return Err(CryptoError::InvalidKey(None));
+    }
+    let (pq_public_key, traditional_public_key) = data.split_at(variant.pq_public_key_length());
+    let pq_public_key = import_ml_kem_public_key(variant.ml_kem_variant(), pq_public_key, false)?;
+    match variant {
+        HybridKemVariant::MlKem768P256 => {
+            p256::PublicKey::from_sec1_bytes(traditional_public_key)
+                .map_err(|_| CryptoError::InvalidKey(None))?;
+        },
+        HybridKemVariant::MlKem768X25519 => {
+            <[u8; 32]>::try_from(traditional_public_key)
+                .map_err(|_| CryptoError::InvalidKey(None))?;
+        },
+        HybridKemVariant::MlKem1024P384 => {
+            p384::PublicKey::from_sec1_bytes(traditional_public_key)
+                .map_err(|_| CryptoError::InvalidKey(None))?;
+        },
+    }
+    let mut normalized = pq_public_key;
+    normalized.extend_from_slice(traditional_public_key);
+    Ok(normalized)
+}
+
+pub(crate) fn import_hybrid_kem_private_key(
+    variant: HybridKemVariant,
+    data: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    derive_hybrid_key_pair(variant, data)?;
+    Ok(data.to_vec())
+}
+
+pub(crate) fn hybrid_kem_encapsulate(
+    variant: HybridKemVariant,
+    public_key: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+    let public_key = import_hybrid_kem_public_key(variant, public_key)?;
+    let (pq_public_key, traditional_public_key) =
+        public_key.split_at(variant.pq_public_key_length());
+    let (pq_ciphertext, pq_shared_key) =
+        ml_kem_encapsulate(variant.ml_kem_variant(), pq_public_key)?;
+    let (traditional_ciphertext, traditional_shared_key) =
+        traditional_encapsulate(variant, traditional_public_key)?;
+    let shared_key = hybrid_kem_combiner(
+        variant,
+        &pq_shared_key,
+        &traditional_shared_key,
+        &traditional_ciphertext,
+        traditional_public_key,
+    );
+    let mut ciphertext = pq_ciphertext;
+    ciphertext.extend_from_slice(&traditional_ciphertext);
+    Ok((ciphertext, shared_key))
+}
+
+pub(crate) fn hybrid_kem_decapsulate(
+    variant: HybridKemVariant,
+    seed: &[u8],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    if ciphertext.len() != variant.ciphertext_length() {
+        return Err(CryptoError::OperationFailed(Some(
+            "Invalid hybrid KEM ciphertext".into(),
+        )));
+    }
+    let key_pair = derive_hybrid_key_pair(variant, seed)?;
+    let (pq_ciphertext, traditional_ciphertext) =
+        ciphertext.split_at(variant.pq_ciphertext_length());
+    let pq_shared_key =
+        ml_kem_decapsulate(variant.ml_kem_variant(), &key_pair.pq_seed, pq_ciphertext)?;
+    let traditional_shared_key =
+        traditional_decapsulate(&key_pair.traditional_private_key, traditional_ciphertext)?;
+    Ok(hybrid_kem_combiner(
+        variant,
+        &pq_shared_key,
+        &traditional_shared_key,
+        traditional_ciphertext,
+        &key_pair.traditional_public_key,
+    ))
 }

--- a/modules/llrt_crypto/src/provider/modern.rs
+++ b/modules/llrt_crypto/src/provider/modern.rs
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use chacha20poly1305::{
+    aead::{Aead, Payload},
+    ChaCha20Poly1305, KeyInit, Nonce,
+};
+
+use super::CryptoError;
+
+pub(crate) fn chacha20_poly1305_encrypt(
+    key: &[u8],
+    iv: &[u8],
+    data: &[u8],
+    additional_data: Option<&[u8]>,
+) -> Result<Vec<u8>, CryptoError> {
+    let cipher =
+        ChaCha20Poly1305::new_from_slice(key).map_err(|_| CryptoError::InvalidKey(None))?;
+    let nonce = Nonce::try_from(iv).map_err(|_| CryptoError::InvalidData(None))?;
+    cipher
+        .encrypt(
+            &nonce,
+            Payload {
+                msg: data,
+                aad: additional_data.unwrap_or_default(),
+            },
+        )
+        .map_err(|_| CryptoError::EncryptionFailed(None))
+}
+
+pub(crate) fn chacha20_poly1305_decrypt(
+    key: &[u8],
+    iv: &[u8],
+    data: &[u8],
+    additional_data: Option<&[u8]>,
+) -> Result<Vec<u8>, CryptoError> {
+    let cipher =
+        ChaCha20Poly1305::new_from_slice(key).map_err(|_| CryptoError::InvalidKey(None))?;
+    let nonce = Nonce::try_from(iv).map_err(|_| CryptoError::InvalidData(None))?;
+    cipher
+        .decrypt(
+            &nonce,
+            Payload {
+                msg: data,
+                aad: additional_data.unwrap_or_default(),
+            },
+        )
+        .map_err(|_| CryptoError::DecryptionFailed(None))
+}

--- a/modules/llrt_crypto/src/provider/modern.rs
+++ b/modules/llrt_crypto/src/provider/modern.rs
@@ -12,8 +12,13 @@ use ml_dsa::{
     },
     Keypair, MlDsa44, MlDsa65, MlDsa87, MlDsaParams, Seed, Signature, SigningKey, VerifyingKey,
 };
+use ml_kem::{
+    Decapsulate, EncapsulationKey as MlKemEncapsulationKey, Key as MlKemKey,
+    KeyExport as MlKemKeyExport, MlKem1024, MlKem512, MlKem768, Seed as MlKemSeed,
+    B32 as MlKemRandomness,
+};
 
-use super::{CryptoError, MlDsaVariant};
+use super::{CryptoError, MlDsaVariant, MlKemVariant};
 
 trait MlDsaParameterSet: MlDsaParams + AssociatedAlgorithmIdentifier<Params = AnyRef<'static>> {}
 
@@ -27,6 +32,25 @@ macro_rules! dispatch_ml_dsa {
             MlDsaVariant::MlDsa44 => $function::<MlDsa44>($($argument),*),
             MlDsaVariant::MlDsa65 => $function::<MlDsa65>($($argument),*),
             MlDsaVariant::MlDsa87 => $function::<MlDsa87>($($argument),*),
+        }
+    };
+}
+
+macro_rules! dispatch_ml_kem {
+    ($variant:expr, |$kem:ident| $body:block) => {
+        match $variant {
+            MlKemVariant::MlKem512 => {
+                type $kem = MlKem512;
+                $body
+            },
+            MlKemVariant::MlKem768 => {
+                type $kem = MlKem768;
+                $body
+            },
+            MlKemVariant::MlKem1024 => {
+                type $kem = MlKem1024;
+                $body
+            },
         }
     };
 }
@@ -233,4 +257,125 @@ pub(crate) fn export_ml_dsa_private_key_pkcs8(
     seed: &[u8],
 ) -> Result<Vec<u8>, CryptoError> {
     dispatch_ml_dsa!(variant, export_ml_dsa_private_key_pkcs8_for, seed,)
+}
+
+pub(crate) fn generate_ml_kem_key(
+    variant: MlKemVariant,
+) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+    let seed = crate::random_byte_array(64);
+    let seed = MlKemSeed::try_from(seed.as_slice()).map_err(|_| CryptoError::InvalidKey(None))?;
+    dispatch_ml_kem!(variant, |Kem| {
+        let private_key = ml_kem::DecapsulationKey::<Kem>::from_seed(seed);
+        let public_key = private_key.encapsulation_key().to_bytes().to_vec();
+        Ok((seed.to_vec(), public_key))
+    })
+}
+
+pub(crate) fn ml_kem_public_key(
+    variant: MlKemVariant,
+    seed: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let seed = MlKemSeed::try_from(seed).map_err(|_| CryptoError::InvalidKey(None))?;
+    dispatch_ml_kem!(variant, |Kem| {
+        let private_key = ml_kem::DecapsulationKey::<Kem>::from_seed(seed);
+        Ok(private_key.encapsulation_key().to_bytes().to_vec())
+    })
+}
+
+pub(crate) fn ml_kem_encapsulate(
+    variant: MlKemVariant,
+    public_key: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+    let randomness = crate::random_byte_array(32);
+    let randomness = MlKemRandomness::try_from(randomness.as_slice())
+        .map_err(|_| CryptoError::OperationFailed(None))?;
+    dispatch_ml_kem!(variant, |Kem| {
+        let encoded = MlKemKey::<MlKemEncapsulationKey<Kem>>::try_from(public_key)
+            .map_err(|_| CryptoError::InvalidKey(None))?;
+        let public_key = MlKemEncapsulationKey::<Kem>::new(&encoded)
+            .map_err(|_| CryptoError::InvalidKey(None))?;
+        let (ciphertext, shared_key) = public_key.encapsulate_deterministic(&randomness);
+        Ok((ciphertext.to_vec(), shared_key.to_vec()))
+    })
+}
+
+pub(crate) fn ml_kem_decapsulate(
+    variant: MlKemVariant,
+    seed: &[u8],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let seed = MlKemSeed::try_from(seed).map_err(|_| CryptoError::InvalidKey(None))?;
+    dispatch_ml_kem!(variant, |Kem| {
+        let private_key = ml_kem::DecapsulationKey::<Kem>::from_seed(seed);
+        private_key
+            .decapsulate_slice(ciphertext)
+            .map(|shared_key| shared_key.to_vec())
+            .map_err(|_| CryptoError::OperationFailed(Some("Invalid ML-KEM ciphertext".into())))
+    })
+}
+
+pub(crate) fn import_ml_kem_public_key(
+    variant: MlKemVariant,
+    data: &[u8],
+    spki: bool,
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_kem!(variant, |Kem| {
+        let key = if spki {
+            MlKemEncapsulationKey::<Kem>::from_public_key_der(data)
+                .map_err(|_| CryptoError::InvalidKey(None))?
+        } else {
+            let encoded = MlKemKey::<MlKemEncapsulationKey<Kem>>::try_from(data)
+                .map_err(|_| CryptoError::InvalidKey(None))?;
+            MlKemEncapsulationKey::<Kem>::new(&encoded)
+                .map_err(|_| CryptoError::InvalidKey(None))?
+        };
+        Ok(key.to_bytes().to_vec())
+    })
+}
+
+pub(crate) fn import_ml_kem_private_key(
+    variant: MlKemVariant,
+    data: &[u8],
+    pkcs8: bool,
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_kem!(variant, |Kem| {
+        let key = if pkcs8 {
+            ml_kem::DecapsulationKey::<Kem>::from_pkcs8_der(data)
+                .map_err(|_| CryptoError::InvalidKey(None))?
+        } else {
+            let seed = MlKemSeed::try_from(data).map_err(|_| CryptoError::InvalidKey(None))?;
+            ml_kem::DecapsulationKey::<Kem>::from_seed(seed)
+        };
+        key.to_seed()
+            .map(|seed| seed.to_vec())
+            .ok_or(CryptoError::InvalidKey(None))
+    })
+}
+
+pub(crate) fn export_ml_kem_public_key_spki(
+    variant: MlKemVariant,
+    public_key: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    dispatch_ml_kem!(variant, |Kem| {
+        let encoded = MlKemKey::<MlKemEncapsulationKey<Kem>>::try_from(public_key)
+            .map_err(|_| CryptoError::InvalidKey(None))?;
+        MlKemEncapsulationKey::<Kem>::new(&encoded)
+            .map_err(|_| CryptoError::InvalidKey(None))?
+            .to_public_key_der()
+            .map(|document| document.as_bytes().to_vec())
+            .map_err(|_| CryptoError::InvalidKey(None))
+    })
+}
+
+pub(crate) fn export_ml_kem_private_key_pkcs8(
+    variant: MlKemVariant,
+    seed: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let seed = MlKemSeed::try_from(seed).map_err(|_| CryptoError::InvalidKey(None))?;
+    dispatch_ml_kem!(variant, |Kem| {
+        ml_kem::DecapsulationKey::<Kem>::from_seed(seed)
+            .to_pkcs8_der()
+            .map(|document| document.as_bytes().to_vec())
+            .map_err(|_| CryptoError::InvalidKey(None))
+    })
 }

--- a/modules/llrt_crypto/src/provider/modern.rs
+++ b/modules/llrt_crypto/src/provider/modern.rs
@@ -5,11 +5,10 @@ use chacha20poly1305::{
     aead::{Aead, Payload},
     ChaCha20Poly1305, KeyInit, Nonce,
 };
+#[cfg(feature = "_subtle-full")]
+use ml_dsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey};
 use ml_dsa::{
-    pkcs8::{
-        der::AnyRef, spki::AssociatedAlgorithmIdentifier, DecodePrivateKey, DecodePublicKey,
-        EncodePrivateKey, EncodePublicKey,
-    },
+    pkcs8::{der::AnyRef, spki::AssociatedAlgorithmIdentifier, DecodePublicKey},
     Keypair, MlDsa44, MlDsa65, MlDsa87, MlDsaParams, Seed, Signature, SigningKey, VerifyingKey,
 };
 use ml_kem::{
@@ -187,6 +186,7 @@ pub(crate) fn ml_dsa_verify(
     )
 }
 
+#[cfg(feature = "_subtle-full")]
 fn import_ml_dsa_public_key_for<P: MlDsaParameterSet>(
     data: &[u8],
     spki: bool,
@@ -199,6 +199,7 @@ fn import_ml_dsa_public_key_for<P: MlDsaParameterSet>(
     Ok(key.encode().to_vec())
 }
 
+#[cfg(feature = "_subtle-full")]
 pub(crate) fn import_ml_dsa_public_key(
     variant: MlDsaVariant,
     data: &[u8],
@@ -207,6 +208,7 @@ pub(crate) fn import_ml_dsa_public_key(
     dispatch_ml_dsa!(variant, import_ml_dsa_public_key_for, data, spki)
 }
 
+#[cfg(feature = "_subtle-full")]
 fn import_ml_dsa_private_key_for<P: MlDsaParameterSet>(
     data: &[u8],
     pkcs8: bool,
@@ -219,6 +221,7 @@ fn import_ml_dsa_private_key_for<P: MlDsaParameterSet>(
     Ok(key.to_seed().to_vec())
 }
 
+#[cfg(feature = "_subtle-full")]
 pub(crate) fn import_ml_dsa_private_key(
     variant: MlDsaVariant,
     data: &[u8],
@@ -227,6 +230,7 @@ pub(crate) fn import_ml_dsa_private_key(
     dispatch_ml_dsa!(variant, import_ml_dsa_private_key_for, data, pkcs8)
 }
 
+#[cfg(feature = "_subtle-full")]
 fn export_ml_dsa_public_key_spki_for<P: MlDsaParameterSet>(
     public_key: &[u8],
 ) -> Result<Vec<u8>, CryptoError> {
@@ -236,6 +240,7 @@ fn export_ml_dsa_public_key_spki_for<P: MlDsaParameterSet>(
         .map_err(|_| CryptoError::InvalidKey(None))
 }
 
+#[cfg(feature = "_subtle-full")]
 pub(crate) fn export_ml_dsa_public_key_spki(
     variant: MlDsaVariant,
     public_key: &[u8],
@@ -243,6 +248,7 @@ pub(crate) fn export_ml_dsa_public_key_spki(
     dispatch_ml_dsa!(variant, export_ml_dsa_public_key_spki_for, public_key,)
 }
 
+#[cfg(feature = "_subtle-full")]
 fn export_ml_dsa_private_key_pkcs8_for<P: MlDsaParameterSet>(
     seed: &[u8],
 ) -> Result<Vec<u8>, CryptoError> {
@@ -252,6 +258,7 @@ fn export_ml_dsa_private_key_pkcs8_for<P: MlDsaParameterSet>(
         .map_err(|_| CryptoError::InvalidKey(None))
 }
 
+#[cfg(feature = "_subtle-full")]
 pub(crate) fn export_ml_dsa_private_key_pkcs8(
     variant: MlDsaVariant,
     seed: &[u8],
@@ -333,6 +340,7 @@ pub(crate) fn import_ml_kem_public_key(
     })
 }
 
+#[cfg(feature = "_subtle-full")]
 pub(crate) fn import_ml_kem_private_key(
     variant: MlKemVariant,
     data: &[u8],
@@ -352,6 +360,7 @@ pub(crate) fn import_ml_kem_private_key(
     })
 }
 
+#[cfg(feature = "_subtle-full")]
 pub(crate) fn export_ml_kem_public_key_spki(
     variant: MlKemVariant,
     public_key: &[u8],
@@ -367,6 +376,7 @@ pub(crate) fn export_ml_kem_public_key_spki(
     })
 }
 
+#[cfg(feature = "_subtle-full")]
 pub(crate) fn export_ml_kem_private_key_pkcs8(
     variant: MlKemVariant,
     seed: &[u8],
@@ -633,6 +643,7 @@ pub(crate) fn import_hybrid_kem_public_key(
     Ok(normalized)
 }
 
+#[cfg(feature = "_subtle-full")]
 pub(crate) fn import_hybrid_kem_private_key(
     variant: HybridKemVariant,
     data: &[u8],

--- a/modules/llrt_crypto/src/provider/openssl.rs
+++ b/modules/llrt_crypto/src/provider/openssl.rs
@@ -1203,6 +1203,7 @@ impl CryptoProvider for OpenSslProvider {
         let nid = curve_to_nid(curve);
         let group = EcGroup::from_curve_name(nid)
             .map_err(|e| CryptoError::InvalidKey(Some(e.to_string().into())))?;
+        let coord_len = (group.degree() as usize).div_ceil(8);
         let mut ctx = openssl::bn::BigNumContext::new()
             .map_err(|e| CryptoError::InvalidKey(Some(e.to_string().into())))?;
 
@@ -1221,17 +1222,19 @@ impl CryptoProvider for OpenSslProvider {
                 .affine_coordinates(&group, &mut x, &mut y, &mut ctx)
                 .map_err(|e| CryptoError::InvalidKey(Some(e.to_string().into())))?;
             Ok(super::EcJwkExport {
-                x: x.to_vec(),
-                y: y.to_vec(),
-                d: Some(ec_key.private_key().to_vec()),
+                x: x.to_vec_padded(coord_len as i32)
+                    .map_err(|e| CryptoError::InvalidKey(Some(e.to_string().into())))?,
+                y: y.to_vec_padded(coord_len as i32)
+                    .map_err(|e| CryptoError::InvalidKey(Some(e.to_string().into())))?,
+                d: Some(
+                    ec_key
+                        .private_key()
+                        .to_vec_padded(coord_len as i32)
+                        .map_err(|e| CryptoError::InvalidKey(Some(e.to_string().into())))?,
+                ),
             })
         } else {
             // key_data is SEC1 uncompressed point (0x04 || x || y)
-            let coord_len = match curve {
-                EllipticCurve::P256 => 32,
-                EllipticCurve::P384 => 48,
-                EllipticCurve::P521 => 66,
-            };
             if key_data.len() != 1 + 2 * coord_len || key_data[0] != 0x04 {
                 return Err(CryptoError::InvalidKey(None));
             }

--- a/modules/llrt_crypto/src/subtle/derive_keys.rs
+++ b/modules/llrt_crypto/src/subtle/derive_keys.rs
@@ -73,6 +73,7 @@ fn derive_key<'js>(
 ) -> Result<Class<'js, CryptoKey<'js>>> {
     let length = match &key_algorithm.algorithm {
         KeyAlgorithm::Aes { length, .. } => DeriveBitsLength::Specified(u32::from(*length)),
+        KeyAlgorithm::ChaCha20Poly1305 => DeriveBitsLength::Specified(256),
         KeyAlgorithm::Hmac { length, .. } => DeriveBitsLength::Specified(*length),
         KeyAlgorithm::HkdfImport | KeyAlgorithm::Pbkdf2Import => DeriveBitsLength::Default,
         _ => {

--- a/modules/llrt_crypto/src/subtle/derive_keys.rs
+++ b/modules/llrt_crypto/src/subtle/derive_keys.rs
@@ -88,7 +88,7 @@ fn derive_key<'js>(
 
     import_key(
         ctx.clone(),
-        KeyFormatData::Raw(ObjectBytes::Vec(bytes)),
+        KeyFormatData::RawSecret(ObjectBytes::Vec(bytes)),
         derived_key_algorithm,
         extractable,
         key_usages,

--- a/modules/llrt_crypto/src/subtle/digest.rs
+++ b/modules/llrt_crypto/src/subtle/digest.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 // SPDX-License-Identifier: Apache-2.0
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
 use rquickjs::{ArrayBuffer, Ctx, Result, Value};
+use sha3::{Digest, Sha3_256, Sha3_384, Sha3_512};
 
 use crate::{
     hash::HashAlgorithm,
@@ -12,6 +13,13 @@ use crate::{
 };
 
 use super::algorithm_not_supported_error;
+
+enum DigestAlgorithm {
+    Fixed(HashAlgorithm),
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
+}
 
 pub fn subtle_digest<'js>(
     ctx: Ctx<'js>,
@@ -22,8 +30,13 @@ pub fn subtle_digest<'js>(
     let prepared = prepare_digest(&ctx, algorithm, data);
 
     async move {
-        let (hash_algorithm, input) = prepared?;
-        let bytes = digest(&hash_algorithm, &input);
+        let (algorithm, input) = prepared?;
+        let bytes = match algorithm {
+            DigestAlgorithm::Fixed(hash) => digest(&hash, &input),
+            DigestAlgorithm::Sha3_256 => Sha3_256::digest(&input).to_vec(),
+            DigestAlgorithm::Sha3_384 => Sha3_384::digest(&input).to_vec(),
+            DigestAlgorithm::Sha3_512 => Sha3_512::digest(&input).to_vec(),
+        };
         ArrayBuffer::new(ctx, bytes)
     }
 }
@@ -32,7 +45,7 @@ fn prepare_digest<'js>(
     ctx: &Ctx<'js>,
     algorithm: Value<'js>,
     data: ObjectBytes<'js>,
-) -> Result<(HashAlgorithm, Vec<u8>)> {
+) -> Result<(DigestAlgorithm, Vec<u8>)> {
     let algorithm = if let Some(s) = algorithm.as_string() {
         s.to_string().or_throw(ctx)?
     } else if let Some(name) = algorithm.get_optional::<_, String>("name")? {
@@ -43,12 +56,18 @@ fn prepare_digest<'js>(
             "Algorithm 'name' property required",
         ));
     };
-    let hash_algorithm = match HashAlgorithm::try_from(algorithm.as_str()) {
-        Ok(h) => h,
-        Err(_) => return algorithm_not_supported_error(ctx),
+    let algorithm = algorithm.to_ascii_uppercase();
+    let algorithm = match algorithm.as_str() {
+        "SHA3-256" => DigestAlgorithm::Sha3_256,
+        "SHA3-384" => DigestAlgorithm::Sha3_384,
+        "SHA3-512" => DigestAlgorithm::Sha3_512,
+        name => match HashAlgorithm::from_strict_str(name) {
+            Ok(hash) => DigestAlgorithm::Fixed(hash),
+            Err(_) => return algorithm_not_supported_error(ctx),
+        },
     };
     let input = data.as_bytes_opt().map(<[u8]>::to_vec).unwrap_or_default();
-    Ok((hash_algorithm, input))
+    Ok((algorithm, input))
 }
 
 pub fn digest(hash_algorithm: &HashAlgorithm, data: &[u8]) -> Vec<u8> {

--- a/modules/llrt_crypto/src/subtle/digest.rs
+++ b/modules/llrt_crypto/src/subtle/digest.rs
@@ -2,8 +2,8 @@ use std::future::Future;
 
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
-use rquickjs::{ArrayBuffer, Ctx, Object, Result, Value};
+use llrt_utils::bytes::ObjectBytes;
+use rquickjs::{ArrayBuffer, Ctx, Exception, Object, Result, Value};
 use sha3::{Digest, Sha3_256, Sha3_384, Sha3_512};
 
 use crate::{
@@ -14,8 +14,35 @@ use crate::{
 
 use super::{
     algorithm_not_supported_error, enforce_range_u32, enforce_range_u8,
-    get_optional_dictionary_value, get_required_dictionary_value,
+    get_optional_dictionary_value, get_required_dictionary_value, to_name_and_maybe_object,
 };
+
+enum DigestAlgorithmName {
+    Fixed(HashAlgorithm),
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
+    CShake(u16),
+    TurboShake(u16),
+}
+
+impl TryFrom<&str> for DigestAlgorithmName {
+    type Error = ();
+
+    fn try_from(name: &str) -> std::result::Result<Self, Self::Error> {
+        let name = name.to_ascii_uppercase();
+        Ok(match name.as_str() {
+            "CSHAKE128" => Self::CShake(128),
+            "CSHAKE256" => Self::CShake(256),
+            "TURBOSHAKE128" => Self::TurboShake(128),
+            "TURBOSHAKE256" => Self::TurboShake(256),
+            "SHA3-256" => Self::Sha3_256,
+            "SHA3-384" => Self::Sha3_384,
+            "SHA3-512" => Self::Sha3_512,
+            _ => Self::Fixed(HashAlgorithm::from_strict_str(&name).map_err(|_| ())?),
+        })
+    }
+}
 
 enum DigestAlgorithm {
     Fixed(HashAlgorithm),
@@ -78,22 +105,16 @@ fn prepare_digest<'js>(
     algorithm: Value<'js>,
     data: ObjectBytes<'js>,
 ) -> Result<(DigestAlgorithm, Vec<u8>)> {
-    let (name, object) = if let Some(s) = algorithm.as_string() {
-        (s.to_string().or_throw(ctx)?, None)
-    } else if let Some(object) = algorithm.into_object() {
-        let name = object.get_required::<_, String>("name", "algorithm")?;
-        (name, Some(object))
-    } else {
-        return Err(rquickjs::Exception::throw_type(
-            ctx,
-            "Algorithm 'name' property required",
-        ));
+    let (name, object) = to_name_and_maybe_object(ctx, algorithm)?;
+    let name = match DigestAlgorithmName::try_from(name.as_str()) {
+        Ok(name) => name,
+        Err(()) => return algorithm_not_supported_error(ctx),
     };
-    let name = name.to_ascii_uppercase();
-    let algorithm = match name.as_str() {
-        "CSHAKE128" | "CSHAKE256" => {
-            let object = required_object(ctx, object)?;
-            let output_length = required_u32(ctx, &object, "outputLength")?;
+    let algorithm = match name {
+        DigestAlgorithmName::CShake(strength) => {
+            let object = object?;
+            let value = get_required_dictionary_value(&object, "outputLength", "algorithm")?;
+            let output_length = enforce_range_u32(ctx, value, "outputLength")?;
             if u64::from(output_length).div_ceil(8) * 8 > u64::from(u32::MAX) {
                 return Err(llrt_exceptions::DOMException::operation_error(
                     ctx,
@@ -103,15 +124,16 @@ fn prepare_digest<'js>(
             let function_name = optional_bytes(ctx, &object, "functionName")?;
             let customization = optional_bytes(ctx, &object, "customization")?;
             DigestAlgorithm::CShake {
-                strength: if name == "CSHAKE128" { 128 } else { 256 },
+                strength,
                 output_length,
                 function_name,
                 customization,
             }
         },
-        "TURBOSHAKE128" | "TURBOSHAKE256" => {
-            let object = required_object(ctx, object)?;
-            let output_length = required_u32(ctx, &object, "outputLength")?;
+        DigestAlgorithmName::TurboShake(strength) => {
+            let object = object?;
+            let value = get_required_dictionary_value(&object, "outputLength", "algorithm")?;
+            let output_length = enforce_range_u32(ctx, value, "outputLength")?;
             if output_length == 0 || !output_length.is_multiple_of(8) {
                 return Err(llrt_exceptions::DOMException::operation_error(
                     ctx,
@@ -129,18 +151,15 @@ fn prepare_digest<'js>(
                 ));
             }
             DigestAlgorithm::TurboShake {
-                strength: if name == "TURBOSHAKE128" { 128 } else { 256 },
+                strength,
                 output_length,
                 domain_separation,
             }
         },
-        "SHA3-256" => DigestAlgorithm::Sha3_256,
-        "SHA3-384" => DigestAlgorithm::Sha3_384,
-        "SHA3-512" => DigestAlgorithm::Sha3_512,
-        name => match HashAlgorithm::from_strict_str(name) {
-            Ok(hash) => DigestAlgorithm::Fixed(hash),
-            Err(_) => return algorithm_not_supported_error(ctx),
-        },
+        DigestAlgorithmName::Sha3_256 => DigestAlgorithm::Sha3_256,
+        DigestAlgorithmName::Sha3_384 => DigestAlgorithm::Sha3_384,
+        DigestAlgorithmName::Sha3_512 => DigestAlgorithm::Sha3_512,
+        DigestAlgorithmName::Fixed(hash) => DigestAlgorithm::Fixed(hash),
     };
     let input = data.as_bytes_opt().map(<[u8]>::to_vec).unwrap_or_default();
     Ok((algorithm, input))
@@ -154,22 +173,13 @@ pub(super) fn supports_digest_algorithm<'js>(
     Ok(true)
 }
 
-fn required_object<'js>(ctx: &Ctx<'js>, object: Option<Object<'js>>) -> Result<Object<'js>> {
-    object.ok_or_else(|| rquickjs::Exception::throw_type(ctx, "algorithm must be an object"))
-}
-
-fn required_u32<'js>(ctx: &Ctx<'js>, object: &Object<'js>, name: &str) -> Result<u32> {
-    let value = get_required_dictionary_value(object, name, "algorithm")?;
-    enforce_range_u32(ctx, value, name)
-}
-
 fn optional_bytes<'js>(ctx: &Ctx<'js>, object: &Object<'js>, name: &str) -> Result<Vec<u8>> {
     let value = object.get::<_, Value>(name)?;
     if value.is_undefined() {
         return Ok(Vec::new());
     }
     if value.is_null() {
-        return Err(rquickjs::Exception::throw_type(
+        return Err(Exception::throw_type(
             ctx,
             &[name, " must be a BufferSource"].concat(),
         ));

--- a/modules/llrt_crypto/src/subtle/digest.rs
+++ b/modules/llrt_crypto/src/subtle/digest.rs
@@ -146,6 +146,14 @@ fn prepare_digest<'js>(
     Ok((algorithm, input))
 }
 
+pub(super) fn supports_digest_algorithm<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+) -> Result<bool> {
+    prepare_digest(ctx, algorithm, ObjectBytes::Vec(Vec::new()))?;
+    Ok(true)
+}
+
 fn required_object<'js>(ctx: &Ctx<'js>, object: Option<Object<'js>>) -> Result<Object<'js>> {
     object.ok_or_else(|| rquickjs::Exception::throw_type(ctx, "algorithm must be an object"))
 }

--- a/modules/llrt_crypto/src/subtle/digest.rs
+++ b/modules/llrt_crypto/src/subtle/digest.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 use llrt_utils::{bytes::ObjectBytes, object::ObjectExt, result::ResultExt};
-use rquickjs::{ArrayBuffer, Ctx, Result, Value};
+use rquickjs::{ArrayBuffer, Ctx, Object, Result, Value};
 use sha3::{Digest, Sha3_256, Sha3_384, Sha3_512};
 
 use crate::{
@@ -12,13 +12,27 @@ use crate::{
     CRYPTO_PROVIDER,
 };
 
-use super::algorithm_not_supported_error;
+use super::{
+    algorithm_not_supported_error, enforce_range_u32, enforce_range_u8,
+    get_optional_dictionary_value, get_required_dictionary_value,
+};
 
 enum DigestAlgorithm {
     Fixed(HashAlgorithm),
     Sha3_256,
     Sha3_384,
     Sha3_512,
+    CShake {
+        strength: u16,
+        output_length: u32,
+        function_name: Vec<u8>,
+        customization: Vec<u8>,
+    },
+    TurboShake {
+        strength: u16,
+        output_length: u32,
+        domain_separation: u8,
+    },
 }
 
 pub fn subtle_digest<'js>(
@@ -36,6 +50,24 @@ pub fn subtle_digest<'js>(
             DigestAlgorithm::Sha3_256 => Sha3_256::digest(&input).to_vec(),
             DigestAlgorithm::Sha3_384 => Sha3_384::digest(&input).to_vec(),
             DigestAlgorithm::Sha3_512 => Sha3_512::digest(&input).to_vec(),
+            DigestAlgorithm::CShake {
+                strength,
+                output_length,
+                function_name,
+                customization,
+            } => cshake_digest(
+                &ctx,
+                strength,
+                output_length,
+                &function_name,
+                &customization,
+                &input,
+            )?,
+            DigestAlgorithm::TurboShake {
+                strength,
+                output_length,
+                domain_separation,
+            } => turbo_shake_digest(&ctx, strength, output_length, domain_separation, &input)?,
         };
         ArrayBuffer::new(ctx, bytes)
     }
@@ -46,18 +78,62 @@ fn prepare_digest<'js>(
     algorithm: Value<'js>,
     data: ObjectBytes<'js>,
 ) -> Result<(DigestAlgorithm, Vec<u8>)> {
-    let algorithm = if let Some(s) = algorithm.as_string() {
-        s.to_string().or_throw(ctx)?
-    } else if let Some(name) = algorithm.get_optional::<_, String>("name")? {
-        name
+    let (name, object) = if let Some(s) = algorithm.as_string() {
+        (s.to_string().or_throw(ctx)?, None)
+    } else if let Some(object) = algorithm.into_object() {
+        let name = object.get_required::<_, String>("name", "algorithm")?;
+        (name, Some(object))
     } else {
         return Err(rquickjs::Exception::throw_type(
             ctx,
             "Algorithm 'name' property required",
         ));
     };
-    let algorithm = algorithm.to_ascii_uppercase();
-    let algorithm = match algorithm.as_str() {
+    let name = name.to_ascii_uppercase();
+    let algorithm = match name.as_str() {
+        "CSHAKE128" | "CSHAKE256" => {
+            let object = required_object(ctx, object)?;
+            let output_length = required_u32(ctx, &object, "outputLength")?;
+            if u64::from(output_length).div_ceil(8) * 8 > u64::from(u32::MAX) {
+                return Err(llrt_exceptions::DOMException::operation_error(
+                    ctx,
+                    "Invalid cSHAKE outputLength",
+                ));
+            }
+            let function_name = optional_bytes(ctx, &object, "functionName")?;
+            let customization = optional_bytes(ctx, &object, "customization")?;
+            DigestAlgorithm::CShake {
+                strength: if name == "CSHAKE128" { 128 } else { 256 },
+                output_length,
+                function_name,
+                customization,
+            }
+        },
+        "TURBOSHAKE128" | "TURBOSHAKE256" => {
+            let object = required_object(ctx, object)?;
+            let output_length = required_u32(ctx, &object, "outputLength")?;
+            if output_length == 0 || !output_length.is_multiple_of(8) {
+                return Err(llrt_exceptions::DOMException::operation_error(
+                    ctx,
+                    "TurboSHAKE outputLength must be a positive multiple of 8",
+                ));
+            }
+            let domain_separation = get_optional_dictionary_value(&object, "domainSeparation")?
+                .map(|value| enforce_range_u8(ctx, value, "domainSeparation"))
+                .transpose()?
+                .unwrap_or(0x1f);
+            if !(0x01..=0x7f).contains(&domain_separation) {
+                return Err(llrt_exceptions::DOMException::operation_error(
+                    ctx,
+                    "Invalid TurboSHAKE domainSeparation",
+                ));
+            }
+            DigestAlgorithm::TurboShake {
+                strength: if name == "TURBOSHAKE128" { 128 } else { 256 },
+                output_length,
+                domain_separation,
+            }
+        },
         "SHA3-256" => DigestAlgorithm::Sha3_256,
         "SHA3-384" => DigestAlgorithm::Sha3_384,
         "SHA3-512" => DigestAlgorithm::Sha3_512,
@@ -70,8 +146,127 @@ fn prepare_digest<'js>(
     Ok((algorithm, input))
 }
 
+fn required_object<'js>(ctx: &Ctx<'js>, object: Option<Object<'js>>) -> Result<Object<'js>> {
+    object.ok_or_else(|| rquickjs::Exception::throw_type(ctx, "algorithm must be an object"))
+}
+
+fn required_u32<'js>(ctx: &Ctx<'js>, object: &Object<'js>, name: &str) -> Result<u32> {
+    let value = get_required_dictionary_value(object, name, "algorithm")?;
+    enforce_range_u32(ctx, value, name)
+}
+
+fn optional_bytes<'js>(ctx: &Ctx<'js>, object: &Object<'js>, name: &str) -> Result<Vec<u8>> {
+    let value = object.get::<_, Value>(name)?;
+    if value.is_undefined() {
+        return Ok(Vec::new());
+    }
+    if value.is_null() {
+        return Err(rquickjs::Exception::throw_type(
+            ctx,
+            &[name, " must be a BufferSource"].concat(),
+        ));
+    }
+    ObjectBytes::from(ctx, &value)?.into_bytes(ctx)
+}
+
+fn try_allocate_digest_output(
+    length: usize,
+) -> std::result::Result<Vec<u8>, std::collections::TryReserveError> {
+    let mut output = Vec::new();
+    output.try_reserve_exact(length)?;
+    output.resize(length, 0);
+    Ok(output)
+}
+
+fn allocate_digest_output(ctx: &Ctx<'_>, length: usize) -> Result<Vec<u8>> {
+    try_allocate_digest_output(length).map_err(|_| {
+        llrt_exceptions::DOMException::operation_error(ctx, "Digest output allocation failed")
+    })
+}
+
+fn cshake_digest(
+    ctx: &Ctx<'_>,
+    strength: u16,
+    output_length: u32,
+    function_name: &[u8],
+    customization: &[u8],
+    input: &[u8],
+) -> Result<Vec<u8>> {
+    use cshake::digest::{ExtendableOutput, Update, XofReader};
+
+    let mut output = allocate_digest_output(ctx, (output_length as usize).div_ceil(8))?;
+    if output.is_empty() {
+        return Ok(output);
+    }
+    if strength == 128 {
+        let mut hasher = cshake::CShake128::new_with_function_name(function_name, customization);
+        hasher.update(input);
+        hasher.finalize_xof().read(&mut output);
+    } else {
+        let mut hasher = cshake::CShake256::new_with_function_name(function_name, customization);
+        hasher.update(input);
+        hasher.finalize_xof().read(&mut output);
+    }
+    if !output_length.is_multiple_of(8) {
+        let mask = u8::MAX << (8 - output_length % 8);
+        *output.last_mut().unwrap() &= mask;
+    }
+    Ok(output)
+}
+
+fn turbo_shake_digest(
+    ctx: &Ctx<'_>,
+    strength: u16,
+    output_length: u32,
+    domain_separation: u8,
+    input: &[u8],
+) -> Result<Vec<u8>> {
+    if strength == 128 {
+        turbo_shake::<168>(ctx, domain_separation, input, output_length as usize / 8)
+    } else {
+        turbo_shake::<136>(ctx, domain_separation, input, output_length as usize / 8)
+    }
+}
+
+fn turbo_shake<const RATE: usize>(
+    ctx: &Ctx<'_>,
+    domain: u8,
+    input: &[u8],
+    length: usize,
+) -> Result<Vec<u8>> {
+    use keccak::{Keccak, State1600};
+    use sponge_cursor::SpongeCursor;
+
+    let keccak = Keccak::new();
+    let mut state = State1600::default();
+    let mut cursor: SpongeCursor<RATE> = Default::default();
+    keccak.with_p1600::<12>(|permutation| {
+        cursor.absorb_u64_le(&mut state, permutation, input);
+        let position = cursor.pos();
+        state[position / 8] ^= u64::from(domain) << (8 * (position % 8));
+        state[RATE / 8 - 1] ^= 1 << 63;
+    });
+
+    let mut output = allocate_digest_output(ctx, length)?;
+    let mut reader: SpongeCursor<RATE> = Default::default();
+    keccak.with_p1600::<12>(|permutation| {
+        reader.squeeze_read_u64_le(&mut state, permutation, &mut output);
+    });
+    Ok(output)
+}
+
 pub fn digest(hash_algorithm: &HashAlgorithm, data: &[u8]) -> Vec<u8> {
     let mut hasher = CRYPTO_PROVIDER.digest(*hash_algorithm);
     hasher.update(data);
     hasher.finalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::try_allocate_digest_output;
+
+    #[test]
+    fn digest_output_allocation_is_fallible() {
+        assert!(try_allocate_digest_output(usize::MAX).is_err());
+    }
 }

--- a/modules/llrt_crypto/src/subtle/digest.rs
+++ b/modules/llrt_crypto/src/subtle/digest.rs
@@ -106,9 +106,8 @@ fn prepare_digest<'js>(
     data: ObjectBytes<'js>,
 ) -> Result<(DigestAlgorithm, Vec<u8>)> {
     let (name, object) = to_name_and_maybe_object(ctx, algorithm)?;
-    let name = match DigestAlgorithmName::try_from(name.as_str()) {
-        Ok(name) => name,
-        Err(()) => return algorithm_not_supported_error(ctx),
+    let Ok(name) = DigestAlgorithmName::try_from(name.as_str()) else {
+        return algorithm_not_supported_error(ctx);
     };
     let algorithm = match name {
         DigestAlgorithmName::CShake(strength) => {

--- a/modules/llrt_crypto/src/subtle/encapsulation.rs
+++ b/modules/llrt_crypto/src/subtle/encapsulation.rs
@@ -4,7 +4,7 @@
 use std::future::Future;
 
 use llrt_utils::bytes::ObjectBytes;
-use rquickjs::{Array, ArrayBuffer, Class, Ctx, Result, Value};
+use rquickjs::{Array, ArrayBuffer, Class, Ctx, Object, Result, Value};
 
 use crate::provider::{modern, HybridKemVariant, MlKemVariant};
 
@@ -26,8 +26,8 @@ pub(super) enum EncapsulationAlgorithm {
 impl EncapsulationAlgorithm {
     fn name(self) -> &'static str {
         match self {
-            Self::MlKem(variant) => variant.name(),
-            Self::HybridKem(variant) => variant.name(),
+            Self::MlKem(variant) => variant.as_str(),
+            Self::HybridKem(variant) => variant.as_str(),
         }
     }
 
@@ -66,20 +66,13 @@ pub(super) fn normalize_encapsulation_algorithm<'js>(
     value: Value<'js>,
 ) -> Result<EncapsulationAlgorithm> {
     let (name, _) = to_name_and_maybe_object(ctx, value)?;
-    match normalize_algorithm_name(&name).as_str() {
-        "ML-KEM-512" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem512)),
-        "ML-KEM-768" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem768)),
-        "ML-KEM-1024" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem1024)),
-        "MLKEM768-P256" => Ok(EncapsulationAlgorithm::HybridKem(
-            HybridKemVariant::MlKem768P256,
-        )),
-        "MLKEM768-X25519" => Ok(EncapsulationAlgorithm::HybridKem(
-            HybridKemVariant::MlKem768X25519,
-        )),
-        "MLKEM1024-P384" => Ok(EncapsulationAlgorithm::HybridKem(
-            HybridKemVariant::MlKem1024P384,
-        )),
-        _ => algorithm_not_supported_error(ctx),
+    let name = normalize_algorithm_name(&name);
+    if let Ok(variant) = MlKemVariant::try_from(name.as_str()) {
+        Ok(EncapsulationAlgorithm::MlKem(variant))
+    } else if let Ok(variant) = HybridKemVariant::try_from(name.as_str()) {
+        Ok(EncapsulationAlgorithm::HybridKem(variant))
+    } else {
+        algorithm_not_supported_error(ctx)
     }
 }
 
@@ -106,15 +99,11 @@ fn check_encapsulation_key(
     usage: &str,
     kind: KeyKind,
 ) -> Result<()> {
-    let matches_algorithm = matches!(
-        (algorithm, &key.algorithm),
-        (EncapsulationAlgorithm::MlKem(variant), KeyAlgorithm::MlKem(key_variant))
-            if variant == *key_variant
-    ) || matches!(
-        (algorithm, &key.algorithm),
-        (EncapsulationAlgorithm::HybridKem(variant), KeyAlgorithm::HybridKem(key_variant))
-            if variant == *key_variant
-    );
+    let matches_algorithm = match (algorithm, &key.algorithm) {
+        (EncapsulationAlgorithm::MlKem(a), KeyAlgorithm::MlKem(b)) => a == *b,
+        (EncapsulationAlgorithm::HybridKem(a), KeyAlgorithm::HybridKem(b)) => a == *b,
+        _ => false,
+    };
     if key.name.as_ref() != algorithm.name() || !matches_algorithm {
         return algorithm_invalid_access_error(ctx, algorithm.name());
     }
@@ -126,7 +115,7 @@ pub fn subtle_encapsulate_bits<'js>(
     ctx: Ctx<'js>,
     algorithm: Value<'js>,
     key: Class<'js, CryptoKey<'js>>,
-) -> impl Future<Output = Result<rquickjs::Object<'js>>> + 'js {
+) -> impl Future<Output = Result<Object<'js>>> + 'js {
     let prepared = normalize_encapsulation_algorithm(&ctx, algorithm);
 
     async move {
@@ -137,7 +126,7 @@ pub fn subtle_encapsulate_bits<'js>(
             algorithm.encapsulate(&key.handle).or_throw_dom(&ctx)?
         };
 
-        let result = rquickjs::Object::new(ctx.clone())?;
+        let result = Object::new(ctx.clone())?;
         result.set("sharedKey", ArrayBuffer::new(ctx.clone(), shared_key)?)?;
         result.set("ciphertext", ArrayBuffer::new(ctx, ciphertext)?)?;
         Ok(result)
@@ -179,7 +168,7 @@ pub fn subtle_encapsulate_key<'js>(
     shared_key_algorithm: Value<'js>,
     extractable: bool,
     usages: Array<'js>,
-) -> impl Future<Output = Result<rquickjs::Object<'js>>> + 'js {
+) -> impl Future<Output = Result<Object<'js>>> + 'js {
     let prepared = normalize_encapsulation_algorithm(&ctx, algorithm);
 
     async move {
@@ -191,7 +180,7 @@ pub fn subtle_encapsulate_key<'js>(
         };
         let shared_key =
             import_shared_key(&ctx, shared_key_algorithm, extractable, usages, shared_key)?;
-        let result = rquickjs::Object::new(ctx.clone())?;
+        let result = Object::new(ctx.clone())?;
         result.set("sharedKey", shared_key)?;
         result.set("ciphertext", ArrayBuffer::new(ctx, ciphertext)?)?;
         Ok(result)

--- a/modules/llrt_crypto/src/subtle/encapsulation.rs
+++ b/modules/llrt_crypto/src/subtle/encapsulation.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{Array, ArrayBuffer, Class, Ctx, Result, Value};
 
-use crate::provider::{modern, MlKemVariant};
+use crate::provider::{modern, HybridKemVariant, MlKemVariant};
 
 use super::import_key::import_key;
 use super::{
@@ -20,12 +20,14 @@ use super::{
 #[derive(Clone, Copy)]
 enum EncapsulationAlgorithm {
     MlKem(MlKemVariant),
+    HybridKem(HybridKemVariant),
 }
 
 impl EncapsulationAlgorithm {
     fn name(self) -> &'static str {
         match self {
             Self::MlKem(variant) => variant.name(),
+            Self::HybridKem(variant) => variant.name(),
         }
     }
 
@@ -35,6 +37,7 @@ impl EncapsulationAlgorithm {
     ) -> std::result::Result<(Vec<u8>, Vec<u8>), crate::provider::CryptoError> {
         match self {
             Self::MlKem(variant) => modern::ml_kem_encapsulate(variant, public_key),
+            Self::HybridKem(variant) => modern::hybrid_kem_encapsulate(variant, public_key),
         }
     }
 
@@ -45,6 +48,9 @@ impl EncapsulationAlgorithm {
     ) -> std::result::Result<Vec<u8>, crate::provider::CryptoError> {
         match self {
             Self::MlKem(variant) => modern::ml_kem_decapsulate(variant, private_key, ciphertext),
+            Self::HybridKem(variant) => {
+                modern::hybrid_kem_decapsulate(variant, private_key, ciphertext)
+            },
         }
     }
 }
@@ -58,6 +64,15 @@ fn normalize_encapsulation_algorithm<'js>(
         "ML-KEM-512" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem512)),
         "ML-KEM-768" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem768)),
         "ML-KEM-1024" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem1024)),
+        "MLKEM768-P256" => Ok(EncapsulationAlgorithm::HybridKem(
+            HybridKemVariant::MlKem768P256,
+        )),
+        "MLKEM768-X25519" => Ok(EncapsulationAlgorithm::HybridKem(
+            HybridKemVariant::MlKem768X25519,
+        )),
+        "MLKEM1024-P384" => Ok(EncapsulationAlgorithm::HybridKem(
+            HybridKemVariant::MlKem1024P384,
+        )),
         _ => algorithm_not_supported_error(ctx),
     }
 }
@@ -88,6 +103,10 @@ fn check_encapsulation_key(
     let matches_algorithm = matches!(
         (algorithm, &key.algorithm),
         (EncapsulationAlgorithm::MlKem(variant), KeyAlgorithm::MlKem(key_variant))
+            if variant == *key_variant
+    ) || matches!(
+        (algorithm, &key.algorithm),
+        (EncapsulationAlgorithm::HybridKem(variant), KeyAlgorithm::HybridKem(key_variant))
             if variant == *key_variant
     );
     if key.name.as_ref() != algorithm.name() || !matches_algorithm {

--- a/modules/llrt_crypto/src/subtle/encapsulation.rs
+++ b/modules/llrt_crypto/src/subtle/encapsulation.rs
@@ -18,7 +18,7 @@ use super::{
 };
 
 #[derive(Clone, Copy)]
-enum EncapsulationAlgorithm {
+pub(super) enum EncapsulationAlgorithm {
     MlKem(MlKemVariant),
     HybridKem(HybridKemVariant),
 }
@@ -28,6 +28,12 @@ impl EncapsulationAlgorithm {
         match self {
             Self::MlKem(variant) => variant.name(),
             Self::HybridKem(variant) => variant.name(),
+        }
+    }
+
+    pub(super) const fn shared_key_length(self) -> usize {
+        match self {
+            Self::MlKem(_) | Self::HybridKem(_) => 32,
         }
     }
 
@@ -55,7 +61,7 @@ impl EncapsulationAlgorithm {
     }
 }
 
-fn normalize_encapsulation_algorithm<'js>(
+pub(super) fn normalize_encapsulation_algorithm<'js>(
     ctx: &Ctx<'js>,
     value: Value<'js>,
 ) -> Result<EncapsulationAlgorithm> {

--- a/modules/llrt_crypto/src/subtle/encapsulation.rs
+++ b/modules/llrt_crypto/src/subtle/encapsulation.rs
@@ -1,0 +1,205 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+
+use llrt_utils::bytes::ObjectBytes;
+use rquickjs::{Array, ArrayBuffer, Class, Ctx, Result, Value};
+
+use crate::provider::{modern, MlKemVariant};
+
+use super::import_key::import_key;
+use super::{
+    algorithm_invalid_access_error, algorithm_not_supported_error,
+    crypto_key::{CryptoKey, KeyKind},
+    key_algorithm::{KeyAlgorithm, KeyFormatData},
+    normalize_algorithm_name, to_name_and_maybe_object,
+    util::ResultDomExt,
+};
+
+#[derive(Clone, Copy)]
+enum EncapsulationAlgorithm {
+    MlKem(MlKemVariant),
+}
+
+impl EncapsulationAlgorithm {
+    fn name(self) -> &'static str {
+        match self {
+            Self::MlKem(variant) => variant.name(),
+        }
+    }
+
+    fn encapsulate(
+        self,
+        public_key: &[u8],
+    ) -> std::result::Result<(Vec<u8>, Vec<u8>), crate::provider::CryptoError> {
+        match self {
+            Self::MlKem(variant) => modern::ml_kem_encapsulate(variant, public_key),
+        }
+    }
+
+    fn decapsulate(
+        self,
+        private_key: &[u8],
+        ciphertext: &[u8],
+    ) -> std::result::Result<Vec<u8>, crate::provider::CryptoError> {
+        match self {
+            Self::MlKem(variant) => modern::ml_kem_decapsulate(variant, private_key, ciphertext),
+        }
+    }
+}
+
+fn normalize_encapsulation_algorithm<'js>(
+    ctx: &Ctx<'js>,
+    value: Value<'js>,
+) -> Result<EncapsulationAlgorithm> {
+    let (name, _) = to_name_and_maybe_object(ctx, value)?;
+    match normalize_algorithm_name(&name).as_str() {
+        "ML-KEM-512" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem512)),
+        "ML-KEM-768" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem768)),
+        "ML-KEM-1024" => Ok(EncapsulationAlgorithm::MlKem(MlKemVariant::MlKem1024)),
+        _ => algorithm_not_supported_error(ctx),
+    }
+}
+
+fn import_shared_key<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    extractable: bool,
+    usages: Array<'js>,
+    data: Vec<u8>,
+) -> Result<Class<'js, CryptoKey<'js>>> {
+    import_key(
+        ctx.clone(),
+        KeyFormatData::RawSecret(ObjectBytes::Vec(data)),
+        algorithm,
+        extractable,
+        usages,
+    )
+}
+
+fn check_encapsulation_key(
+    ctx: &Ctx<'_>,
+    key: &CryptoKey<'_>,
+    algorithm: EncapsulationAlgorithm,
+    usage: &str,
+    kind: KeyKind,
+) -> Result<()> {
+    let matches_algorithm = matches!(
+        (algorithm, &key.algorithm),
+        (EncapsulationAlgorithm::MlKem(variant), KeyAlgorithm::MlKem(key_variant))
+            if variant == *key_variant
+    );
+    if key.name.as_ref() != algorithm.name() || !matches_algorithm {
+        return algorithm_invalid_access_error(ctx, algorithm.name());
+    }
+    key.check_validity(usage).or_throw_dom(ctx)?;
+    key.check_kind(kind).or_throw_dom(ctx)
+}
+
+pub fn subtle_encapsulate_bits<'js>(
+    ctx: Ctx<'js>,
+    algorithm: Value<'js>,
+    key: Class<'js, CryptoKey<'js>>,
+) -> impl Future<Output = Result<rquickjs::Object<'js>>> + 'js {
+    let prepared = normalize_encapsulation_algorithm(&ctx, algorithm);
+
+    async move {
+        let algorithm = prepared?;
+        let (ciphertext, shared_key) = {
+            let key = key.borrow();
+            check_encapsulation_key(&ctx, &key, algorithm, "encapsulateBits", KeyKind::Public)?;
+            algorithm.encapsulate(&key.handle).or_throw_dom(&ctx)?
+        };
+
+        let result = rquickjs::Object::new(ctx.clone())?;
+        result.set("sharedKey", ArrayBuffer::new(ctx.clone(), shared_key)?)?;
+        result.set("ciphertext", ArrayBuffer::new(ctx, ciphertext)?)?;
+        Ok(result)
+    }
+}
+
+pub fn subtle_decapsulate_bits<'js>(
+    ctx: Ctx<'js>,
+    algorithm: Value<'js>,
+    key: Class<'js, CryptoKey<'js>>,
+    ciphertext: ObjectBytes<'js>,
+) -> impl Future<Output = Result<ArrayBuffer<'js>>> + 'js {
+    let prepared: Result<_> = (|| {
+        let algorithm = normalize_encapsulation_algorithm(&ctx, algorithm)?;
+        let ciphertext = ciphertext
+            .as_bytes_opt()
+            .map(<[u8]>::to_vec)
+            .unwrap_or_default();
+        Ok((algorithm, ciphertext))
+    })();
+
+    async move {
+        let (algorithm, ciphertext) = prepared?;
+        let shared_key = {
+            let key = key.borrow();
+            check_encapsulation_key(&ctx, &key, algorithm, "decapsulateBits", KeyKind::Private)?;
+            algorithm
+                .decapsulate(&key.handle, &ciphertext)
+                .or_throw_dom(&ctx)?
+        };
+        ArrayBuffer::new(ctx, shared_key)
+    }
+}
+
+pub fn subtle_encapsulate_key<'js>(
+    ctx: Ctx<'js>,
+    algorithm: Value<'js>,
+    key: Class<'js, CryptoKey<'js>>,
+    shared_key_algorithm: Value<'js>,
+    extractable: bool,
+    usages: Array<'js>,
+) -> impl Future<Output = Result<rquickjs::Object<'js>>> + 'js {
+    let prepared = normalize_encapsulation_algorithm(&ctx, algorithm);
+
+    async move {
+        let algorithm = prepared?;
+        let (ciphertext, shared_key) = {
+            let key = key.borrow();
+            check_encapsulation_key(&ctx, &key, algorithm, "encapsulateKey", KeyKind::Public)?;
+            algorithm.encapsulate(&key.handle).or_throw_dom(&ctx)?
+        };
+        let shared_key =
+            import_shared_key(&ctx, shared_key_algorithm, extractable, usages, shared_key)?;
+        let result = rquickjs::Object::new(ctx.clone())?;
+        result.set("sharedKey", shared_key)?;
+        result.set("ciphertext", ArrayBuffer::new(ctx, ciphertext)?)?;
+        Ok(result)
+    }
+}
+
+pub fn subtle_decapsulate_key<'js>(
+    ctx: Ctx<'js>,
+    algorithm: Value<'js>,
+    key: Class<'js, CryptoKey<'js>>,
+    ciphertext: ObjectBytes<'js>,
+    shared_key_algorithm: Value<'js>,
+    extractable: bool,
+    usages: Array<'js>,
+) -> impl Future<Output = Result<Class<'js, CryptoKey<'js>>>> + 'js {
+    let prepared: Result<_> = (|| {
+        let algorithm = normalize_encapsulation_algorithm(&ctx, algorithm)?;
+        let ciphertext = ciphertext
+            .as_bytes_opt()
+            .map(<[u8]>::to_vec)
+            .unwrap_or_default();
+        Ok((algorithm, ciphertext))
+    })();
+
+    async move {
+        let (algorithm, ciphertext) = prepared?;
+        let shared_key = {
+            let key = key.borrow();
+            check_encapsulation_key(&ctx, &key, algorithm, "decapsulateKey", KeyKind::Private)?;
+            algorithm
+                .decapsulate(&key.handle, &ciphertext)
+                .or_throw_dom(&ctx)?
+        };
+        import_shared_key(&ctx, shared_key_algorithm, extractable, usages, shared_key)
+    }
+}

--- a/modules/llrt_crypto/src/subtle/encryption.rs
+++ b/modules/llrt_crypto/src/subtle/encryption.rs
@@ -7,7 +7,7 @@ use llrt_utils::{bytes::ObjectBytes, result::ResultExt};
 use rquickjs::{ArrayBuffer, Class, Ctx, Exception, FromJs, Result, Value};
 
 use crate::{
-    provider::{AesMode, CryptoProvider},
+    provider::{modern, AesMode, CryptoProvider},
     CRYPTO_PROVIDER,
 };
 
@@ -184,6 +184,31 @@ pub fn encrypt_decrypt(
                             data,
                             aad,
                         )
+                        .or_throw_dom(ctx)?
+                },
+            }
+        },
+        EncryptionAlgorithm::ChaCha20Poly1305 {
+            iv,
+            tag_length,
+            additional_data,
+        } => {
+            if !matches!(key.algorithm, KeyAlgorithm::ChaCha20Poly1305) {
+                return algorithm_mismatch_error(ctx, "ChaCha20-Poly1305");
+            }
+            if iv.len() != 12 || *tag_length != 128 {
+                return Err(DOMException::operation_error(
+                    ctx,
+                    "Invalid ChaCha20-Poly1305 parameters",
+                ));
+            }
+            match operation {
+                EncryptionOperation::Encrypt => {
+                    modern::chacha20_poly1305_encrypt(handle, iv, data, additional_data.as_deref())
+                        .or_throw_dom(ctx)?
+                },
+                EncryptionOperation::Decrypt => {
+                    modern::chacha20_poly1305_decrypt(handle, iv, data, additional_data.as_deref())
                         .or_throw_dom(ctx)?
                 },
             }

--- a/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/encryption_algorithm.rs
@@ -23,6 +23,11 @@ pub enum EncryptionAlgorithm {
         tag_length: u8,
         additional_data: Option<Box<[u8]>>,
     },
+    ChaCha20Poly1305 {
+        iv: Box<[u8]>,
+        tag_length: u8,
+        additional_data: Option<Box<[u8]>>,
+    },
     RsaOaep {
         label: Option<Box<[u8]>>,
     },
@@ -97,6 +102,28 @@ impl<'js> FromJs<'js> for EncryptionAlgorithm {
                     iv,
                     additional_data,
                     tag_length,
+                })
+            },
+            "ChaCha20-Poly1305" => {
+                let obj = obj?;
+                let iv = obj
+                    .get_required::<_, ObjectBytes>("iv", "algorithm")?
+                    .into_bytes(ctx)?
+                    .into_boxed_slice();
+                let additional_data = obj
+                    .get_optional::<_, ObjectBytes>("additionalData")?
+                    .map(|value| value.into_bytes(ctx))
+                    .transpose()?
+                    .map(Vec::into_boxed_slice);
+                let tag_length = get_optional_dictionary_value(&obj, "tagLength")?
+                    .map(|value| enforce_range_u8(ctx, value, "tagLength"))
+                    .transpose()?
+                    .unwrap_or(128);
+
+                Ok(EncryptionAlgorithm::ChaCha20Poly1305 {
+                    iv,
+                    tag_length,
+                    additional_data,
                 })
             },
             "RSA-OAEP" => {

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -65,7 +65,7 @@ pub fn export_key<'js>(
         KeyFormat::RawPublic
             if matches!(
                 key.algorithm,
-                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_)
+                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_) | KeyAlgorithm::HybridKem(_)
             ) =>
         {
             if key.kind != KeyKind::Public {
@@ -79,7 +79,7 @@ pub fn export_key<'js>(
         KeyFormat::RawSeed
             if matches!(
                 key.algorithm,
-                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_)
+                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_) | KeyAlgorithm::HybridKem(_)
             ) =>
         {
             if key.kind != KeyKind::Private {
@@ -93,7 +93,7 @@ pub fn export_key<'js>(
         KeyFormat::Raw
             if matches!(
                 key.algorithm,
-                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_)
+                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_) | KeyAlgorithm::HybridKem(_)
             ) =>
         {
             return key_format_not_supported_error(ctx, &key.name, "raw");
@@ -270,6 +270,19 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
         KeyAlgorithm::MlKem(variant) => {
             let public_key = if key.kind == KeyKind::Private {
                 modern::ml_kem_public_key(*variant, &key.handle).or_throw_dom(ctx)?
+            } else {
+                key.handle.to_vec()
+            };
+            obj.set("kty", "AKP")?;
+            obj.set("alg", variant.name())?;
+            obj.set("pub", bytes_to_b64_url_safe_string(&public_key))?;
+            if key.kind == KeyKind::Private {
+                obj.set("priv", bytes_to_b64_url_safe_string(&key.handle))?;
+            }
+        },
+        KeyAlgorithm::HybridKem(variant) => {
+            let public_key = if key.kind == KeyKind::Private {
+                modern::hybrid_kem_public_key(*variant, &key.handle).or_throw_dom(ctx)?
             } else {
                 key.handle.to_vec()
             };

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -62,7 +62,12 @@ pub fn export_key<'js>(
     }
     let bytes = match format {
         KeyFormat::Jwk => return Ok(ExportOutput::Object(export_jwk(ctx, key)?)),
-        KeyFormat::RawPublic if matches!(key.algorithm, KeyAlgorithm::MlDsa(_)) => {
+        KeyFormat::RawPublic
+            if matches!(
+                key.algorithm,
+                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_)
+            ) =>
+        {
             if key.kind != KeyKind::Public {
                 return Err(DOMException::invalid_access_error(
                     ctx,
@@ -71,7 +76,12 @@ pub fn export_key<'js>(
             }
             Ok(key.handle.to_vec())
         },
-        KeyFormat::RawSeed if matches!(key.algorithm, KeyAlgorithm::MlDsa(_)) => {
+        KeyFormat::RawSeed
+            if matches!(
+                key.algorithm,
+                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_)
+            ) =>
+        {
             if key.kind != KeyKind::Private {
                 return Err(DOMException::invalid_access_error(
                     ctx,
@@ -80,7 +90,12 @@ pub fn export_key<'js>(
             }
             Ok(key.handle.to_vec())
         },
-        KeyFormat::Raw if matches!(key.algorithm, KeyAlgorithm::MlDsa(_)) => {
+        KeyFormat::Raw
+            if matches!(
+                key.algorithm,
+                KeyAlgorithm::MlDsa(_) | KeyAlgorithm::MlKem(_)
+            ) =>
+        {
             return key_format_not_supported_error(ctx, &key.name, "raw");
         },
         KeyFormat::Raw => export_raw(ctx, key),
@@ -143,6 +158,9 @@ fn export_pkcs8(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
         KeyAlgorithm::MlDsa(variant) => {
             modern::export_ml_dsa_private_key_pkcs8(*variant, &key.handle).or_throw_dom(ctx)
         },
+        KeyAlgorithm::MlKem(variant) => {
+            modern::export_ml_kem_private_key_pkcs8(*variant, &key.handle).or_throw_dom(ctx)
+        },
         KeyAlgorithm::X25519 => CRYPTO_PROVIDER
             .export_okp_private_key_pkcs8(
                 &key.handle,
@@ -179,6 +197,9 @@ fn export_spki(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
         KeyAlgorithm::MlDsa(variant) => {
             modern::export_ml_dsa_public_key_spki(*variant, &key.handle).or_throw_dom(ctx)
         },
+        KeyAlgorithm::MlKem(variant) => {
+            modern::export_ml_kem_public_key_spki(*variant, &key.handle).or_throw_dom(ctx)
+        },
         KeyAlgorithm::Rsa { .. } => CRYPTO_PROVIDER
             .export_rsa_public_key_spki(&key.handle)
             .or_throw_dom(ctx),
@@ -195,6 +216,9 @@ fn supports_der_export(name: &str) -> bool {
             | "ML-DSA-44"
             | "ML-DSA-65"
             | "ML-DSA-87"
+            | "ML-KEM-512"
+            | "ML-KEM-768"
+            | "ML-KEM-1024"
             | "RSA-OAEP"
             | "RSA-PSS"
             | "RSASSA-PKCS1-v1_5"
@@ -233,6 +257,19 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
         KeyAlgorithm::MlDsa(variant) => {
             let public_key = if key.kind == KeyKind::Private {
                 modern::ml_dsa_public_key(*variant, &key.handle).or_throw_dom(ctx)?
+            } else {
+                key.handle.to_vec()
+            };
+            obj.set("kty", "AKP")?;
+            obj.set("alg", variant.name())?;
+            obj.set("pub", bytes_to_b64_url_safe_string(&public_key))?;
+            if key.kind == KeyKind::Private {
+                obj.set("priv", bytes_to_b64_url_safe_string(&key.handle))?;
+            }
+        },
+        KeyAlgorithm::MlKem(variant) => {
+            let public_key = if key.kind == KeyKind::Private {
+                modern::ml_kem_public_key(*variant, &key.handle).or_throw_dom(ctx)?
             } else {
                 key.handle.to_vec()
             };

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -7,7 +7,7 @@ use llrt_encoding::bytes_to_b64_url_safe_string;
 use llrt_exceptions::DOMException;
 use rquickjs::{ArrayBuffer, Class, Ctx, FromJs, Object, Result, Value};
 
-use crate::provider::CryptoProvider;
+use crate::provider::{modern, CryptoProvider};
 use crate::CRYPTO_PROVIDER;
 
 use super::{
@@ -62,6 +62,27 @@ pub fn export_key<'js>(
     }
     let bytes = match format {
         KeyFormat::Jwk => return Ok(ExportOutput::Object(export_jwk(ctx, key)?)),
+        KeyFormat::RawPublic if matches!(key.algorithm, KeyAlgorithm::MlDsa(_)) => {
+            if key.kind != KeyKind::Public {
+                return Err(DOMException::invalid_access_error(
+                    ctx,
+                    "raw-public requires a public key",
+                ));
+            }
+            Ok(key.handle.to_vec())
+        },
+        KeyFormat::RawSeed if matches!(key.algorithm, KeyAlgorithm::MlDsa(_)) => {
+            if key.kind != KeyKind::Private {
+                return Err(DOMException::invalid_access_error(
+                    ctx,
+                    "raw-seed requires a private key",
+                ));
+            }
+            Ok(key.handle.to_vec())
+        },
+        KeyFormat::Raw if matches!(key.algorithm, KeyAlgorithm::MlDsa(_)) => {
+            return key_format_not_supported_error(ctx, &key.name, "raw");
+        },
         KeyFormat::Raw => export_raw(ctx, key),
         KeyFormat::RawPublic if key.kind != KeyKind::Secret => export_raw(ctx, key),
         KeyFormat::RawSecret if key.kind == KeyKind::Secret => export_raw(ctx, key),
@@ -119,6 +140,9 @@ fn export_pkcs8(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
                 const_oid::db::rfc8410::ID_ED_25519.as_bytes(),
             )
             .or_throw_dom(ctx),
+        KeyAlgorithm::MlDsa(variant) => {
+            modern::export_ml_dsa_private_key_pkcs8(*variant, &key.handle).or_throw_dom(ctx)
+        },
         KeyAlgorithm::X25519 => CRYPTO_PROVIDER
             .export_okp_private_key_pkcs8(
                 &key.handle,
@@ -152,6 +176,9 @@ fn export_spki(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
         KeyAlgorithm::X25519 => CRYPTO_PROVIDER
             .export_okp_public_key_spki(&key.handle, const_oid::db::rfc8410::ID_X_25519.as_bytes())
             .or_throw_dom(ctx),
+        KeyAlgorithm::MlDsa(variant) => {
+            modern::export_ml_dsa_public_key_spki(*variant, &key.handle).or_throw_dom(ctx)
+        },
         KeyAlgorithm::Rsa { .. } => CRYPTO_PROVIDER
             .export_rsa_public_key_spki(&key.handle)
             .or_throw_dom(ctx),
@@ -162,7 +189,16 @@ fn export_spki(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
 fn supports_der_export(name: &str) -> bool {
     matches!(
         name,
-        "ECDH" | "ECDSA" | "Ed25519" | "RSA-OAEP" | "RSA-PSS" | "RSASSA-PKCS1-v1_5" | "X25519"
+        "ECDH"
+            | "ECDSA"
+            | "Ed25519"
+            | "ML-DSA-44"
+            | "ML-DSA-65"
+            | "ML-DSA-87"
+            | "RSA-OAEP"
+            | "RSA-PSS"
+            | "RSASSA-PKCS1-v1_5"
+            | "X25519"
     )
 }
 
@@ -193,6 +229,19 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
             obj.set("kty", "oct")?;
             obj.set("alg", "C20P")?;
             obj.set("k", bytes_to_b64_url_safe_string(&key.handle))?;
+        },
+        KeyAlgorithm::MlDsa(variant) => {
+            let public_key = if key.kind == KeyKind::Private {
+                modern::ml_dsa_public_key(*variant, &key.handle).or_throw_dom(ctx)?
+            } else {
+                key.handle.to_vec()
+            };
+            obj.set("kty", "AKP")?;
+            obj.set("alg", variant.name())?;
+            obj.set("pub", bytes_to_b64_url_safe_string(&public_key))?;
+            if key.kind == KeyKind::Private {
+                obj.set("priv", bytes_to_b64_url_safe_string(&key.handle))?;
+            }
         },
         KeyAlgorithm::Ec { curve, .. } => {
             let jwk = CRYPTO_PROVIDER

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -7,7 +7,7 @@ use llrt_encoding::bytes_to_b64_url_safe_string;
 use llrt_exceptions::DOMException;
 use rquickjs::{ArrayBuffer, Class, Ctx, FromJs, Object, Result, Value};
 
-use crate::provider::{modern, CryptoProvider};
+use crate::provider::{modern, CryptoProvider, MlDsaVariant, MlKemVariant};
 use crate::CRYPTO_PROVIDER;
 
 use super::{
@@ -208,22 +208,12 @@ fn export_spki(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
 }
 
 fn supports_der_export(name: &str) -> bool {
-    matches!(
-        name,
-        "ECDH"
-            | "ECDSA"
-            | "Ed25519"
-            | "ML-DSA-44"
-            | "ML-DSA-65"
-            | "ML-DSA-87"
-            | "ML-KEM-512"
-            | "ML-KEM-768"
-            | "ML-KEM-1024"
-            | "RSA-OAEP"
-            | "RSA-PSS"
-            | "RSASSA-PKCS1-v1_5"
-            | "X25519"
-    )
+    MlDsaVariant::try_from(name).is_ok()
+        || MlKemVariant::try_from(name).is_ok()
+        || matches!(
+            name,
+            "ECDH" | "ECDSA" | "Ed25519" | "RSA-OAEP" | "RSA-PSS" | "RSASSA-PKCS1-v1_5" | "X25519"
+        )
 }
 
 fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
@@ -261,7 +251,7 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
                 key.handle.to_vec()
             };
             obj.set("kty", "AKP")?;
-            obj.set("alg", variant.name())?;
+            obj.set("alg", variant.as_str())?;
             obj.set("pub", bytes_to_b64_url_safe_string(&public_key))?;
             if key.kind == KeyKind::Private {
                 obj.set("priv", bytes_to_b64_url_safe_string(&key.handle))?;
@@ -274,7 +264,7 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
                 key.handle.to_vec()
             };
             obj.set("kty", "AKP")?;
-            obj.set("alg", variant.name())?;
+            obj.set("alg", variant.as_str())?;
             obj.set("pub", bytes_to_b64_url_safe_string(&public_key))?;
             if key.kind == KeyKind::Private {
                 obj.set("priv", bytes_to_b64_url_safe_string(&key.handle))?;
@@ -287,7 +277,7 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
                 key.handle.to_vec()
             };
             obj.set("kty", "AKP")?;
-            obj.set("alg", variant.name())?;
+            obj.set("alg", variant.as_str())?;
             obj.set("pub", bytes_to_b64_url_safe_string(&public_key))?;
             if key.kind == KeyKind::Private {
                 obj.set("priv", bytes_to_b64_url_safe_string(&key.handle))?;

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -83,7 +83,9 @@ fn export_raw(ctx: &Ctx<'_>, key: &CryptoKey) -> Result<Vec<u8>> {
         ));
     }
     match &key.algorithm {
-        KeyAlgorithm::Aes { .. } | KeyAlgorithm::Hmac { .. } => Ok(key.handle.to_vec()),
+        KeyAlgorithm::Aes { .. } | KeyAlgorithm::Hmac { .. } | KeyAlgorithm::ChaCha20Poly1305 => {
+            Ok(key.handle.to_vec())
+        },
         KeyAlgorithm::Ec { curve, .. } => CRYPTO_PROVIDER
             .export_ec_public_key_sec1(&key.handle, *curve, false)
             .or_throw_dom(ctx),
@@ -185,6 +187,11 @@ fn export_jwk<'js>(ctx: &Ctx<'js>, key: &CryptoKey) -> Result<Object<'js>> {
         KeyAlgorithm::Hmac { hash, .. } => {
             obj.set("kty", "oct")?;
             obj.set("alg", ["HS", &hash.as_str()[4..]].concat())?;
+            obj.set("k", bytes_to_b64_url_safe_string(&key.handle))?;
+        },
+        KeyAlgorithm::ChaCha20Poly1305 => {
+            obj.set("kty", "oct")?;
+            obj.set("alg", "C20P")?;
             obj.set("k", bytes_to_b64_url_safe_string(&key.handle))?;
         },
         KeyAlgorithm::Ec { curve, .. } => {

--- a/modules/llrt_crypto/src/subtle/export_key.rs
+++ b/modules/llrt_crypto/src/subtle/export_key.rs
@@ -12,7 +12,7 @@ use crate::CRYPTO_PROVIDER;
 
 use super::{
     crypto_key::KeyKind,
-    key_algorithm::{KeyAlgorithm, KeyFormat},
+    key_algorithm::{key_format_not_supported_error, KeyAlgorithm, KeyFormat},
     util::ResultDomExt,
     CryptoKey,
 };
@@ -63,8 +63,11 @@ pub fn export_key<'js>(
     let bytes = match format {
         KeyFormat::Jwk => return Ok(ExportOutput::Object(export_jwk(ctx, key)?)),
         KeyFormat::Raw => export_raw(ctx, key),
+        KeyFormat::RawPublic if key.kind != KeyKind::Secret => export_raw(ctx, key),
+        KeyFormat::RawSecret if key.kind == KeyKind::Secret => export_raw(ctx, key),
         KeyFormat::Spki => export_spki(ctx, key),
         KeyFormat::Pkcs8 => export_pkcs8(ctx, key),
+        format => return key_format_not_supported_error(ctx, &key.name, format.as_str()),
     }?;
     Ok(ExportOutput::Bytes(bytes))
 }

--- a/modules/llrt_crypto/src/subtle/generate_key.rs
+++ b/modules/llrt_crypto/src/subtle/generate_key.rs
@@ -111,6 +111,8 @@ fn generate_key(ctx: &Ctx<'_>, algorithm: &KeyAlgorithm) -> Result<(Vec<u8>, Vec
             .or_throw_dom_with_msg(ctx, "ML-DSA key generation failed"),
         KeyAlgorithm::MlKem(variant) => modern::generate_ml_kem_key(*variant)
             .or_throw_dom_with_msg(ctx, "ML-KEM key generation failed"),
+        KeyAlgorithm::HybridKem(variant) => modern::generate_hybrid_kem_key(*variant)
+            .or_throw_dom_with_msg(ctx, "Hybrid KEM key generation failed"),
         KeyAlgorithm::Rsa {
             modulus_length,
             public_exponent,

--- a/modules/llrt_crypto/src/subtle/generate_key.rs
+++ b/modules/llrt_crypto/src/subtle/generate_key.rs
@@ -109,6 +109,8 @@ fn generate_key(ctx: &Ctx<'_>, algorithm: &KeyAlgorithm) -> Result<(Vec<u8>, Vec
             .or_throw_dom_with_msg(ctx, "X25519 key generation failed"),
         KeyAlgorithm::MlDsa(variant) => modern::generate_ml_dsa_key(*variant)
             .or_throw_dom_with_msg(ctx, "ML-DSA key generation failed"),
+        KeyAlgorithm::MlKem(variant) => modern::generate_ml_kem_key(*variant)
+            .or_throw_dom_with_msg(ctx, "ML-KEM key generation failed"),
         KeyAlgorithm::Rsa {
             modulus_length,
             public_exponent,

--- a/modules/llrt_crypto/src/subtle/generate_key.rs
+++ b/modules/llrt_crypto/src/subtle/generate_key.rs
@@ -3,7 +3,10 @@
 use llrt_exceptions::DOMException;
 use rquickjs::{object::Property, Array, Class, Ctx, Object, Result, Value};
 
-use crate::{provider::CryptoProvider, CRYPTO_PROVIDER};
+use crate::{
+    provider::{modern, CryptoProvider},
+    CRYPTO_PROVIDER,
+};
 
 use super::{
     algorithm_not_supported_error,
@@ -104,6 +107,8 @@ fn generate_key(ctx: &Ctx<'_>, algorithm: &KeyAlgorithm) -> Result<(Vec<u8>, Vec
         KeyAlgorithm::X25519 => CRYPTO_PROVIDER
             .generate_x25519_key()
             .or_throw_dom_with_msg(ctx, "X25519 key generation failed"),
+        KeyAlgorithm::MlDsa(variant) => modern::generate_ml_dsa_key(*variant)
+            .or_throw_dom_with_msg(ctx, "ML-DSA key generation failed"),
         KeyAlgorithm::Rsa {
             modulus_length,
             public_exponent,

--- a/modules/llrt_crypto/src/subtle/generate_key.rs
+++ b/modules/llrt_crypto/src/subtle/generate_key.rs
@@ -33,7 +33,7 @@ pub async fn subtle_generate_key<'js>(
 
     if matches!(
         key_algorithm,
-        KeyAlgorithm::Aes { .. } | KeyAlgorithm::Hmac { .. }
+        KeyAlgorithm::Aes { .. } | KeyAlgorithm::Hmac { .. } | KeyAlgorithm::ChaCha20Poly1305
     ) {
         return Ok(Class::instance(
             ctx,
@@ -94,6 +94,7 @@ fn generate_key(ctx: &Ctx<'_>, algorithm: &KeyAlgorithm) -> Result<(Vec<u8>, Vec
                 .or_throw_dom_with_msg(ctx, "HMAC key generation failed")?;
             Ok((vec![], key))
         },
+        KeyAlgorithm::ChaCha20Poly1305 => Ok((vec![], crate::random_byte_array(32))),
         KeyAlgorithm::Ec { curve, .. } => CRYPTO_PROVIDER
             .generate_ec_key(*curve)
             .or_throw_dom_with_msg(ctx, "EC key generation failed"),

--- a/modules/llrt_crypto/src/subtle/get_public_key.rs
+++ b/modules/llrt_crypto/src/subtle/get_public_key.rs
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+
+use llrt_exceptions::DOMException;
+use rquickjs::{Array, Class, Ctx, Result};
+
+use crate::{
+    provider::{modern, CryptoProvider, RsaJwkImport},
+    CRYPTO_PROVIDER,
+};
+
+use super::{
+    crypto_key::{CryptoKey, KeyKind},
+    key_algorithm::KeyAlgorithm,
+    util::ResultDomExt,
+};
+
+pub fn subtle_get_public_key<'js>(
+    ctx: Ctx<'js>,
+    key: Class<'js, CryptoKey<'js>>,
+    usages: Array<'js>,
+) -> impl Future<Output = Result<Class<'js, CryptoKey<'js>>>> + 'js {
+    let prepared = {
+        let key = key.borrow();
+        if !key.algorithm.supports_get_public_key() {
+            Err(DOMException::not_supported_error(
+                &ctx,
+                "This algorithm cannot derive a public key",
+            ))
+        } else if key.kind != KeyKind::Private {
+            Err(DOMException::invalid_access_error(
+                &ctx,
+                "getPublicKey requires a private key",
+            ))
+        } else {
+            key.algorithm
+                .validate_public_usages(&ctx, &key.name, &usages)
+        }
+    };
+
+    async move {
+        let usages = prepared?;
+        let (name, algorithm, public_key) = {
+            let key = key.borrow();
+            let public_key = match &key.algorithm {
+                KeyAlgorithm::Ec { curve, .. } => CRYPTO_PROVIDER
+                    .export_ec_public_key_sec1(&key.handle, *curve, true)
+                    .or_throw_dom(&ctx)?,
+                KeyAlgorithm::Ed25519 => {
+                    CRYPTO_PROVIDER
+                        .export_okp_jwk(&key.handle, true, true)
+                        .or_throw_dom(&ctx)?
+                        .x
+                },
+                KeyAlgorithm::X25519 => {
+                    CRYPTO_PROVIDER
+                        .export_okp_jwk(&key.handle, true, false)
+                        .or_throw_dom(&ctx)?
+                        .x
+                },
+                KeyAlgorithm::Rsa { .. } => {
+                    let jwk = CRYPTO_PROVIDER
+                        .export_rsa_jwk(&key.handle, true)
+                        .or_throw_dom(&ctx)?;
+                    CRYPTO_PROVIDER
+                        .import_rsa_jwk(RsaJwkImport {
+                            n: &jwk.n,
+                            e: &jwk.e,
+                            d: None,
+                            p: None,
+                            q: None,
+                            dp: None,
+                            dq: None,
+                            qi: None,
+                        })
+                        .or_throw_dom(&ctx)?
+                        .key_data
+                },
+                KeyAlgorithm::MlDsa(variant) => {
+                    modern::ml_dsa_public_key(*variant, &key.handle).or_throw_dom(&ctx)?
+                },
+                KeyAlgorithm::MlKem(variant) => {
+                    modern::ml_kem_public_key(*variant, &key.handle).or_throw_dom(&ctx)?
+                },
+                KeyAlgorithm::HybridKem(variant) => {
+                    modern::hybrid_kem_public_key(*variant, &key.handle).or_throw_dom(&ctx)?
+                },
+                _ => unreachable!(),
+            };
+            (key.name.clone(), key.algorithm.clone(), public_key)
+        };
+
+        Class::instance(
+            ctx,
+            CryptoKey::new(KeyKind::Public, name, true, algorithm, usages, public_key),
+        )
+    }
+}

--- a/modules/llrt_crypto/src/subtle/import_key.rs
+++ b/modules/llrt_crypto/src/subtle/import_key.rs
@@ -9,7 +9,7 @@ use rquickjs::FromJs;
 use rquickjs::{Array, Class, Ctx, Result, Value};
 
 #[cfg(feature = "_subtle-full")]
-use super::key_algorithm::KeyFormat;
+use super::key_algorithm::{key_format_not_supported_error, KeyFormat};
 use super::{
     crypto_key::{CryptoKey, KeyKind},
     key_algorithm::{KeyAlgorithm, KeyAlgorithmMode, KeyAlgorithmWithUsages, KeyFormatData},
@@ -34,6 +34,10 @@ pub async fn subtle_import_key<'js>(
     )?;
     let format = match format {
         KeyFormat::Raw => KeyFormatData::Raw(ObjectBytes::from_js(&ctx, key_data)?),
+        KeyFormat::RawPrivate => KeyFormatData::RawPrivate(ObjectBytes::from_js(&ctx, key_data)?),
+        KeyFormat::RawPublic => KeyFormatData::RawPublic(ObjectBytes::from_js(&ctx, key_data)?),
+        KeyFormat::RawSecret => KeyFormatData::RawSecret(ObjectBytes::from_js(&ctx, key_data)?),
+        KeyFormat::RawSeed => KeyFormatData::RawSeed(ObjectBytes::from_js(&ctx, key_data)?),
         KeyFormat::Pkcs8 => KeyFormatData::Pkcs8(ObjectBytes::from_js(&ctx, key_data)?),
         KeyFormat::Spki => KeyFormatData::Spki(ObjectBytes::from_js(&ctx, key_data)?),
         KeyFormat::Jwk => KeyFormatData::Jwk(key_data.into_object_or_throw(&ctx, "keyData")?),
@@ -116,15 +120,8 @@ fn validate_import_algorithm<'js>(
         super::key_algorithm::KeyAlgorithm::HkdfImport
             | super::key_algorithm::KeyAlgorithm::Pbkdf2Import
     ) {
-        if !matches!(format, KeyFormat::Raw) {
-            return Err(DOMException::not_supported_error(
-                ctx,
-                [
-                    normalized.name.as_str(),
-                    " only supports 'raw' import format",
-                ]
-                .concat(),
-            ));
+        if !matches!(format, KeyFormat::Raw | KeyFormat::RawSecret) {
+            return key_format_not_supported_error(ctx, &normalized.name, format.as_str());
         }
         if extractable {
             return Err(DOMException::syntax_error(

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -30,7 +30,7 @@ use x25519_dalek::{PublicKey, StaticSecret};
 use crate::{
     hash::HashAlgorithm,
     provider::{
-        hmac_length_is_byte_aligned, parse_rsa_public_exponent, MlDsaVariant,
+        hmac_length_is_byte_aligned, parse_rsa_public_exponent, MlDsaVariant, MlKemVariant,
         MAX_HMAC_KEY_LENGTH_BITS,
     },
 };
@@ -56,6 +56,10 @@ pub enum KeyUsage {
     DeriveBits,
     WrapKey,
     UnwrapKey,
+    EncapsulateKey,
+    EncapsulateBits,
+    DecapsulateKey,
+    DecapsulateBits,
 }
 
 impl TryFrom<&str> for KeyUsage {
@@ -71,13 +75,17 @@ impl TryFrom<&str> for KeyUsage {
             "verify" => KeyUsage::Verify,
             "deriveKey" => KeyUsage::DeriveKey,
             "deriveBits" => KeyUsage::DeriveBits,
+            "encapsulateKey" => KeyUsage::EncapsulateKey,
+            "encapsulateBits" => KeyUsage::EncapsulateBits,
+            "decapsulateKey" => KeyUsage::DecapsulateKey,
+            "decapsulateBits" => KeyUsage::DecapsulateBits,
             _ => return Err(["Invalid key usage: ", s].concat()),
         })
     }
 }
 
 impl KeyUsage {
-    const CANONICAL_ORDER: [Self; 8] = [
+    const CANONICAL_ORDER: [Self; 12] = [
         Self::Encrypt,
         Self::Decrypt,
         Self::Sign,
@@ -86,6 +94,10 @@ impl KeyUsage {
         Self::DeriveBits,
         Self::WrapKey,
         Self::UnwrapKey,
+        Self::EncapsulateKey,
+        Self::EncapsulateBits,
+        Self::DecapsulateKey,
+        Self::DecapsulateBits,
     ];
 
     const fn as_str(self) -> &'static str {
@@ -98,6 +110,10 @@ impl KeyUsage {
             Self::DeriveBits => "deriveBits",
             Self::WrapKey => "wrapKey",
             Self::UnwrapKey => "unwrapKey",
+            Self::EncapsulateKey => "encapsulateKey",
+            Self::EncapsulateBits => "encapsulateBits",
+            Self::DecapsulateKey => "decapsulateKey",
+            Self::DecapsulateBits => "decapsulateBits",
         }
     }
 
@@ -184,12 +200,12 @@ impl KeyUsage {
         Ok(())
     }
 
-    const fn mask(self) -> u16 {
-        1 << self as u16
+    const fn mask(self) -> u32 {
+        1 << self as u32
     }
 }
 
-#[repr(u16)]
+#[repr(u32)]
 #[derive(Clone, Copy)]
 pub enum KeyUsageAlgorithm {
     //single mask algorithms (symmetric)
@@ -204,23 +220,27 @@ pub enum KeyUsageAlgorithm {
 
     // asymmetric derive algorithms - use high bits as private usages
     // ECDH/X25519
-    DeriveAsymmetric = ((KeyUsage::DeriveKey.mask() | KeyUsage::DeriveBits.mask()) << 8),
+    DeriveAsymmetric = ((KeyUsage::DeriveKey.mask() | KeyUsage::DeriveBits.mask()) << 16),
 
     // HKDF/PBKDF2
     DeriveSymmetric = KeyUsage::DeriveKey.mask() | KeyUsage::DeriveBits.mask(),
 
-    RsaOaep = ((KeyUsage::Decrypt.mask() | KeyUsage::UnwrapKey.mask()) << 8) //private
+    RsaOaep = ((KeyUsage::Decrypt.mask() | KeyUsage::UnwrapKey.mask()) << 16) //private
     | KeyUsage::Encrypt.mask() | KeyUsage::WrapKey.mask(), //public
 
     //ECDSA, ED25519, all non-OEAP RSA
-    Sign = (KeyUsage::Sign.mask() << 8) //private
+    Sign = (KeyUsage::Sign.mask() << 16) //private
         | KeyUsage::Verify.mask(), //public
+
+    MlKem = ((KeyUsage::DecapsulateKey.mask() | KeyUsage::DecapsulateBits.mask()) << 16)
+        | KeyUsage::EncapsulateKey.mask()
+        | KeyUsage::EncapsulateBits.mask(),
 }
 impl KeyUsageAlgorithm {
-    fn masks(&self) -> (u16, u16) {
-        let value = *self as u16;
-        let private_mask = value >> 8;
-        let public_mask = value & 0xFF;
+    fn masks(&self) -> (u32, u32) {
+        let value = *self as u32;
+        let private_mask = value >> 16;
+        let public_mask = value & 0xFFFF;
         (private_mask, public_mask)
     }
 
@@ -233,6 +253,7 @@ impl KeyUsageAlgorithm {
                 | Self::DeriveAsymmetric
                 | Self::DeriveSymmetric
                 | Self::Sign
+                | Self::MlKem
                 | Self::RsaOaep
         )
     }
@@ -319,6 +340,7 @@ pub enum KeyAlgorithm {
     },
     ChaCha20Poly1305,
     MlDsa(MlDsaVariant),
+    MlKem(MlKemVariant),
     Rsa {
         modulus_length: u32,
         public_exponent: Rc<Box<[u8]>>,
@@ -885,6 +907,122 @@ fn from_ml_dsa<'js>(
     Ok(KeyAlgorithm::MlDsa(variant))
 }
 
+fn from_ml_kem<'js>(
+    ctx: &Ctx<'js>,
+    mode: KeyAlgorithmMode<'_, 'js>,
+    algorithm_name: &str,
+    variant: MlKemVariant,
+    usages: &Array<'js>,
+    private_usages: &mut Vec<String>,
+    public_usages: &mut Vec<String>,
+) -> Result<KeyAlgorithm> {
+    #[cfg(feature = "_subtle-full")]
+    fn import<'js>(
+        ctx: &Ctx<'js>,
+        mode: KeyAlgorithmMode<'_, 'js>,
+        algorithm_name: &str,
+        variant: MlKemVariant,
+    ) -> Result<Option<KeyKind>> {
+        use crate::provider::modern;
+
+        let KeyAlgorithmMode::Import { format, kind, data } = mode else {
+            return Ok(None);
+        };
+
+        match format {
+            KeyFormatData::RawPublic(bytes) => {
+                *data = modern::import_ml_kem_public_key(variant, bytes.as_bytes(ctx)?, false)
+                    .or_throw_dom(ctx)?;
+                *kind = KeyKind::Public;
+            },
+            KeyFormatData::Spki(bytes) => {
+                *data = modern::import_ml_kem_public_key(variant, bytes.as_bytes(ctx)?, true)
+                    .or_throw_dom(ctx)?;
+                *kind = KeyKind::Public;
+            },
+            KeyFormatData::RawSeed(bytes) => {
+                *data = modern::import_ml_kem_private_key(variant, bytes.as_bytes(ctx)?, false)
+                    .or_throw_dom(ctx)?;
+                *kind = KeyKind::Private;
+            },
+            KeyFormatData::Pkcs8(bytes) => {
+                let bytes = bytes.as_bytes(ctx)?;
+                validate_ml_private_key_info(
+                    ctx,
+                    bytes,
+                    match variant {
+                        MlKemVariant::MlKem512 => "2.16.840.1.101.3.4.4.1",
+                        MlKemVariant::MlKem768 => "2.16.840.1.101.3.4.4.2",
+                        MlKemVariant::MlKem1024 => "2.16.840.1.101.3.4.4.3",
+                    },
+                    match variant {
+                        MlKemVariant::MlKem512 => 1632,
+                        MlKemVariant::MlKem768 => 2400,
+                        MlKemVariant::MlKem1024 => 3168,
+                    },
+                )?;
+                *data =
+                    modern::import_ml_kem_private_key(variant, bytes, true).or_throw_dom(ctx)?;
+                *kind = KeyKind::Private;
+            },
+            KeyFormatData::Jwk(object) => {
+                validate_jwk_kty(ctx, &object, "AKP")?;
+                validate_jwk_use(ctx, &object, false)?;
+                if get_jwk_required_string(ctx, &object, "alg")? != algorithm_name {
+                    return Err(DOMException::data_error(
+                        ctx,
+                        "JWK 'alg' parameter does not match the algorithm",
+                    ));
+                }
+
+                let public_key = get_jwk_required_bytes(ctx, &object, "pub")?;
+                if let Some(seed) = get_jwk_optional_bytes(ctx, &object, "priv")? {
+                    *data = modern::import_ml_kem_private_key(variant, &seed, false)
+                        .or_throw_dom(ctx)?;
+                    let derived_public_key =
+                        modern::ml_kem_public_key(variant, data).or_throw_dom(ctx)?;
+                    if derived_public_key != public_key {
+                        return Err(DOMException::data_error(
+                            ctx,
+                            "JWK public and private key values do not match",
+                        ));
+                    }
+                    *kind = KeyKind::Private;
+                } else {
+                    *data = modern::import_ml_kem_public_key(variant, &public_key, false)
+                        .or_throw_dom(ctx)?;
+                    *kind = KeyKind::Public;
+                }
+            },
+            format => {
+                return key_format_not_supported_error(ctx, algorithm_name, format.as_str());
+            },
+        }
+        Ok(Some(*kind))
+    }
+
+    #[cfg(not(feature = "_subtle-full"))]
+    fn import<'js>(
+        _ctx: &Ctx<'js>,
+        _mode: KeyAlgorithmMode<'_, 'js>,
+        _algorithm_name: &str,
+        _variant: MlKemVariant,
+    ) -> Result<Option<KeyKind>> {
+        Ok(None)
+    }
+
+    let key_kind = import(ctx, mode, algorithm_name, variant)?;
+    KeyUsage::classify_and_check_usages(
+        ctx,
+        KeyUsageAlgorithm::MlKem,
+        usages,
+        private_usages,
+        public_usages,
+        key_kind.as_ref(),
+    )?;
+    Ok(KeyAlgorithm::MlKem(variant))
+}
+
 fn from_rsa<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
@@ -1105,6 +1243,7 @@ impl KeyAlgorithm {
                 "AES-KW" => "wrapKey",
                 "AES-CBC" | "AES-CTR" | "AES-GCM" | "ChaCha20-Poly1305" | "RSA-OAEP" => "encrypt",
                 "ECDH" | "X25519" | "HKDF" | "PBKDF2" => "deriveKey",
+                "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" => "encapsulateKey",
                 _ => "sign",
             };
             synthetic_usages.set(0, usage)?;
@@ -1197,6 +1336,19 @@ impl KeyAlgorithm {
                     "ML-DSA-44" => MlDsaVariant::MlDsa44,
                     "ML-DSA-65" => MlDsaVariant::MlDsa65,
                     _ => MlDsaVariant::MlDsa87,
+                },
+                &usages,
+                &mut private_usages,
+                &mut public_usages,
+            )?,
+            "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" => from_ml_kem(
+                ctx,
+                mode,
+                algorithm_name,
+                match algorithm_name {
+                    "ML-KEM-512" => MlKemVariant::MlKem512,
+                    "ML-KEM-768" => MlKemVariant::MlKem768,
+                    _ => MlKemVariant::MlKem1024,
                 },
                 &usages,
                 &mut private_usages,

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -1489,6 +1489,60 @@ impl KeyAlgorithm {
         })
     }
 
+    pub fn supports_get_public_key(&self) -> bool {
+        matches!(
+            self,
+            KeyAlgorithm::Ec { .. }
+                | KeyAlgorithm::Ed25519
+                | KeyAlgorithm::X25519
+                | KeyAlgorithm::Rsa { .. }
+                | KeyAlgorithm::MlDsa(_)
+                | KeyAlgorithm::MlKem(_)
+                | KeyAlgorithm::HybridKem(_)
+        )
+    }
+
+    pub fn validate_public_usages<'js>(
+        &self,
+        ctx: &Ctx<'js>,
+        name: &str,
+        usages: &Array<'js>,
+    ) -> Result<Vec<String>> {
+        let usage_algorithm = match self {
+            KeyAlgorithm::Ec {
+                algorithm: EcAlgorithm::Ecdh,
+                ..
+            }
+            | KeyAlgorithm::X25519 => KeyUsageAlgorithm::DeriveAsymmetric,
+            KeyAlgorithm::Ec {
+                algorithm: EcAlgorithm::Ecdsa,
+                ..
+            }
+            | KeyAlgorithm::Ed25519
+            | KeyAlgorithm::MlDsa(_) => KeyUsageAlgorithm::Sign,
+            KeyAlgorithm::Rsa { .. } if name == "RSA-OAEP" => KeyUsageAlgorithm::RsaOaep,
+            KeyAlgorithm::Rsa { .. } => KeyUsageAlgorithm::Sign,
+            KeyAlgorithm::MlKem(_) | KeyAlgorithm::HybridKem(_) => KeyUsageAlgorithm::MlKem,
+            _ => {
+                return Err(DOMException::not_supported_error(
+                    ctx,
+                    "This algorithm cannot derive a public key",
+                ));
+            },
+        };
+        let mut private_usages = Vec::new();
+        let mut public_usages = Vec::new();
+        KeyUsage::classify_and_check_usages(
+            ctx,
+            usage_algorithm,
+            usages,
+            &mut private_usages,
+            &mut public_usages,
+            Some(&KeyKind::Public),
+        )?;
+        Ok(public_usages)
+    }
+
     pub fn as_object<'js, T: AsRef<str>>(&self, ctx: &Ctx<'js>, name: T) -> Result<Object<'js>> {
         let obj = Object::new(ctx.clone())?;
         obj.set(PredefinedAtom::Name, name.as_ref())?;

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 #[cfg(feature = "_subtle-full")]
 use der::{
-    asn1::{AnyRef, BitStringRef, OctetString, OctetStringRef},
+    asn1::{BitStringRef, OctetString, OctetStringRef},
     Decode, Encode,
 };
 #[cfg(feature = "_subtle-full")]
@@ -840,6 +840,7 @@ fn from_ml_dsa<'js>(
                         MlDsaVariant::MlDsa65 => "2.16.840.1.101.3.4.3.18",
                         MlDsaVariant::MlDsa87 => "2.16.840.1.101.3.4.3.19",
                     },
+                    32,
                     match variant {
                         MlDsaVariant::MlDsa44 => 2560,
                         MlDsaVariant::MlDsa65 => 4032,
@@ -956,6 +957,7 @@ fn from_ml_kem<'js>(
                         MlKemVariant::MlKem768 => "2.16.840.1.101.3.4.4.2",
                         MlKemVariant::MlKem1024 => "2.16.840.1.101.3.4.4.3",
                     },
+                    64,
                     match variant {
                         MlKemVariant::MlKem512 => 1632,
                         MlKemVariant::MlKem768 => 2400,
@@ -1643,6 +1645,7 @@ fn validate_ml_private_key_info(
     ctx: &Ctx<'_>,
     data: &[u8],
     expected_oid: &str,
+    seed_length: usize,
     expanded_key_length: usize,
 ) -> Result<()> {
     let private_key_info = PrivateKeyInfoRef::from_der(data).or_throw_data_error(ctx)?;
@@ -1673,7 +1676,21 @@ fn validate_ml_private_key_info(
             ))
         },
         Some(0x30) => {
-            AnyRef::from_der(private_key).or_throw_data_error(ctx)?;
+            let values = Vec::<&OctetStringRef>::from_der(private_key).or_throw_data_error(ctx)?;
+            let [seed, expanded_key] = values.as_slice() else {
+                return Err(DOMException::data_error(
+                    ctx,
+                    "Combined private key has invalid structure",
+                ));
+            };
+            if seed.as_bytes().len() != seed_length
+                || expanded_key.as_bytes().len() != expanded_key_length
+            {
+                return Err(DOMException::data_error(
+                    ctx,
+                    "Combined private key has invalid component length",
+                ));
+            }
             Err(DOMException::not_supported_error(
                 ctx,
                 "Combined seed and expanded private keys are not supported",

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -733,6 +733,45 @@ fn from_hmac<'js>(
     Ok(KeyAlgorithm::Hmac { hash, length })
 }
 
+fn import_chacha20_poly1305<'js>(
+    ctx: &Ctx<'js>,
+    mode: KeyAlgorithmMode<'_, 'js>,
+    algorithm_name: &str,
+) -> Result<Option<KeyKind>> {
+    let KeyAlgorithmMode::Import { format, kind, data } = mode else {
+        return Ok(None);
+    };
+
+    *kind = KeyKind::Secret;
+    *data = match format {
+        KeyFormatData::RawSecret(bytes) => bytes.into_bytes(ctx)?,
+        #[cfg(feature = "_subtle-full")]
+        KeyFormatData::Jwk(object) => {
+            validate_jwk_kty(ctx, &object, "oct")?;
+            validate_jwk_use(ctx, &object, false)?;
+            if let Some(alg) = object.get_optional::<_, String>("alg")? {
+                if alg != "C20P" {
+                    return Err(DOMException::data_error(
+                        ctx,
+                        "JWK 'alg' parameter must be 'C20P'",
+                    ));
+                }
+            }
+            get_jwk_required_bytes(ctx, &object, "k")?
+        },
+        format => {
+            return key_format_not_supported_error(ctx, algorithm_name, format.as_str());
+        },
+    };
+    if data.len() != 32 {
+        return Err(DOMException::data_error(
+            ctx,
+            "ChaCha20-Poly1305 keys must be 256 bits",
+        ));
+    }
+    Ok(Some(*kind))
+}
+
 fn from_chacha20_poly1305<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
@@ -741,46 +780,7 @@ fn from_chacha20_poly1305<'js>(
     private_usages: &mut Vec<String>,
     public_usages: &mut Vec<String>,
 ) -> Result<KeyAlgorithm> {
-    fn import<'js>(
-        ctx: &Ctx<'js>,
-        mode: KeyAlgorithmMode<'_, 'js>,
-        algorithm_name: &str,
-    ) -> Result<Option<KeyKind>> {
-        let KeyAlgorithmMode::Import { format, kind, data } = mode else {
-            return Ok(None);
-        };
-
-        *kind = KeyKind::Secret;
-        *data = match format {
-            KeyFormatData::RawSecret(bytes) => bytes.into_bytes(ctx)?,
-            #[cfg(feature = "_subtle-full")]
-            KeyFormatData::Jwk(object) => {
-                validate_jwk_kty(ctx, &object, "oct")?;
-                validate_jwk_use(ctx, &object, false)?;
-                if let Some(alg) = object.get_optional::<_, String>("alg")? {
-                    if alg != "C20P" {
-                        return Err(DOMException::data_error(
-                            ctx,
-                            "JWK 'alg' parameter must be 'C20P'",
-                        ));
-                    }
-                }
-                get_jwk_required_bytes(ctx, &object, "k")?
-            },
-            format => {
-                return key_format_not_supported_error(ctx, algorithm_name, format.as_str());
-            },
-        };
-        if data.len() != 32 {
-            return Err(DOMException::data_error(
-                ctx,
-                "ChaCha20-Poly1305 keys must be 256 bits",
-            ));
-        }
-        Ok(Some(*kind))
-    }
-
-    let key_kind = import(ctx, mode, algorithm_name)?;
+    let key_kind = import_chacha20_poly1305(ctx, mode, algorithm_name)?;
     KeyUsage::classify_and_check_usages(
         ctx,
         KeyUsageAlgorithm::Symmetric,

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -33,9 +33,9 @@ use crate::{
 };
 
 #[cfg(feature = "_subtle-full")]
-use super::util::DataError;
+use super::{algorithm_mismatch_error, util::DataError};
 use super::{
-    algorithm_mismatch_error, algorithm_not_supported_error,
+    algorithm_not_supported_error,
     crypto_key::KeyKind,
     enforce_range_u16, enforce_range_u32, get_optional_dictionary_value,
     get_required_dictionary_value, normalize_algorithm_name, to_name_and_maybe_object,
@@ -327,11 +327,25 @@ pub enum KeyAlgorithm {
 pub enum KeyFormat {
     Jwk,
     Raw,
+    RawPrivate,
+    RawPublic,
+    RawSecret,
+    RawSeed,
     Spki,
     Pkcs8,
 }
 
-str_enum!(KeyFormat, Jwk => "jwk", Raw => "raw", Spki => "spki", Pkcs8 => "pkcs8");
+str_enum!(
+    KeyFormat,
+    Jwk => "jwk",
+    Raw => "raw",
+    RawPrivate => "raw-private",
+    RawPublic => "raw-public",
+    RawSecret => "raw-secret",
+    RawSeed => "raw-seed",
+    Spki => "spki",
+    Pkcs8 => "pkcs8"
+);
 
 impl<'js> FromJs<'js> for KeyFormat {
     fn from_js(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
@@ -346,8 +360,38 @@ impl<'js> FromJs<'js> for KeyFormat {
 pub enum KeyFormatData<'js> {
     Jwk(Object<'js>),
     Raw(ObjectBytes<'js>),
+    RawPrivate(ObjectBytes<'js>),
+    RawPublic(ObjectBytes<'js>),
+    RawSecret(ObjectBytes<'js>),
+    RawSeed(ObjectBytes<'js>),
     Spki(ObjectBytes<'js>),
     Pkcs8(ObjectBytes<'js>),
+}
+
+impl KeyFormatData<'_> {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Jwk(_) => "jwk",
+            Self::Raw(_) => "raw",
+            Self::RawPrivate(_) => "raw-private",
+            Self::RawPublic(_) => "raw-public",
+            Self::RawSecret(_) => "raw-secret",
+            Self::RawSeed(_) => "raw-seed",
+            Self::Spki(_) => "spki",
+            Self::Pkcs8(_) => "pkcs8",
+        }
+    }
+}
+
+pub(super) fn key_format_not_supported_error<T>(
+    ctx: &Ctx<'_>,
+    algorithm_name: &str,
+    format: &str,
+) -> Result<T> {
+    Err(DOMException::not_supported_error(
+        ctx,
+        format!("{algorithm_name} does not support the '{format}' key format"),
+    ))
 }
 
 #[derive(PartialEq)]
@@ -1081,14 +1125,12 @@ fn import_derive_key<'js>(
     data: &mut Vec<u8>,
     algorithm_name: &str,
 ) -> Result<()> {
-    if let KeyFormatData::Raw(object_bytes) = format {
-        *data = object_bytes.into_bytes(ctx)?;
-        *kind = KeyKind::Secret;
-    } else {
-        return Err(DOMException::not_supported_error(
-            ctx,
-            [algorithm_name, " only supports 'raw' import format"].concat(),
-        ));
+    match format {
+        KeyFormatData::Raw(object_bytes) | KeyFormatData::RawSecret(object_bytes) => {
+            *data = object_bytes.into_bytes(ctx)?;
+            *kind = KeyKind::Secret;
+        },
+        format => return key_format_not_supported_error(ctx, algorithm_name, format.as_str()),
     }
 
     Ok(())
@@ -1179,7 +1221,7 @@ fn import_rsa_key<'js>(
             };
             (result.modulus_length as usize, result.public_exponent)
         },
-        KeyFormatData::Raw(object_bytes) => {
+        KeyFormatData::Raw(object_bytes) | KeyFormatData::RawPublic(object_bytes) => {
             let result = CRYPTO_PROVIDER
                 .import_rsa_public_key_pkcs1(object_bytes.as_bytes(ctx)?)
                 .or_throw_dom(ctx)?;
@@ -1208,6 +1250,7 @@ fn import_rsa_key<'js>(
             *kind = KeyKind::Public;
             (result.modulus_length as usize, result.public_exponent)
         },
+        format => return key_format_not_supported_error(ctx, algorithm_name, format.as_str()),
     };
 
     let public_exponent = public_exponent.into_boxed_slice();
@@ -1256,13 +1299,13 @@ fn import_symmetric_key<'js>(
             *data = bytes_from_b64_url_safe(k.as_bytes()).or_throw(ctx)?;
             Ok(data.len() * 8)
         },
-        KeyFormatData::Raw(object_bytes) => {
+        KeyFormatData::Raw(object_bytes) | KeyFormatData::RawSecret(object_bytes) => {
             let bytes = object_bytes.into_bytes(ctx)?;
 
             *data = bytes;
             Ok(data.len() * 8)
         },
-        _ => algorithm_mismatch_error(ctx, algorithm_name),
+        format => key_format_not_supported_error(ctx, algorithm_name, format.as_str()),
     }
 }
 
@@ -1336,7 +1379,7 @@ fn import_ec_key<'js>(
                 KeyKind::Public
             };
         },
-        KeyFormatData::Raw(object_bytes) => {
+        KeyFormatData::Raw(object_bytes) | KeyFormatData::RawPublic(object_bytes) => {
             let bytes = object_bytes.as_bytes(ctx)?;
             let result = CRYPTO_PROVIDER
                 .import_ec_public_key_sec1(bytes, *curve)
@@ -1364,6 +1407,7 @@ fn import_ec_key<'js>(
             *data = result.key_data;
             *kind = KeyKind::Private;
         },
+        format => return key_format_not_supported_error(ctx, algorithm_name, format.as_str()),
     };
     Ok(())
 }
@@ -1430,7 +1474,7 @@ fn import_okp_key<'js>(
                 *kind = KeyKind::Public;
             }
         },
-        KeyFormatData::Raw(object_bytes) => {
+        KeyFormatData::Raw(object_bytes) | KeyFormatData::RawPublic(object_bytes) => {
             let bytes = object_bytes.into_bytes(ctx)?;
             if bytes.len() != 32 {
                 return Err(DOMException::data_error(
@@ -1479,6 +1523,7 @@ fn import_okp_key<'js>(
             }
             *kind = KeyKind::Private;
         },
+        format => return key_format_not_supported_error(ctx, algorithm_name, format.as_str()),
     }
 
     Ok(())

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -30,8 +30,8 @@ use x25519_dalek::{PublicKey, StaticSecret};
 use crate::{
     hash::HashAlgorithm,
     provider::{
-        hmac_length_is_byte_aligned, parse_rsa_public_exponent, MlDsaVariant, MlKemVariant,
-        MAX_HMAC_KEY_LENGTH_BITS,
+        hmac_length_is_byte_aligned, parse_rsa_public_exponent, HybridKemVariant, MlDsaVariant,
+        MlKemVariant, MAX_HMAC_KEY_LENGTH_BITS,
     },
 };
 
@@ -341,6 +341,7 @@ pub enum KeyAlgorithm {
     ChaCha20Poly1305,
     MlDsa(MlDsaVariant),
     MlKem(MlKemVariant),
+    HybridKem(HybridKemVariant),
     Rsa {
         modulus_length: u32,
         public_exponent: Rc<Box<[u8]>>,
@@ -1023,6 +1024,97 @@ fn from_ml_kem<'js>(
     Ok(KeyAlgorithm::MlKem(variant))
 }
 
+fn from_hybrid_kem<'js>(
+    ctx: &Ctx<'js>,
+    mode: KeyAlgorithmMode<'_, 'js>,
+    algorithm_name: &str,
+    variant: HybridKemVariant,
+    usages: &Array<'js>,
+    private_usages: &mut Vec<String>,
+    public_usages: &mut Vec<String>,
+) -> Result<KeyAlgorithm> {
+    #[cfg(feature = "_subtle-full")]
+    fn import<'js>(
+        ctx: &Ctx<'js>,
+        mode: KeyAlgorithmMode<'_, 'js>,
+        algorithm_name: &str,
+        variant: HybridKemVariant,
+    ) -> Result<Option<KeyKind>> {
+        use crate::provider::modern;
+
+        let KeyAlgorithmMode::Import { format, kind, data } = mode else {
+            return Ok(None);
+        };
+
+        match format {
+            KeyFormatData::RawPublic(bytes) => {
+                *data = modern::import_hybrid_kem_public_key(variant, bytes.as_bytes(ctx)?)
+                    .or_throw_dom(ctx)?;
+                *kind = KeyKind::Public;
+            },
+            KeyFormatData::RawSeed(bytes) => {
+                *data = modern::import_hybrid_kem_private_key(variant, bytes.as_bytes(ctx)?)
+                    .or_throw_dom(ctx)?;
+                *kind = KeyKind::Private;
+            },
+            KeyFormatData::Jwk(object) => {
+                validate_jwk_kty(ctx, &object, "AKP")?;
+                validate_jwk_use(ctx, &object, false)?;
+                if get_jwk_required_string(ctx, &object, "alg")? != algorithm_name {
+                    return Err(DOMException::data_error(
+                        ctx,
+                        "JWK 'alg' parameter does not match the algorithm",
+                    ));
+                }
+
+                let public_key = get_jwk_required_bytes(ctx, &object, "pub")?;
+                if let Some(seed) = get_jwk_optional_bytes(ctx, &object, "priv")? {
+                    *data =
+                        modern::import_hybrid_kem_private_key(variant, &seed).or_throw_dom(ctx)?;
+                    let derived_public_key =
+                        modern::hybrid_kem_public_key(variant, data).or_throw_dom(ctx)?;
+                    if derived_public_key != public_key {
+                        return Err(DOMException::data_error(
+                            ctx,
+                            "JWK public and private key values do not match",
+                        ));
+                    }
+                    *kind = KeyKind::Private;
+                } else {
+                    *data = modern::import_hybrid_kem_public_key(variant, &public_key)
+                        .or_throw_dom(ctx)?;
+                    *kind = KeyKind::Public;
+                }
+            },
+            format => {
+                return key_format_not_supported_error(ctx, algorithm_name, format.as_str());
+            },
+        }
+        Ok(Some(*kind))
+    }
+
+    #[cfg(not(feature = "_subtle-full"))]
+    fn import<'js>(
+        _ctx: &Ctx<'js>,
+        _mode: KeyAlgorithmMode<'_, 'js>,
+        _algorithm_name: &str,
+        _variant: HybridKemVariant,
+    ) -> Result<Option<KeyKind>> {
+        Ok(None)
+    }
+
+    let key_kind = import(ctx, mode, algorithm_name, variant)?;
+    KeyUsage::classify_and_check_usages(
+        ctx,
+        KeyUsageAlgorithm::MlKem,
+        usages,
+        private_usages,
+        public_usages,
+        key_kind.as_ref(),
+    )?;
+    Ok(KeyAlgorithm::HybridKem(variant))
+}
+
 fn from_rsa<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
@@ -1243,7 +1335,8 @@ impl KeyAlgorithm {
                 "AES-KW" => "wrapKey",
                 "AES-CBC" | "AES-CTR" | "AES-GCM" | "ChaCha20-Poly1305" | "RSA-OAEP" => "encrypt",
                 "ECDH" | "X25519" | "HKDF" | "PBKDF2" => "deriveKey",
-                "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" => "encapsulateKey",
+                "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" | "MLKEM768-P256"
+                | "MLKEM768-X25519" | "MLKEM1024-P384" => "encapsulateKey",
                 _ => "sign",
             };
             synthetic_usages.set(0, usage)?;
@@ -1349,6 +1442,19 @@ impl KeyAlgorithm {
                     "ML-KEM-512" => MlKemVariant::MlKem512,
                     "ML-KEM-768" => MlKemVariant::MlKem768,
                     _ => MlKemVariant::MlKem1024,
+                },
+                &usages,
+                &mut private_usages,
+                &mut public_usages,
+            )?,
+            "MLKEM768-P256" | "MLKEM768-X25519" | "MLKEM1024-P384" => from_hybrid_kem(
+                ctx,
+                mode,
+                algorithm_name,
+                match algorithm_name {
+                    "MLKEM768-P256" => HybridKemVariant::MlKem768P256,
+                    "MLKEM768-X25519" => HybridKemVariant::MlKem768X25519,
+                    _ => HybridKemVariant::MlKem1024P384,
                 },
                 &usages,
                 &mut private_usages,

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -836,9 +836,9 @@ fn from_ml_dsa<'js>(
                     ctx,
                     bytes,
                     match variant {
-                        MlDsaVariant::MlDsa44 => "2.16.840.1.101.3.4.3.17",
-                        MlDsaVariant::MlDsa65 => "2.16.840.1.101.3.4.3.18",
-                        MlDsaVariant::MlDsa87 => "2.16.840.1.101.3.4.3.19",
+                        MlDsaVariant::MlDsa44 => const_oid::db::fips204::ID_ML_DSA_44,
+                        MlDsaVariant::MlDsa65 => const_oid::db::fips204::ID_ML_DSA_65,
+                        MlDsaVariant::MlDsa87 => const_oid::db::fips204::ID_ML_DSA_87,
                     },
                     32,
                     match variant {
@@ -953,9 +953,9 @@ fn from_ml_kem<'js>(
                     ctx,
                     bytes,
                     match variant {
-                        MlKemVariant::MlKem512 => "2.16.840.1.101.3.4.4.1",
-                        MlKemVariant::MlKem768 => "2.16.840.1.101.3.4.4.2",
-                        MlKemVariant::MlKem1024 => "2.16.840.1.101.3.4.4.3",
+                        MlKemVariant::MlKem512 => const_oid::db::fips203::ID_ALG_ML_KEM_512,
+                        MlKemVariant::MlKem768 => const_oid::db::fips203::ID_ALG_ML_KEM_768,
+                        MlKemVariant::MlKem1024 => const_oid::db::fips203::ID_ALG_ML_KEM_1024,
                     },
                     64,
                     match variant {
@@ -1452,41 +1452,40 @@ impl KeyAlgorithm {
                 &mut private_usages,
                 &mut public_usages,
             )?,
-            _ => {
-                if let Ok(variant) = MlDsaVariant::try_from(algorithm_name) {
-                    from_ml_dsa(
-                        ctx,
-                        mode,
-                        algorithm_name,
-                        variant,
-                        &usages,
-                        &mut private_usages,
-                        &mut public_usages,
-                    )?
-                } else if let Ok(variant) = MlKemVariant::try_from(algorithm_name) {
-                    from_ml_kem(
-                        ctx,
-                        mode,
-                        algorithm_name,
-                        variant,
-                        &usages,
-                        &mut private_usages,
-                        &mut public_usages,
-                    )?
-                } else if let Ok(variant) = HybridKemVariant::try_from(algorithm_name) {
-                    from_hybrid_kem(
-                        ctx,
-                        mode,
-                        algorithm_name,
-                        variant,
-                        &usages,
-                        &mut private_usages,
-                        &mut public_usages,
-                    )?
-                } else {
-                    return algorithm_not_supported_error(ctx);
-                }
-            },
+            "ML-DSA-44" | "ML-DSA-65" | "ML-DSA-87" => from_ml_dsa(
+                ctx,
+                mode,
+                algorithm_name,
+                MlDsaVariant::try_from(algorithm_name)
+                    .map_err(NotSupportedError)
+                    .or_throw_dom(ctx)?,
+                &usages,
+                &mut private_usages,
+                &mut public_usages,
+            )?,
+            "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" => from_ml_kem(
+                ctx,
+                mode,
+                algorithm_name,
+                MlKemVariant::try_from(algorithm_name)
+                    .map_err(NotSupportedError)
+                    .or_throw_dom(ctx)?,
+                &usages,
+                &mut private_usages,
+                &mut public_usages,
+            )?,
+            "MLKEM768-P256" | "MLKEM768-X25519" | "MLKEM1024-P384" => from_hybrid_kem(
+                ctx,
+                mode,
+                algorithm_name,
+                HybridKemVariant::try_from(algorithm_name)
+                    .map_err(NotSupportedError)
+                    .or_throw_dom(ctx)?,
+                &usages,
+                &mut private_usages,
+                &mut public_usages,
+            )?,
+            _ => return algorithm_not_supported_error(ctx),
         };
 
         Ok(KeyAlgorithmWithUsages {
@@ -1650,12 +1649,11 @@ impl KeyAlgorithm {
 fn validate_ml_private_key_info(
     ctx: &Ctx<'_>,
     data: &[u8],
-    expected_oid: &str,
+    expected_oid: ObjectIdentifier,
     seed_length: usize,
     expanded_key_length: usize,
 ) -> Result<()> {
     let private_key_info = PrivateKeyInfoRef::from_der(data).or_throw_data_error(ctx)?;
-    let expected_oid = ObjectIdentifier::new_unwrap(expected_oid);
     if private_key_info.algorithm.oid != expected_oid
         || private_key_info.algorithm.parameters.is_some()
     {

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -314,6 +314,7 @@ pub enum KeyAlgorithm {
         hash: HashAlgorithm,
         length: u32,
     },
+    ChaCha20Poly1305,
     Rsa {
         modulus_length: u32,
         public_exponent: Rc<Box<[u8]>>,
@@ -705,6 +706,65 @@ fn from_hmac<'js>(
     Ok(KeyAlgorithm::Hmac { hash, length })
 }
 
+fn from_chacha20_poly1305<'js>(
+    ctx: &Ctx<'js>,
+    mode: KeyAlgorithmMode<'_, 'js>,
+    algorithm_name: &str,
+    usages: &Array<'js>,
+    private_usages: &mut Vec<String>,
+    public_usages: &mut Vec<String>,
+) -> Result<KeyAlgorithm> {
+    fn import<'js>(
+        ctx: &Ctx<'js>,
+        mode: KeyAlgorithmMode<'_, 'js>,
+        algorithm_name: &str,
+    ) -> Result<Option<KeyKind>> {
+        let KeyAlgorithmMode::Import { format, kind, data } = mode else {
+            return Ok(None);
+        };
+
+        *kind = KeyKind::Secret;
+        *data = match format {
+            KeyFormatData::RawSecret(bytes) => bytes.into_bytes(ctx)?,
+            #[cfg(feature = "_subtle-full")]
+            KeyFormatData::Jwk(object) => {
+                validate_jwk_kty(ctx, &object, "oct")?;
+                validate_jwk_use(ctx, &object, false)?;
+                if let Some(alg) = object.get_optional::<_, String>("alg")? {
+                    if alg != "C20P" {
+                        return Err(DOMException::data_error(
+                            ctx,
+                            "JWK 'alg' parameter must be 'C20P'",
+                        ));
+                    }
+                }
+                get_jwk_required_bytes(ctx, &object, "k")?
+            },
+            format => {
+                return key_format_not_supported_error(ctx, algorithm_name, format.as_str());
+            },
+        };
+        if data.len() != 32 {
+            return Err(DOMException::data_error(
+                ctx,
+                "ChaCha20-Poly1305 keys must be 256 bits",
+            ));
+        }
+        Ok(Some(*kind))
+    }
+
+    let key_kind = import(ctx, mode, algorithm_name)?;
+    KeyUsage::classify_and_check_usages(
+        ctx,
+        KeyUsageAlgorithm::Symmetric,
+        usages,
+        private_usages,
+        public_usages,
+        key_kind.as_ref(),
+    )?;
+    Ok(KeyAlgorithm::ChaCha20Poly1305)
+}
+
 fn from_rsa<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
@@ -902,7 +962,14 @@ impl KeyAlgorithm {
         if matches!(mode, KeyAlgorithmMode::Import { .. })
             && !matches!(
                 name.as_str(),
-                "AES-CBC" | "AES-CTR" | "AES-GCM" | "AES-KW" | "HMAC" | "HKDF" | "PBKDF2"
+                "AES-CBC"
+                    | "AES-CTR"
+                    | "AES-GCM"
+                    | "AES-KW"
+                    | "ChaCha20-Poly1305"
+                    | "HMAC"
+                    | "HKDF"
+                    | "PBKDF2"
             )
         {
             return Err(DOMException::not_supported_error(
@@ -916,7 +983,7 @@ impl KeyAlgorithm {
             let synthetic_usages = Array::new(ctx.clone())?;
             let usage = match name.as_str() {
                 "AES-KW" => "wrapKey",
-                "AES-CBC" | "AES-CTR" | "AES-GCM" | "RSA-OAEP" => "encrypt",
+                "AES-CBC" | "AES-CTR" | "AES-GCM" | "ChaCha20-Poly1305" | "RSA-OAEP" => "encrypt",
                 "ECDH" | "X25519" | "HKDF" | "PBKDF2" => "deriveKey",
                 _ => "sign",
             };
@@ -980,6 +1047,14 @@ impl KeyAlgorithm {
                 ctx,
                 mode,
                 obj,
+                algorithm_name,
+                &usages,
+                &mut private_usages,
+                &mut public_usages,
+            )?,
+            "ChaCha20-Poly1305" => from_chacha20_poly1305(
+                ctx,
+                mode,
                 algorithm_name,
                 &usages,
                 &mut private_usages,

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -1301,6 +1301,22 @@ fn from_pbkdf2<'js>(
     Ok(algorithm)
 }
 
+pub(super) fn synthetic_key_usage(name: &str) -> Option<&'static str> {
+    if MlKemVariant::try_from(name).is_ok() || HybridKemVariant::try_from(name).is_ok() {
+        return Some("encapsulateKey");
+    }
+    if MlDsaVariant::try_from(name).is_ok() {
+        return Some("sign");
+    }
+    Some(match name {
+        "AES-KW" => "wrapKey",
+        "AES-CBC" | "AES-CTR" | "AES-GCM" | "ChaCha20-Poly1305" | "RSA-OAEP" => "encrypt",
+        "ECDH" | "X25519" | "HKDF" | "PBKDF2" => "deriveKey",
+        "ECDSA" | "Ed25519" | "HMAC" | "RSA-PSS" | "RSASSA-PKCS1-v1_5" => "sign",
+        _ => return None,
+    })
+}
+
 impl KeyAlgorithm {
     pub fn from_js<'js>(
         ctx: &Ctx<'js>,
@@ -1333,13 +1349,8 @@ impl KeyAlgorithm {
             || (mode == KeyAlgorithmMode::ValidateImport && usages.is_empty())
         {
             let synthetic_usages = Array::new(ctx.clone())?;
-            let usage = match name.as_str() {
-                "AES-KW" => "wrapKey",
-                "AES-CBC" | "AES-CTR" | "AES-GCM" | "ChaCha20-Poly1305" | "RSA-OAEP" => "encrypt",
-                "ECDH" | "X25519" | "HKDF" | "PBKDF2" => "deriveKey",
-                "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" | "MLKEM768-P256"
-                | "MLKEM768-X25519" | "MLKEM1024-P384" => "encapsulateKey",
-                _ => "sign",
+            let Some(usage) = synthetic_key_usage(&name) else {
+                return algorithm_not_supported_error(ctx);
             };
             synthetic_usages.set(0, usage)?;
             synthetic_usages
@@ -1423,45 +1434,6 @@ impl KeyAlgorithm {
                 &mut private_usages,
                 &mut public_usages,
             )?,
-            "ML-DSA-44" | "ML-DSA-65" | "ML-DSA-87" => from_ml_dsa(
-                ctx,
-                mode,
-                algorithm_name,
-                match algorithm_name {
-                    "ML-DSA-44" => MlDsaVariant::MlDsa44,
-                    "ML-DSA-65" => MlDsaVariant::MlDsa65,
-                    _ => MlDsaVariant::MlDsa87,
-                },
-                &usages,
-                &mut private_usages,
-                &mut public_usages,
-            )?,
-            "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" => from_ml_kem(
-                ctx,
-                mode,
-                algorithm_name,
-                match algorithm_name {
-                    "ML-KEM-512" => MlKemVariant::MlKem512,
-                    "ML-KEM-768" => MlKemVariant::MlKem768,
-                    _ => MlKemVariant::MlKem1024,
-                },
-                &usages,
-                &mut private_usages,
-                &mut public_usages,
-            )?,
-            "MLKEM768-P256" | "MLKEM768-X25519" | "MLKEM1024-P384" => from_hybrid_kem(
-                ctx,
-                mode,
-                algorithm_name,
-                match algorithm_name {
-                    "MLKEM768-P256" => HybridKemVariant::MlKem768P256,
-                    "MLKEM768-X25519" => HybridKemVariant::MlKem768X25519,
-                    _ => HybridKemVariant::MlKem1024P384,
-                },
-                &usages,
-                &mut private_usages,
-                &mut public_usages,
-            )?,
             "HKDF" => from_hkdf(
                 ctx,
                 mode,
@@ -1480,7 +1452,41 @@ impl KeyAlgorithm {
                 &mut private_usages,
                 &mut public_usages,
             )?,
-            _ => return algorithm_not_supported_error(ctx),
+            _ => {
+                if let Ok(variant) = MlDsaVariant::try_from(algorithm_name) {
+                    from_ml_dsa(
+                        ctx,
+                        mode,
+                        algorithm_name,
+                        variant,
+                        &usages,
+                        &mut private_usages,
+                        &mut public_usages,
+                    )?
+                } else if let Ok(variant) = MlKemVariant::try_from(algorithm_name) {
+                    from_ml_kem(
+                        ctx,
+                        mode,
+                        algorithm_name,
+                        variant,
+                        &usages,
+                        &mut private_usages,
+                        &mut public_usages,
+                    )?
+                } else if let Ok(variant) = HybridKemVariant::try_from(algorithm_name) {
+                    from_hybrid_kem(
+                        ctx,
+                        mode,
+                        algorithm_name,
+                        variant,
+                        &usages,
+                        &mut private_usages,
+                        &mut public_usages,
+                    )?
+                } else {
+                    return algorithm_not_supported_error(ctx);
+                }
+            },
         };
 
         Ok(KeyAlgorithmWithUsages {

--- a/modules/llrt_crypto/src/subtle/key_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/key_algorithm.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 #[cfg(feature = "_subtle-full")]
 use der::{
-    asn1::{BitStringRef, OctetString, OctetStringRef},
+    asn1::{AnyRef, BitStringRef, OctetString, OctetStringRef},
     Decode, Encode,
 };
 #[cfg(feature = "_subtle-full")]
@@ -29,7 +29,10 @@ use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::{
     hash::HashAlgorithm,
-    provider::{hmac_length_is_byte_aligned, parse_rsa_public_exponent, MAX_HMAC_KEY_LENGTH_BITS},
+    provider::{
+        hmac_length_is_byte_aligned, parse_rsa_public_exponent, MlDsaVariant,
+        MAX_HMAC_KEY_LENGTH_BITS,
+    },
 };
 
 #[cfg(feature = "_subtle-full")]
@@ -315,6 +318,7 @@ pub enum KeyAlgorithm {
         length: u32,
     },
     ChaCha20Poly1305,
+    MlDsa(MlDsaVariant),
     Rsa {
         modulus_length: u32,
         public_exponent: Rc<Box<[u8]>>,
@@ -765,6 +769,122 @@ fn from_chacha20_poly1305<'js>(
     Ok(KeyAlgorithm::ChaCha20Poly1305)
 }
 
+fn from_ml_dsa<'js>(
+    ctx: &Ctx<'js>,
+    mode: KeyAlgorithmMode<'_, 'js>,
+    algorithm_name: &str,
+    variant: MlDsaVariant,
+    usages: &Array<'js>,
+    private_usages: &mut Vec<String>,
+    public_usages: &mut Vec<String>,
+) -> Result<KeyAlgorithm> {
+    #[cfg(feature = "_subtle-full")]
+    fn import<'js>(
+        ctx: &Ctx<'js>,
+        mode: KeyAlgorithmMode<'_, 'js>,
+        algorithm_name: &str,
+        variant: MlDsaVariant,
+    ) -> Result<Option<KeyKind>> {
+        use crate::provider::modern;
+
+        let KeyAlgorithmMode::Import { format, kind, data } = mode else {
+            return Ok(None);
+        };
+
+        match format {
+            KeyFormatData::RawPublic(bytes) => {
+                *data = modern::import_ml_dsa_public_key(variant, bytes.as_bytes(ctx)?, false)
+                    .or_throw_dom(ctx)?;
+                *kind = KeyKind::Public;
+            },
+            KeyFormatData::Spki(bytes) => {
+                *data = modern::import_ml_dsa_public_key(variant, bytes.as_bytes(ctx)?, true)
+                    .or_throw_dom(ctx)?;
+                *kind = KeyKind::Public;
+            },
+            KeyFormatData::RawSeed(bytes) => {
+                *data = modern::import_ml_dsa_private_key(variant, bytes.as_bytes(ctx)?, false)
+                    .or_throw_dom(ctx)?;
+                *kind = KeyKind::Private;
+            },
+            KeyFormatData::Pkcs8(bytes) => {
+                let bytes = bytes.as_bytes(ctx)?;
+                validate_ml_private_key_info(
+                    ctx,
+                    bytes,
+                    match variant {
+                        MlDsaVariant::MlDsa44 => "2.16.840.1.101.3.4.3.17",
+                        MlDsaVariant::MlDsa65 => "2.16.840.1.101.3.4.3.18",
+                        MlDsaVariant::MlDsa87 => "2.16.840.1.101.3.4.3.19",
+                    },
+                    match variant {
+                        MlDsaVariant::MlDsa44 => 2560,
+                        MlDsaVariant::MlDsa65 => 4032,
+                        MlDsaVariant::MlDsa87 => 4896,
+                    },
+                )?;
+                *data =
+                    modern::import_ml_dsa_private_key(variant, bytes, true).or_throw_dom(ctx)?;
+                *kind = KeyKind::Private;
+            },
+            KeyFormatData::Jwk(object) => {
+                validate_jwk_kty(ctx, &object, "AKP")?;
+                validate_jwk_use(ctx, &object, true)?;
+                if get_jwk_required_string(ctx, &object, "alg")? != algorithm_name {
+                    return Err(DOMException::data_error(
+                        ctx,
+                        "JWK 'alg' parameter does not match the algorithm",
+                    ));
+                }
+
+                let public_key = get_jwk_required_bytes(ctx, &object, "pub")?;
+                if let Some(seed) = get_jwk_optional_bytes(ctx, &object, "priv")? {
+                    *data = modern::import_ml_dsa_private_key(variant, &seed, false)
+                        .or_throw_dom(ctx)?;
+                    let derived_public_key =
+                        modern::ml_dsa_public_key(variant, data).or_throw_dom(ctx)?;
+                    if derived_public_key != public_key {
+                        return Err(DOMException::data_error(
+                            ctx,
+                            "JWK public and private key values do not match",
+                        ));
+                    }
+                    *kind = KeyKind::Private;
+                } else {
+                    *data = modern::import_ml_dsa_public_key(variant, &public_key, false)
+                        .or_throw_dom(ctx)?;
+                    *kind = KeyKind::Public;
+                }
+            },
+            format => {
+                return key_format_not_supported_error(ctx, algorithm_name, format.as_str());
+            },
+        }
+        Ok(Some(*kind))
+    }
+
+    #[cfg(not(feature = "_subtle-full"))]
+    fn import<'js>(
+        _ctx: &Ctx<'js>,
+        _mode: KeyAlgorithmMode<'_, 'js>,
+        _algorithm_name: &str,
+        _variant: MlDsaVariant,
+    ) -> Result<Option<KeyKind>> {
+        Ok(None)
+    }
+
+    let key_kind = import(ctx, mode, algorithm_name, variant)?;
+    KeyUsage::classify_and_check_usages(
+        ctx,
+        KeyUsageAlgorithm::Sign,
+        usages,
+        private_usages,
+        public_usages,
+        key_kind.as_ref(),
+    )?;
+    Ok(KeyAlgorithm::MlDsa(variant))
+}
+
 fn from_rsa<'js>(
     ctx: &Ctx<'js>,
     mode: KeyAlgorithmMode<'_, 'js>,
@@ -1069,6 +1189,19 @@ impl KeyAlgorithm {
                 &mut private_usages,
                 &mut public_usages,
             )?,
+            "ML-DSA-44" | "ML-DSA-65" | "ML-DSA-87" => from_ml_dsa(
+                ctx,
+                mode,
+                algorithm_name,
+                match algorithm_name {
+                    "ML-DSA-44" => MlDsaVariant::MlDsa44,
+                    "ML-DSA-65" => MlDsaVariant::MlDsa65,
+                    _ => MlDsaVariant::MlDsa87,
+                },
+                &usages,
+                &mut private_usages,
+                &mut public_usages,
+            )?,
             "HKDF" => from_hkdf(
                 ctx,
                 mode,
@@ -1190,6 +1323,54 @@ impl KeyAlgorithm {
         )?;
 
         Ok(KeyAlgorithm::Ec { curve, algorithm })
+    }
+}
+
+#[cfg(feature = "_subtle-full")]
+fn validate_ml_private_key_info(
+    ctx: &Ctx<'_>,
+    data: &[u8],
+    expected_oid: &str,
+    expanded_key_length: usize,
+) -> Result<()> {
+    let private_key_info = PrivateKeyInfoRef::from_der(data).or_throw_data_error(ctx)?;
+    let expected_oid = ObjectIdentifier::new_unwrap(expected_oid);
+    if private_key_info.algorithm.oid != expected_oid
+        || private_key_info.algorithm.parameters.is_some()
+    {
+        return Err(DOMException::data_error(
+            ctx,
+            "PKCS#8 algorithm identifier is invalid",
+        ));
+    }
+
+    let private_key = private_key_info.private_key.as_bytes();
+    match private_key.first() {
+        Some(0x80) => Ok(()),
+        Some(0x04) => {
+            let expanded_key = OctetString::from_der(private_key).or_throw_data_error(ctx)?;
+            if expanded_key.as_bytes().len() != expanded_key_length {
+                return Err(DOMException::data_error(
+                    ctx,
+                    "Expanded private key has invalid length",
+                ));
+            }
+            Err(DOMException::not_supported_error(
+                ctx,
+                "Expanded private keys are not supported",
+            ))
+        },
+        Some(0x30) => {
+            AnyRef::from_der(private_key).or_throw_data_error(ctx)?;
+            Err(DOMException::not_supported_error(
+                ctx,
+                "Combined seed and expanded private keys are not supported",
+            ))
+        },
+        _ => Err(DOMException::data_error(
+            ctx,
+            "Private key format is invalid",
+        )),
     }
 }
 

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -58,7 +58,8 @@ use key_algorithm::KeyAlgorithm;
 use llrt_exceptions::DOMException;
 use llrt_utils::{object::ObjectExt, str_enum};
 use rquickjs::{
-    atom::PredefinedAtom, Coerced, Ctx, Error, Exception, FromJs, Object, Result, Value,
+    atom::PredefinedAtom, prelude::Opt, Array, Class, Coerced, Ctx, Error, Exception, FromJs,
+    Object, Result, Value,
 };
 
 use crate::provider::{CryptoProvider, SimpleDigest};
@@ -85,9 +86,9 @@ impl SubtleCrypto {
     pub async fn get_public_key<'js>(
         &self,
         ctx: Ctx<'js>,
-        key: rquickjs::Class<'js, CryptoKey<'js>>,
-        usages: rquickjs::Array<'js>,
-    ) -> Result<rquickjs::Class<'js, CryptoKey<'js>>> {
+        key: Class<'js, CryptoKey<'js>>,
+        usages: Array<'js>,
+    ) -> Result<Class<'js, CryptoKey<'js>>> {
         subtle_get_public_key(ctx, key, usages).await
     }
 
@@ -96,7 +97,7 @@ impl SubtleCrypto {
         ctx: Ctx<'js>,
         operation: Coerced<String>,
         algorithm: Value<'js>,
-        additional: rquickjs::prelude::Opt<Value<'js>>,
+        additional: Opt<Value<'js>>,
     ) -> Result<bool> {
         subtle_supports(ctx, operation, algorithm, additional)
     }

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -11,6 +11,7 @@ mod encryption_algorithm;
 #[cfg(feature = "_subtle-full")]
 mod export_key;
 mod generate_key;
+mod get_public_key;
 mod import_key;
 #[cfg(feature = "_subtle-full")]
 mod key_algorithm;
@@ -34,6 +35,7 @@ pub use encryption::subtle_encrypt;
 #[cfg(feature = "_subtle-full")]
 pub use export_key::subtle_export_key;
 pub use generate_key::subtle_generate_key;
+pub use get_public_key::subtle_get_public_key;
 #[cfg(feature = "_subtle-full")]
 pub use import_key::subtle_import_key;
 #[cfg(feature = "_subtle-full")]
@@ -75,6 +77,16 @@ impl SubtleCrypto {
     #[qjs(prop, rename = PredefinedAtom::SymbolToStringTag, configurable)]
     pub fn to_string_tag() -> &'static str {
         stringify!(SubtleCrypto)
+    }
+
+    #[qjs(rename = "getPublicKey")]
+    pub async fn get_public_key<'js>(
+        &self,
+        ctx: Ctx<'js>,
+        key: rquickjs::Class<'js, CryptoKey<'js>>,
+        usages: rquickjs::Array<'js>,
+    ) -> Result<rquickjs::Class<'js, CryptoKey<'js>>> {
+        subtle_get_public_key(ctx, key, usages).await
     }
 }
 

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -179,6 +179,7 @@ pub fn to_name_and_maybe_object<'js>(
 pub fn normalize_algorithm_name(name: &str) -> String {
     let name = name.to_ascii_uppercase();
     match name.as_str() {
+        "CHACHA20-POLY1305" => "ChaCha20-Poly1305".to_string(),
         "ED25519" => "Ed25519".to_string(),
         "RSASSA-PKCS1-V1_5" => "RSASSA-PKCS1-v1_5".to_string(),
         _ => name,

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -5,6 +5,7 @@ mod derive_algorithm;
 mod derive_bits;
 mod derive_keys;
 mod digest;
+mod encapsulation;
 mod encryption;
 mod encryption_algorithm;
 #[cfg(feature = "_subtle-full")]
@@ -24,6 +25,10 @@ pub use crypto_key::CryptoKey;
 pub use derive_bits::subtle_derive_bits;
 pub use derive_keys::subtle_derive_key;
 pub use digest::subtle_digest;
+pub use encapsulation::{
+    subtle_decapsulate_bits, subtle_decapsulate_key, subtle_encapsulate_bits,
+    subtle_encapsulate_key,
+};
 pub use encryption::subtle_decrypt;
 pub use encryption::subtle_encrypt;
 #[cfg(feature = "_subtle-full")]

--- a/modules/llrt_crypto/src/subtle/mod.rs
+++ b/modules/llrt_crypto/src/subtle/mod.rs
@@ -17,6 +17,7 @@ mod import_key;
 mod key_algorithm;
 mod sign;
 mod sign_algorithm;
+mod supports;
 mod util;
 mod verify;
 #[cfg(feature = "_subtle-full")]
@@ -41,6 +42,7 @@ pub use import_key::subtle_import_key;
 #[cfg(feature = "_subtle-full")]
 use key_algorithm::KeyAlgorithm;
 pub use sign::subtle_sign;
+use supports::subtle_supports;
 pub use verify::subtle_verify;
 #[cfg(feature = "_subtle-full")]
 pub use wrapping::subtle_unwrap_key;
@@ -87,6 +89,16 @@ impl SubtleCrypto {
         usages: rquickjs::Array<'js>,
     ) -> Result<rquickjs::Class<'js, CryptoKey<'js>>> {
         subtle_get_public_key(ctx, key, usages).await
+    }
+
+    #[qjs(static)]
+    pub fn supports<'js>(
+        ctx: Ctx<'js>,
+        operation: Coerced<String>,
+        algorithm: Value<'js>,
+        additional: rquickjs::prelude::Opt<Value<'js>>,
+    ) -> Result<bool> {
+        subtle_supports(ctx, operation, algorithm, additional)
     }
 }
 

--- a/modules/llrt_crypto/src/subtle/sign.rs
+++ b/modules/llrt_crypto/src/subtle/sign.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::future::Future;
 
-use crate::provider::{CryptoProvider, HmacProvider};
+use crate::provider::{modern, CryptoProvider, HmacProvider};
 use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{ArrayBuffer, Class, Ctx, FromJs, Result, Value};
 
@@ -96,6 +96,13 @@ fn sign(
             let mut hmac = CRYPTO_PROVIDER.hmac(*hash, handle);
             hmac.update(data);
             hmac.finalize()
+        },
+        SigningAlgorithm::MlDsa { variant, context } => {
+            if !matches!(&key.algorithm, KeyAlgorithm::MlDsa(key_variant) if key_variant == variant)
+            {
+                return algorithm_invalid_access_error(ctx, variant.name());
+            }
+            modern::ml_dsa_sign(*variant, handle, data, context).or_throw_dom(ctx)?
         },
         SigningAlgorithm::RsaPss { salt_length } => {
             let (hash, digest) = rsa_hash_digest(ctx, key, data, "RSA-PSS")?;

--- a/modules/llrt_crypto/src/subtle/sign.rs
+++ b/modules/llrt_crypto/src/subtle/sign.rs
@@ -100,7 +100,7 @@ fn sign(
         SigningAlgorithm::MlDsa { variant, context } => {
             if !matches!(&key.algorithm, KeyAlgorithm::MlDsa(key_variant) if key_variant == variant)
             {
-                return algorithm_invalid_access_error(ctx, variant.name());
+                return algorithm_invalid_access_error(ctx, variant.as_str());
             }
             modern::ml_dsa_sign(*variant, handle, data, context).or_throw_dom(ctx)?
         },

--- a/modules/llrt_crypto/src/subtle/sign_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/sign_algorithm.rs
@@ -36,12 +36,21 @@ impl<'js> FromJs<'js> for SigningAlgorithm {
         let algorithm = match name.as_str() {
             "Ed25519" => SigningAlgorithm::Ed25519,
             "HMAC" => SigningAlgorithm::Hmac,
-            "ML-DSA-44" | "ML-DSA-65" | "ML-DSA-87" => {
-                let variant = match name.as_str() {
-                    "ML-DSA-44" => MlDsaVariant::MlDsa44,
-                    "ML-DSA-65" => MlDsaVariant::MlDsa65,
-                    "ML-DSA-87" => MlDsaVariant::MlDsa87,
-                    _ => unreachable!(),
+            "RSASSA-PKCS1-v1_5" => SigningAlgorithm::RsassaPkcs1v15,
+            "ECDSA" => {
+                let obj = obj?;
+                let hash = extract_sha_hash(ctx, &obj)?;
+                SigningAlgorithm::Ecdsa { hash }
+            },
+            "RSA-PSS" => {
+                let value = get_required_dictionary_value(&obj?, "saltLength", "algorithm")?;
+                let salt_length = enforce_range_u32(ctx, value, "saltLength")?;
+
+                SigningAlgorithm::RsaPss { salt_length }
+            },
+            _ => {
+                let Ok(variant) = MlDsaVariant::try_from(name.as_str()) else {
+                    return algorithm_not_supported_error(ctx);
                 };
                 let context = if let Ok(obj) = obj {
                     obj.get_optional::<_, ObjectBytes>("context")?
@@ -62,19 +71,6 @@ impl<'js> FromJs<'js> for SigningAlgorithm {
                     context: context.into_boxed_slice(),
                 }
             },
-            "RSASSA-PKCS1-v1_5" => SigningAlgorithm::RsassaPkcs1v15,
-            "ECDSA" => {
-                let obj = obj?;
-                let hash = extract_sha_hash(ctx, &obj)?;
-                SigningAlgorithm::Ecdsa { hash }
-            },
-            "RSA-PSS" => {
-                let value = get_required_dictionary_value(&obj?, "saltLength", "algorithm")?;
-                let salt_length = enforce_range_u32(ctx, value, "saltLength")?;
-
-                SigningAlgorithm::RsaPss { salt_length }
-            },
-            _ => return algorithm_not_supported_error(ctx),
         };
         Ok(algorithm)
     }
@@ -88,7 +84,7 @@ impl SigningAlgorithm {
             SigningAlgorithm::RsaPss { .. } => "RSA-PSS",
             SigningAlgorithm::RsassaPkcs1v15 => "RSASSA-PKCS1-v1_5",
             SigningAlgorithm::Hmac => "HMAC",
-            SigningAlgorithm::MlDsa { variant, .. } => variant.name(),
+            SigningAlgorithm::MlDsa { variant, .. } => variant.as_str(),
         }
     }
 }

--- a/modules/llrt_crypto/src/subtle/sign_algorithm.rs
+++ b/modules/llrt_crypto/src/subtle/sign_algorithm.rs
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+use llrt_exceptions::DOMException;
+use llrt_utils::{bytes::ObjectBytes, object::ObjectExt};
 use rquickjs::{Ctx, FromJs, Result, Value};
 
-use crate::hash::HashAlgorithm;
+use crate::{hash::HashAlgorithm, provider::MlDsaVariant};
 
 use super::{
     algorithm_not_supported_error, enforce_range_u32, get_required_dictionary_value,
@@ -11,11 +13,19 @@ use super::{
 
 #[derive(Debug)]
 pub enum SigningAlgorithm {
-    Ecdsa { hash: HashAlgorithm },
+    Ecdsa {
+        hash: HashAlgorithm,
+    },
     Ed25519,
-    RsaPss { salt_length: u32 },
+    RsaPss {
+        salt_length: u32,
+    },
     RsassaPkcs1v15,
     Hmac,
+    MlDsa {
+        variant: MlDsaVariant,
+        context: Box<[u8]>,
+    },
 }
 
 impl<'js> FromJs<'js> for SigningAlgorithm {
@@ -26,6 +36,32 @@ impl<'js> FromJs<'js> for SigningAlgorithm {
         let algorithm = match name.as_str() {
             "Ed25519" => SigningAlgorithm::Ed25519,
             "HMAC" => SigningAlgorithm::Hmac,
+            "ML-DSA-44" | "ML-DSA-65" | "ML-DSA-87" => {
+                let variant = match name.as_str() {
+                    "ML-DSA-44" => MlDsaVariant::MlDsa44,
+                    "ML-DSA-65" => MlDsaVariant::MlDsa65,
+                    "ML-DSA-87" => MlDsaVariant::MlDsa87,
+                    _ => unreachable!(),
+                };
+                let context = if let Ok(obj) = obj {
+                    obj.get_optional::<_, ObjectBytes>("context")?
+                        .map(|value| value.into_bytes(ctx))
+                        .transpose()?
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
+                if context.len() > 255 {
+                    return Err(DOMException::operation_error(
+                        ctx,
+                        "ML-DSA context must not exceed 255 bytes",
+                    ));
+                }
+                SigningAlgorithm::MlDsa {
+                    variant,
+                    context: context.into_boxed_slice(),
+                }
+            },
             "RSASSA-PKCS1-v1_5" => SigningAlgorithm::RsassaPkcs1v15,
             "ECDSA" => {
                 let obj = obj?;
@@ -52,6 +88,7 @@ impl SigningAlgorithm {
             SigningAlgorithm::RsaPss { .. } => "RSA-PSS",
             SigningAlgorithm::RsassaPkcs1v15 => "RSASSA-PKCS1-v1_5",
             SigningAlgorithm::Hmac => "HMAC",
+            SigningAlgorithm::MlDsa { variant, .. } => variant.name(),
         }
     }
 }

--- a/modules/llrt_crypto/src/subtle/supports.rs
+++ b/modules/llrt_crypto/src/subtle/supports.rs
@@ -1,0 +1,484 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use llrt_utils::bytes::ObjectBytes;
+use rquickjs::{prelude::Opt, Array, Coerced, Ctx, FromJs, IntoJs, Result, Value};
+
+use super::{
+    algorithm_not_supported_error,
+    crypto_key::KeyKind,
+    derive_algorithm::DeriveAlgorithm,
+    digest::supports_digest_algorithm,
+    encapsulation::normalize_encapsulation_algorithm,
+    encryption_algorithm::EncryptionAlgorithm,
+    enforce_range_u32,
+    key_algorithm::{
+        EcAlgorithm, KeyAlgorithm, KeyAlgorithmMode, KeyAlgorithmWithUsages, KeyDerivation,
+        KeyFormatData,
+    },
+    normalize_algorithm_name,
+    sign_algorithm::SigningAlgorithm,
+    to_name_and_maybe_object, EllipticCurve,
+};
+
+#[cfg(all(feature = "_subtle-full", feature = "crypto-openssl"))]
+fn provider_supports_generate_key(algorithm: &KeyAlgorithm) -> bool {
+    if let KeyAlgorithm::Rsa { modulus_length, .. } = algorithm {
+        return *modulus_length >= 512;
+    }
+    true
+}
+
+#[cfg(all(feature = "_subtle-full", not(feature = "crypto-openssl")))]
+fn provider_supports_generate_key(algorithm: &KeyAlgorithm) -> bool {
+    if let KeyAlgorithm::Rsa { modulus_length, .. } = algorithm {
+        return *modulus_length >= 1024;
+    }
+    true
+}
+
+#[cfg(not(feature = "_subtle-full"))]
+fn provider_supports_generate_key(algorithm: &KeyAlgorithm) -> bool {
+    match algorithm {
+        KeyAlgorithm::ChaCha20Poly1305
+        | KeyAlgorithm::MlDsa(_)
+        | KeyAlgorithm::MlKem(_)
+        | KeyAlgorithm::HybridKem(_) => true,
+        #[cfg(feature = "crypto-graviola")]
+        KeyAlgorithm::Aes { length, .. } => matches!(length, 128 | 256),
+        #[cfg(feature = "crypto-graviola")]
+        KeyAlgorithm::Hmac { .. } => true,
+        _ => false,
+    }
+}
+
+#[cfg(feature = "_subtle-full")]
+fn provider_supports_sign(_algorithm: &SigningAlgorithm) -> bool {
+    true
+}
+
+#[cfg(not(feature = "_subtle-full"))]
+fn provider_supports_sign(algorithm: &SigningAlgorithm) -> bool {
+    match algorithm {
+        SigningAlgorithm::MlDsa { .. } => true,
+        #[cfg(feature = "crypto-graviola")]
+        SigningAlgorithm::Hmac => true,
+        _ => false,
+    }
+}
+
+#[cfg(feature = "_subtle-full")]
+fn provider_supports_encryption(_algorithm: &EncryptionAlgorithm) -> bool {
+    true
+}
+
+#[cfg(not(feature = "_subtle-full"))]
+fn provider_supports_encryption(algorithm: &EncryptionAlgorithm) -> bool {
+    match algorithm {
+        EncryptionAlgorithm::ChaCha20Poly1305 { .. } => true,
+        #[cfg(feature = "crypto-graviola")]
+        EncryptionAlgorithm::AesGcm { tag_length, .. } => *tag_length == 128,
+        _ => false,
+    }
+}
+
+fn algorithm_name<'js>(ctx: &Ctx<'js>, algorithm: Value<'js>) -> Result<String> {
+    let (name, _) = to_name_and_maybe_object(ctx, algorithm)?;
+    Ok(normalize_algorithm_name(&name))
+}
+
+fn synthetic_key_usage(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "AES-KW" => "wrapKey",
+        "AES-CBC" | "AES-CTR" | "AES-GCM" | "ChaCha20-Poly1305" | "RSA-OAEP" => "encrypt",
+        "ECDH" | "X25519" | "HKDF" | "PBKDF2" => "deriveKey",
+        "ECDSA" | "Ed25519" | "HMAC" | "ML-DSA-44" | "ML-DSA-65" | "ML-DSA-87" | "RSA-PSS"
+        | "RSASSA-PKCS1-v1_5" => "sign",
+        "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" | "MLKEM768-P256" | "MLKEM768-X25519"
+        | "MLKEM1024-P384" => "encapsulateKey",
+        _ => return None,
+    })
+}
+
+fn normalize_key_algorithm_with_synthetic_usage<'js>(
+    ctx: &Ctx<'js>,
+    mode: KeyAlgorithmMode<'_, 'js>,
+    algorithm: Value<'js>,
+) -> Result<KeyAlgorithmWithUsages> {
+    let name = algorithm_name(ctx, algorithm.clone())?;
+    let Some(usage) = synthetic_key_usage(&name) else {
+        return algorithm_not_supported_error(ctx);
+    };
+    let usages = Array::new(ctx.clone())?;
+    usages.set(0, usage)?;
+    KeyAlgorithm::from_js(ctx, mode, algorithm, usages)
+}
+
+fn webidl_algorithm_identifier<'js>(ctx: &Ctx<'js>, algorithm: Value<'js>) -> Result<Value<'js>> {
+    if algorithm.is_object() {
+        Ok(algorithm)
+    } else {
+        Coerced::<String>::from_js(ctx, algorithm)?.0.into_js(ctx)
+    }
+}
+
+fn supports_generate_key<'js>(ctx: &Ctx<'js>, algorithm: Value<'js>) -> Result<bool> {
+    let normalized =
+        normalize_key_algorithm_with_synthetic_usage(ctx, KeyAlgorithmMode::Generate, algorithm)?;
+    Ok(provider_supports_generate_key(&normalized.algorithm))
+}
+
+fn supports_import_key<'js>(ctx: &Ctx<'js>, algorithm: Value<'js>) -> Result<bool> {
+    normalize_key_algorithm_with_synthetic_usage(ctx, KeyAlgorithmMode::ValidateImport, algorithm)?;
+    Ok(cfg!(feature = "_subtle-full"))
+}
+
+fn supports_export_key<'js>(ctx: &Ctx<'js>, algorithm: Value<'js>) -> Result<bool> {
+    let name = algorithm_name(ctx, algorithm)?;
+    Ok(cfg!(feature = "_subtle-full")
+        && synthetic_key_usage(&name).is_some()
+        && !matches!(name.as_str(), "HKDF" | "PBKDF2"))
+}
+
+fn supports_encrypt<'js>(ctx: &Ctx<'js>, algorithm: Value<'js>) -> Result<bool> {
+    let normalized = EncryptionAlgorithm::from_js(ctx, algorithm)?;
+    let valid_parameters = match &normalized {
+        EncryptionAlgorithm::AesCtr { counter, .. } => counter.len() == 16,
+        EncryptionAlgorithm::AesGcm { iv, .. } => iv.len() == 12,
+        EncryptionAlgorithm::ChaCha20Poly1305 { iv, tag_length, .. } => {
+            iv.len() == 12 && *tag_length == 128
+        },
+        EncryptionAlgorithm::AesKw => false,
+        _ => true,
+    };
+    Ok(valid_parameters && provider_supports_encryption(&normalized))
+}
+
+fn supports_wrap<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    additional: &SupportsAdditional<'js>,
+    unwrap: bool,
+) -> Result<bool> {
+    if let SupportsAdditional::Algorithm(additional) = additional {
+        let additional_supported = if unwrap {
+            supports_import_key(ctx, additional.clone())?
+        } else {
+            supports_export_key(ctx, additional.clone())?
+        };
+        if !additional_supported {
+            return Ok(false);
+        }
+    }
+
+    let directly_supported = match algorithm_name(ctx, algorithm.clone()) {
+        Ok(name) => name == "AES-KW",
+        Err(_) => {
+            ctx.catch();
+            false
+        },
+    };
+    if directly_supported {
+        return Ok(cfg!(feature = "_subtle-full"));
+    }
+
+    let normalized = EncryptionAlgorithm::from_js(ctx, algorithm)?;
+    let valid_parameters = match &normalized {
+        EncryptionAlgorithm::AesCtr { counter, .. } => counter.len() == 16,
+        EncryptionAlgorithm::AesGcm { iv, .. } => iv.len() == 12,
+        EncryptionAlgorithm::ChaCha20Poly1305 { iv, tag_length, .. } => {
+            iv.len() == 12 && *tag_length == 128
+        },
+        EncryptionAlgorithm::AesKw => false,
+        _ => true,
+    };
+    if !valid_parameters || !cfg!(feature = "_subtle-full") {
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+fn supports_sign<'js>(ctx: &Ctx<'js>, algorithm: Value<'js>) -> Result<bool> {
+    let normalized = SigningAlgorithm::from_js(ctx, algorithm)?;
+    Ok(provider_supports_sign(&normalized))
+}
+
+enum SupportsAdditional<'js> {
+    Length(Option<u32>),
+    Algorithm(Value<'js>),
+}
+
+impl SupportsAdditional<'_> {
+    fn length(&self) -> Option<u32> {
+        match self {
+            SupportsAdditional::Length(length) => *length,
+            SupportsAdditional::Algorithm(_) => None,
+        }
+    }
+}
+
+fn supports_additional<'js>(
+    ctx: &Ctx<'js>,
+    value: Opt<Value<'js>>,
+) -> Result<SupportsAdditional<'js>> {
+    match value.0 {
+        None => Ok(SupportsAdditional::Length(None)),
+        Some(value) if value.is_null() || value.is_undefined() => {
+            Ok(SupportsAdditional::Length(None))
+        },
+        Some(value) if value.is_string() || value.is_object() => {
+            Ok(SupportsAdditional::Algorithm(value))
+        },
+        Some(value) => Ok(SupportsAdditional::Length(Some(enforce_range_u32(
+            ctx, value, "length",
+        )?))),
+    }
+}
+
+fn supports_derive_bits_with_length<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    length: Option<u32>,
+) -> Result<bool> {
+    let normalized = DeriveAlgorithm::from_js(ctx, algorithm)?;
+    Ok(cfg!(feature = "_subtle-full")
+        && match normalized {
+            DeriveAlgorithm::X25519 { .. } => length.is_none_or(|length| length <= 256),
+            DeriveAlgorithm::Ecdh {
+                curve,
+                ec_algorithm,
+                ..
+            } => {
+                if !matches!(ec_algorithm, EcAlgorithm::Ecdh) {
+                    return Ok(false);
+                }
+                let maximum = match curve {
+                    EllipticCurve::P256 => 256,
+                    EllipticCurve::P384 => 384,
+                    EllipticCurve::P521 => 528,
+                };
+                length.is_none_or(|length| length <= maximum)
+            },
+            DeriveAlgorithm::Derive(KeyDerivation::Hkdf { hash, .. }) => {
+                length.is_some_and(|length| {
+                    length.is_multiple_of(8) && length <= (hash.digest_len() * 8 * 255) as u32
+                })
+            },
+            DeriveAlgorithm::Derive(KeyDerivation::Pbkdf2 { iterations, .. }) => {
+                iterations != 0 && length.is_some_and(|length| length.is_multiple_of(8))
+            },
+        })
+}
+
+fn supports_derive_bits<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    additional: &SupportsAdditional<'js>,
+) -> Result<bool> {
+    supports_derive_bits_with_length(ctx, algorithm, additional.length())
+}
+
+fn supports_derive_key<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    additional: &SupportsAdditional<'js>,
+) -> Result<bool> {
+    let SupportsAdditional::Algorithm(target) = additional else {
+        algorithm_name(ctx, algorithm)?;
+        return Ok(false);
+    };
+    if !supports_import_key(ctx, target.clone())? {
+        return Ok(false);
+    }
+    let target = KeyAlgorithm::from_js(
+        ctx,
+        KeyAlgorithmMode::Derive,
+        target.clone(),
+        Array::new(ctx.clone())?,
+    )?;
+    let target_length = match target.algorithm {
+        KeyAlgorithm::Aes { length, .. } => Some(u32::from(length)),
+        KeyAlgorithm::ChaCha20Poly1305 => Some(256),
+        KeyAlgorithm::Hmac { length, .. } => Some(length),
+        KeyAlgorithm::HkdfImport | KeyAlgorithm::Pbkdf2Import => None,
+        _ => return Ok(false),
+    };
+    supports_derive_bits_with_length(ctx, algorithm, target_length)
+}
+
+fn supports_shared_key<'js>(
+    ctx: &Ctx<'js>,
+    algorithm: Value<'js>,
+    shared_key_length: usize,
+) -> Result<bool> {
+    let name = algorithm_name(ctx, algorithm.clone())?;
+    let Some(usage) = synthetic_key_usage(&name) else {
+        return algorithm_not_supported_error(ctx);
+    };
+    let usages = Array::new(ctx.clone())?;
+    usages.set(0, usage)?;
+    let mut kind = KeyKind::Public;
+    let mut data = Vec::new();
+    KeyAlgorithm::from_js(
+        ctx,
+        KeyAlgorithmMode::Import {
+            format: KeyFormatData::RawSecret(ObjectBytes::Vec(vec![0; shared_key_length])),
+            kind: &mut kind,
+            data: &mut data,
+        },
+        algorithm,
+        usages,
+    )?;
+    Ok(matches!(kind, KeyKind::Secret))
+}
+
+fn supports_get_public_key(name: &str) -> bool {
+    let supported = matches!(
+        name,
+        "ECDH"
+            | "ECDSA"
+            | "Ed25519"
+            | "X25519"
+            | "RSA-OAEP"
+            | "RSA-PSS"
+            | "RSASSA-PKCS1-v1_5"
+            | "ML-DSA-44"
+            | "ML-DSA-65"
+            | "ML-DSA-87"
+            | "ML-KEM-512"
+            | "ML-KEM-768"
+            | "ML-KEM-1024"
+            | "MLKEM768-P256"
+            | "MLKEM768-X25519"
+            | "MLKEM1024-P384"
+    );
+    supported
+        && (cfg!(feature = "_subtle-full")
+            || matches!(
+                name,
+                "ML-DSA-44"
+                    | "ML-DSA-65"
+                    | "ML-DSA-87"
+                    | "ML-KEM-512"
+                    | "ML-KEM-768"
+                    | "ML-KEM-1024"
+                    | "MLKEM768-P256"
+                    | "MLKEM768-X25519"
+                    | "MLKEM1024-P384"
+            ))
+}
+
+fn supports_inner<'js>(
+    ctx: &Ctx<'js>,
+    operation: &str,
+    algorithm: Value<'js>,
+    additional: &SupportsAdditional<'js>,
+) -> Result<bool> {
+    match operation {
+        "generateKey" => supports_generate_key(ctx, algorithm),
+        "importKey" => supports_import_key(ctx, algorithm),
+        "exportKey" => supports_export_key(ctx, algorithm),
+        "sign" | "verify" => supports_sign(ctx, algorithm),
+        "encrypt" | "decrypt" => supports_encrypt(ctx, algorithm),
+        "wrapKey" => supports_wrap(ctx, algorithm, additional, false),
+        "unwrapKey" => supports_wrap(ctx, algorithm, additional, true),
+        "deriveBits" => supports_derive_bits(ctx, algorithm, additional),
+        "deriveKey" => supports_derive_key(ctx, algorithm, additional),
+        "digest" => supports_digest_algorithm(ctx, algorithm),
+        "encapsulateKey" | "decapsulateKey" => {
+            let normalized = normalize_encapsulation_algorithm(ctx, algorithm.clone())?;
+            if let SupportsAdditional::Algorithm(shared) = additional {
+                if !supports_shared_key(ctx, shared.clone(), normalized.shared_key_length())? {
+                    return Ok(false);
+                }
+                normalize_encapsulation_algorithm(ctx, algorithm)?;
+                Ok(true)
+            } else {
+                Ok(true)
+            }
+        },
+        "encapsulateBits" | "decapsulateBits" => {
+            normalize_encapsulation_algorithm(ctx, algorithm)?;
+            Ok(true)
+        },
+        "getPublicKey" => Ok(supports_get_public_key(&algorithm_name(ctx, algorithm)?)),
+        _ => Ok(false),
+    }
+}
+
+pub fn subtle_supports<'js>(
+    ctx: Ctx<'js>,
+    operation: Coerced<String>,
+    algorithm: Value<'js>,
+    additional: Opt<Value<'js>>,
+) -> Result<bool> {
+    let algorithm = webidl_algorithm_identifier(&ctx, algorithm)?;
+    let additional = supports_additional(&ctx, additional)?;
+    let operation = operation.0;
+    Ok(
+        match supports_inner(&ctx, &operation, algorithm, &additional) {
+            Ok(supported) => supported,
+            Err(_) => {
+                ctx.catch();
+                false
+            },
+        },
+    )
+}
+
+#[cfg(all(test, any(feature = "crypto-ring", feature = "crypto-graviola")))]
+mod tests {
+    use super::*;
+    #[cfg(feature = "crypto-ring")]
+    use crate::provider::MlDsaVariant;
+    use crate::subtle::key_algorithm::AesAlgorithm;
+
+    #[cfg(feature = "crypto-ring")]
+    #[test]
+    fn pure_ring_reports_only_provider_independent_key_operations() {
+        assert!(provider_supports_generate_key(&KeyAlgorithm::MlDsa(
+            MlDsaVariant::MlDsa44
+        )));
+        assert!(!provider_supports_generate_key(&KeyAlgorithm::Aes {
+            length: 256,
+            algorithm: AesAlgorithm::Gcm,
+        }));
+        assert!(provider_supports_sign(&SigningAlgorithm::MlDsa {
+            variant: MlDsaVariant::MlDsa44,
+            context: Box::default(),
+        }));
+        assert!(!provider_supports_sign(&SigningAlgorithm::Hmac));
+        assert!(supports_get_public_key("ML-KEM-768"));
+        assert!(!supports_get_public_key("ECDSA"));
+    }
+
+    #[cfg(feature = "crypto-graviola")]
+    #[test]
+    fn pure_graviola_reports_its_partial_symmetric_support() {
+        assert!(provider_supports_generate_key(&KeyAlgorithm::Aes {
+            length: 128,
+            algorithm: AesAlgorithm::Gcm,
+        }));
+        assert!(!provider_supports_generate_key(&KeyAlgorithm::Aes {
+            length: 192,
+            algorithm: AesAlgorithm::Gcm,
+        }));
+        assert!(provider_supports_sign(&SigningAlgorithm::Hmac));
+        assert!(supports_get_public_key("ML-KEM-768"));
+        assert!(!supports_get_public_key("ECDSA"));
+        assert!(provider_supports_encryption(&EncryptionAlgorithm::AesGcm {
+            iv: vec![0; 12].into_boxed_slice(),
+            tag_length: 128,
+            additional_data: None,
+        }));
+        for tag_length in [32, 64, 96, 104, 112, 120] {
+            assert!(!provider_supports_encryption(
+                &EncryptionAlgorithm::AesGcm {
+                    iv: vec![0; 12].into_boxed_slice(),
+                    tag_length,
+                    additional_data: None,
+                }
+            ));
+        }
+    }
+}

--- a/modules/llrt_crypto/src/subtle/supports.rs
+++ b/modules/llrt_crypto/src/subtle/supports.rs
@@ -4,6 +4,8 @@
 use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{prelude::Opt, Array, Coerced, Ctx, FromJs, IntoJs, Result, Value};
 
+use crate::provider::{HybridKemVariant, MlDsaVariant, MlKemVariant};
+
 use super::{
     algorithm_not_supported_error,
     crypto_key::KeyKind,
@@ -13,8 +15,8 @@ use super::{
     encryption_algorithm::EncryptionAlgorithm,
     enforce_range_u32,
     key_algorithm::{
-        EcAlgorithm, KeyAlgorithm, KeyAlgorithmMode, KeyAlgorithmWithUsages, KeyDerivation,
-        KeyFormatData,
+        synthetic_key_usage, EcAlgorithm, KeyAlgorithm, KeyAlgorithmMode, KeyAlgorithmWithUsages,
+        KeyDerivation, KeyFormatData,
     },
     normalize_algorithm_name,
     sign_algorithm::SigningAlgorithm,
@@ -85,19 +87,6 @@ fn provider_supports_encryption(algorithm: &EncryptionAlgorithm) -> bool {
 fn algorithm_name<'js>(ctx: &Ctx<'js>, algorithm: Value<'js>) -> Result<String> {
     let (name, _) = to_name_and_maybe_object(ctx, algorithm)?;
     Ok(normalize_algorithm_name(&name))
-}
-
-fn synthetic_key_usage(name: &str) -> Option<&'static str> {
-    Some(match name {
-        "AES-KW" => "wrapKey",
-        "AES-CBC" | "AES-CTR" | "AES-GCM" | "ChaCha20-Poly1305" | "RSA-OAEP" => "encrypt",
-        "ECDH" | "X25519" | "HKDF" | "PBKDF2" => "deriveKey",
-        "ECDSA" | "Ed25519" | "HMAC" | "ML-DSA-44" | "ML-DSA-65" | "ML-DSA-87" | "RSA-PSS"
-        | "RSASSA-PKCS1-v1_5" => "sign",
-        "ML-KEM-512" | "ML-KEM-768" | "ML-KEM-1024" | "MLKEM768-P256" | "MLKEM768-X25519"
-        | "MLKEM1024-P384" => "encapsulateKey",
-        _ => return None,
-    })
 }
 
 fn normalize_key_algorithm_with_synthetic_usage<'js>(
@@ -333,39 +322,21 @@ fn supports_shared_key<'js>(
 }
 
 fn supports_get_public_key(name: &str) -> bool {
-    let supported = matches!(
-        name,
-        "ECDH"
-            | "ECDSA"
-            | "Ed25519"
-            | "X25519"
-            | "RSA-OAEP"
-            | "RSA-PSS"
-            | "RSASSA-PKCS1-v1_5"
-            | "ML-DSA-44"
-            | "ML-DSA-65"
-            | "ML-DSA-87"
-            | "ML-KEM-512"
-            | "ML-KEM-768"
-            | "ML-KEM-1024"
-            | "MLKEM768-P256"
-            | "MLKEM768-X25519"
-            | "MLKEM1024-P384"
-    );
-    supported
-        && (cfg!(feature = "_subtle-full")
-            || matches!(
+    let modern = MlDsaVariant::try_from(name).is_ok()
+        || MlKemVariant::try_from(name).is_ok()
+        || HybridKemVariant::try_from(name).is_ok();
+    modern
+        || cfg!(feature = "_subtle-full")
+            && matches!(
                 name,
-                "ML-DSA-44"
-                    | "ML-DSA-65"
-                    | "ML-DSA-87"
-                    | "ML-KEM-512"
-                    | "ML-KEM-768"
-                    | "ML-KEM-1024"
-                    | "MLKEM768-P256"
-                    | "MLKEM768-X25519"
-                    | "MLKEM1024-P384"
-            ))
+                "ECDH"
+                    | "ECDSA"
+                    | "Ed25519"
+                    | "X25519"
+                    | "RSA-OAEP"
+                    | "RSA-PSS"
+                    | "RSASSA-PKCS1-v1_5"
+            )
 }
 
 fn supports_inner<'js>(
@@ -429,8 +400,6 @@ pub fn subtle_supports<'js>(
 #[cfg(all(test, any(feature = "crypto-ring", feature = "crypto-graviola")))]
 mod tests {
     use super::*;
-    #[cfg(feature = "crypto-ring")]
-    use crate::provider::MlDsaVariant;
     use crate::subtle::key_algorithm::AesAlgorithm;
 
     #[cfg(feature = "crypto-ring")]

--- a/modules/llrt_crypto/src/subtle/verify.rs
+++ b/modules/llrt_crypto/src/subtle/verify.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::future::Future;
 
-use crate::provider::{CryptoError, CryptoProvider, HmacProvider};
+use crate::provider::{modern, CryptoError, CryptoProvider, HmacProvider};
 use ctutils::CtEq;
 use llrt_utils::bytes::ObjectBytes;
 use rquickjs::{Class, Ctx, FromJs, Result, Value};
@@ -119,6 +119,14 @@ fn verify(
             let computed_signature = hmac.finalize();
 
             computed_signature.as_slice().ct_eq(signature).to_bool()
+        },
+        SigningAlgorithm::MlDsa { variant, context } => {
+            if !matches!(&key.algorithm, KeyAlgorithm::MlDsa(key_variant) if key_variant == variant)
+            {
+                return algorithm_invalid_access_error(ctx, variant.name());
+            }
+            modern::ml_dsa_verify(*variant, handle, signature, data, context)
+                .into_verification(ctx)?
         },
         SigningAlgorithm::RsaPss { salt_length } => {
             let (hash, digest) = rsa_hash_digest(ctx, key, data, "RSA-PSS")?;

--- a/modules/llrt_crypto/src/subtle/verify.rs
+++ b/modules/llrt_crypto/src/subtle/verify.rs
@@ -123,7 +123,7 @@ fn verify(
         SigningAlgorithm::MlDsa { variant, context } => {
             if !matches!(&key.algorithm, KeyAlgorithm::MlDsa(key_variant) if key_variant == variant)
             {
-                return algorithm_invalid_access_error(ctx, variant.name());
+                return algorithm_invalid_access_error(ctx, variant.as_str());
             }
             modern::ml_dsa_verify(*variant, handle, signature, data, context)
                 .into_verification(ctx)?

--- a/modules/llrt_crypto/src/subtle/wrapping.rs
+++ b/modules/llrt_crypto/src/subtle/wrapping.rs
@@ -86,6 +86,10 @@ pub async fn subtle_unwrap_key<'js>(
             KeyFormatData::Jwk(json_parse(&ctx, bytes)?.into_object_or_throw(&ctx, "wrappedKey")?)
         },
         KeyFormat::Raw => KeyFormatData::Raw(ObjectBytes::Vec(bytes)),
+        KeyFormat::RawPrivate => KeyFormatData::RawPrivate(ObjectBytes::Vec(bytes)),
+        KeyFormat::RawPublic => KeyFormatData::RawPublic(ObjectBytes::Vec(bytes)),
+        KeyFormat::RawSecret => KeyFormatData::RawSecret(ObjectBytes::Vec(bytes)),
+        KeyFormat::RawSeed => KeyFormatData::RawSeed(ObjectBytes::Vec(bytes)),
         KeyFormat::Spki => KeyFormatData::Spki(ObjectBytes::Vec(bytes)),
         KeyFormat::Pkcs8 => KeyFormatData::Pkcs8(ObjectBytes::Vec(bytes)),
     };

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -451,3 +451,256 @@ describe("Modern WebCrypto ML-DSA", () => {
     ).rejects.toHaveProperty("name", "OperationError");
   });
 });
+
+describe("Modern WebCrypto ML-KEM", () => {
+  it("encapsulates and decapsulates bits for every parameter set", async () => {
+    const variants = [
+      ["ML-KEM-512", 768],
+      ["ML-KEM-768", 1088],
+      ["ML-KEM-1024", 1568],
+    ] as const;
+
+    for (const [name, ciphertextLength] of variants) {
+      const keyPair = await crypto.subtle.generateKey(name, true, [
+        "decapsulateBits",
+        "encapsulateBits",
+      ]);
+      const encapsulated = await crypto.subtle.encapsulateBits(
+        name,
+        keyPair.publicKey
+      );
+      expect(encapsulated.ciphertext.byteLength).toBe(ciphertextLength);
+      expect(encapsulated.sharedKey.byteLength).toBe(32);
+      expect(
+        await crypto.subtle.decapsulateBits(
+          name,
+          keyPair.privateKey,
+          encapsulated.ciphertext
+        )
+      ).toEqual(encapsulated.sharedKey);
+    }
+  });
+
+  it("encapsulates and decapsulates CryptoKeys", async () => {
+    const keyPair = await crypto.subtle.generateKey("ML-KEM-768", false, [
+      "encapsulateKey",
+      "decapsulateKey",
+    ]);
+    const encapsulated = await crypto.subtle.encapsulateKey(
+      "ML-KEM-768",
+      keyPair.publicKey,
+      { name: "AES-GCM", length: 256 },
+      true,
+      ["encrypt"]
+    );
+    const decapsulated = await crypto.subtle.decapsulateKey(
+      "ML-KEM-768",
+      keyPair.privateKey,
+      encapsulated.ciphertext,
+      { name: "AES-GCM", length: 256 },
+      true,
+      ["encrypt"]
+    );
+    expect(await crypto.subtle.exportKey("raw", decapsulated)).toEqual(
+      await crypto.subtle.exportKey("raw", encapsulated.sharedKey)
+    );
+  });
+
+  it("imports the actual shared secret into HMAC keys", async () => {
+    const keyPair = await crypto.subtle.generateKey("ML-KEM-768", false, [
+      "encapsulateKey",
+      "decapsulateBits",
+      "decapsulateKey",
+    ]);
+    let nameReads = 0;
+    const hmacAlgorithm = {
+      get name() {
+        nameReads++;
+        return nameReads === 1 ? "HMAC" : "not-an-algorithm";
+      },
+      hash: "SHA-256",
+      length: 256,
+    };
+
+    const encapsulated = await crypto.subtle.encapsulateKey(
+      "ML-KEM-768",
+      keyPair.publicKey,
+      hmacAlgorithm,
+      true,
+      ["sign"]
+    );
+    expect(nameReads).toBe(1);
+
+    const expected = new Uint8Array(
+      await crypto.subtle.decapsulateBits(
+        "ML-KEM-768",
+        keyPair.privateKey,
+        encapsulated.ciphertext
+      )
+    );
+    expect(
+      new Uint8Array(
+        await crypto.subtle.exportKey("raw-secret", encapsulated.sharedKey)
+      )
+    ).toEqual(expected);
+
+    nameReads = 0;
+    const decapsulated = await crypto.subtle.decapsulateKey(
+      "ML-KEM-768",
+      keyPair.privateKey,
+      encapsulated.ciphertext,
+      hmacAlgorithm,
+      true,
+      ["sign"]
+    );
+    expect(nameReads).toBe(1);
+    expect(
+      new Uint8Array(await crypto.subtle.exportKey("raw-secret", decapsulated))
+    ).toEqual(expected);
+  });
+
+  it("defers shared-key import validation until after KEM operations", async () => {
+    const name = "ML-KEM-512";
+    const bitOnly = await crypto.subtle.generateKey(name, false, [
+      "encapsulateBits",
+      "decapsulateBits",
+    ]);
+    const bitEncapsulation = await crypto.subtle.encapsulateBits(
+      name,
+      bitOnly.publicKey
+    );
+
+    const full = await crypto.subtle.generateKey(name, false, [
+      "encapsulateKey",
+      "encapsulateBits",
+      "decapsulateKey",
+    ]);
+    const validCiphertext = (
+      await crypto.subtle.encapsulateBits(name, full.publicKey)
+    ).ciphertext;
+
+    const cases = [
+      {
+        algorithm: { name: "HMAC", hash: "SHA-256", length: 0 },
+        usages: ["sign"] as webcrypto.KeyUsage[],
+        importError: "DataError",
+      },
+      {
+        algorithm: { name: "HMAC", hash: "SHA-256" },
+        usages: ["encrypt"] as webcrypto.KeyUsage[],
+        importError: "SyntaxError",
+      },
+    ];
+
+    for (const { algorithm, usages, importError } of cases) {
+      await expect(
+        crypto.subtle.encapsulateKey(
+          name,
+          bitOnly.publicKey,
+          algorithm,
+          false,
+          usages
+        )
+      ).rejects.toHaveProperty("name", "InvalidAccessError");
+
+      await expect(
+        crypto.subtle.decapsulateKey(
+          name,
+          bitOnly.privateKey,
+          bitEncapsulation.ciphertext,
+          algorithm,
+          false,
+          usages
+        )
+      ).rejects.toHaveProperty("name", "InvalidAccessError");
+
+      await expect(
+        crypto.subtle.decapsulateKey(
+          name,
+          full.privateKey,
+          new Uint8Array(767),
+          algorithm,
+          false,
+          usages
+        )
+      ).rejects.toHaveProperty("name", "OperationError");
+
+      await expect(
+        crypto.subtle.encapsulateKey(
+          name,
+          full.publicKey,
+          algorithm,
+          false,
+          usages
+        )
+      ).rejects.toHaveProperty("name", importError);
+
+      await expect(
+        crypto.subtle.decapsulateKey(
+          name,
+          full.privateKey,
+          validCiphertext,
+          algorithm,
+          false,
+          usages
+        )
+      ).rejects.toHaveProperty("name", importError);
+    }
+  }, 30000);
+
+  it("assigns KEM usages canonically", async () => {
+    const keyPair = await crypto.subtle.generateKey("ML-KEM-512", false, [
+      "decapsulateBits",
+      "encapsulateKey",
+      "encapsulateBits",
+      "decapsulateKey",
+      "encapsulateKey",
+    ]);
+    expect(keyPair.publicKey.usages).toEqual([
+      "encapsulateKey",
+      "encapsulateBits",
+    ]);
+    expect(keyPair.privateKey.usages).toEqual([
+      "decapsulateKey",
+      "decapsulateBits",
+    ]);
+  });
+
+  it("round-trips public keys and private seeds", async () => {
+    const name = "ML-KEM-512";
+    const keyPair = await crypto.subtle.generateKey(name, true, [
+      "encapsulateBits",
+      "decapsulateBits",
+    ]);
+
+    for (const [key, formats, usages] of [
+      [keyPair.publicKey, ["raw-public", "spki", "jwk"], ["encapsulateBits"]],
+      [keyPair.privateKey, ["raw-seed", "pkcs8", "jwk"], ["decapsulateBits"]],
+    ] as const) {
+      for (const format of formats) {
+        const encoded = await crypto.subtle.exportKey(format, key);
+        const imported = await crypto.subtle.importKey(
+          format,
+          encoded,
+          name,
+          true,
+          usages
+        );
+        expect(imported.type).toBe(key.type);
+      }
+    }
+  });
+
+  it("rejects malformed ciphertext", async () => {
+    const keyPair = await crypto.subtle.generateKey("ML-KEM-512", false, [
+      "decapsulateBits",
+    ]);
+    await expect(
+      crypto.subtle.decapsulateBits(
+        "ML-KEM-512",
+        keyPair.privateKey,
+        new Uint8Array(767)
+      )
+    ).rejects.toHaveProperty("name", "OperationError");
+  });
+});

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -338,3 +338,116 @@ describe("Modern WebCrypto ChaCha20-Poly1305", () => {
     );
   });
 });
+
+describe("Modern WebCrypto ML-DSA", () => {
+  it("signs and verifies with every parameter set and context", async () => {
+    for (const name of ["ML-DSA-44", "ML-DSA-65", "ML-DSA-87"] as const) {
+      const keyPair = await crypto.subtle.generateKey(name, false, [
+        "sign",
+        "verify",
+      ]);
+      const algorithm = {
+        name,
+        context: new TextEncoder().encode("llrt"),
+      };
+      const signature = await crypto.subtle.sign(
+        algorithm,
+        keyPair.privateKey,
+        DATA
+      );
+      const secondSignature = await crypto.subtle.sign(
+        algorithm,
+        keyPair.privateKey,
+        DATA
+      );
+      expect(new Uint8Array(secondSignature)).not.toEqual(
+        new Uint8Array(signature)
+      );
+      expect(
+        await crypto.subtle.verify(
+          algorithm,
+          keyPair.publicKey,
+          signature,
+          DATA
+        )
+      ).toBe(true);
+      expect(
+        await crypto.subtle.verify(
+          { name, context: new Uint8Array() },
+          keyPair.publicKey,
+          signature,
+          DATA
+        )
+      ).toBe(false);
+    }
+  });
+
+  it("round-trips public keys and private seeds", async () => {
+    const name = "ML-DSA-44";
+    const keyPair = await crypto.subtle.generateKey(name, true, [
+      "sign",
+      "verify",
+    ]);
+    const signature = await crypto.subtle.sign(name, keyPair.privateKey, DATA);
+
+    for (const format of ["raw-public", "spki"] as const) {
+      const encoded = await crypto.subtle.exportKey(format, keyPair.publicKey);
+      const imported = await crypto.subtle.importKey(
+        format,
+        encoded,
+        name,
+        true,
+        ["verify"]
+      );
+      expect(await crypto.subtle.verify(name, imported, signature, DATA)).toBe(
+        true
+      );
+    }
+
+    for (const format of ["raw-seed", "pkcs8"] as const) {
+      const encoded = await crypto.subtle.exportKey(format, keyPair.privateKey);
+      const imported = await crypto.subtle.importKey(
+        format,
+        encoded,
+        name,
+        true,
+        ["sign"]
+      );
+      const importedSignature = await crypto.subtle.sign(name, imported, DATA);
+      expect(
+        await crypto.subtle.verify(
+          name,
+          keyPair.publicKey,
+          importedSignature,
+          DATA
+        )
+      ).toBe(true);
+    }
+
+    for (const key of [keyPair.publicKey, keyPair.privateKey]) {
+      const jwk = await crypto.subtle.exportKey("jwk", key);
+      expect(jwk).toMatchObject({ kty: "AKP", alg: name });
+      const imported = await crypto.subtle.importKey(
+        "jwk",
+        jwk,
+        name,
+        true,
+        key.type === "private" ? ["sign"] : ["verify"]
+      );
+      expect(imported.type).toBe(key.type);
+    }
+  });
+
+  it("rejects contexts longer than 255 bytes", async () => {
+    const keyPair = await crypto.subtle.generateKey("ML-DSA-44", false, [
+      "sign",
+    ]);
+    await expect(
+      crypto.subtle.sign(
+        { name: "ML-DSA-44", context: new Uint8Array(256) },
+        keyPair.privateKey,
+        DATA
+      )
+    ).rejects.toHaveProperty("name", "OperationError");
+  });
+});

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -901,3 +901,212 @@ describe("SubtleCrypto.getPublicKey", () => {
     ).rejects.toHaveProperty("name", "NotSupportedError");
   });
 });
+
+describe("SubtleCrypto.supports", () => {
+  const supports = crypto.subtle.constructor.supports;
+
+  it("applies WebIDL conversions before checking support", () => {
+    expect(supports(1 as unknown as string, "SHA-256")).toBe(false);
+    expect(supports(null as unknown as string, "SHA-256")).toBe(false);
+    expect(() => supports("digest", Symbol() as unknown as string)).toThrow(
+      TypeError
+    );
+  });
+
+  it("reports unsupported operations and incomplete deriveKey calls", () => {
+    expect(supports("unknown", { name: "AES-GCM", length: 128 })).toBe(false);
+    expect(supports("deriveKey", "HKDF")).toBe(false);
+  });
+
+  it("reports modern algorithms and methods", () => {
+    expect(supports("digest", "SHA3-256")).toBe(true);
+    expect(supports("digest", { name: "cSHAKE128", outputLength: 256 })).toBe(
+      true
+    );
+    expect(
+      supports("encrypt", {
+        name: "ChaCha20-Poly1305",
+        iv: new Uint8Array(12),
+      })
+    ).toBe(true);
+    expect(
+      supports("encrypt", { name: "AES-GCM", iv: new Uint8Array(12) })
+    ).toBe(true);
+    expect(supports("sign", "ML-DSA-44")).toBe(true);
+    expect(supports("encapsulateBits", "ML-KEM-768")).toBe(true);
+    expect(supports("decapsulateBits", "MLKEM768-X25519")).toBe(true);
+    expect(supports("getPublicKey", "ML-DSA-44")).toBe(true);
+    expect(supports("digest", "unknown")).toBe(false);
+  });
+
+  it("reports only 96-bit AES-GCM IVs as supported", () => {
+    for (const operation of ["encrypt", "decrypt", "wrapKey", "unwrapKey"]) {
+      expect(
+        supports(operation, { name: "AES-GCM", iv: new Uint8Array(12) })
+      ).toBe(true);
+      for (const length of [0, 1, 16, 32]) {
+        expect(
+          supports(operation, {
+            name: "AES-GCM",
+            iv: new Uint8Array(length),
+          })
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("checks the additional algorithm for key wrapping", () => {
+    expect(supports("wrapKey", "AES-KW")).toBe(true);
+    expect(supports("wrapKey", "AES-KW", 7)).toBe(true);
+    expect(supports("wrapKey", "AES-KW", "HMAC")).toBe(true);
+    expect(supports("wrapKey", "AES-KW", "HKDF")).toBe(false);
+  });
+
+  it("checks the additional algorithm for key unwrapping", () => {
+    expect(supports("unwrapKey", "AES-KW")).toBe(true);
+    expect(
+      supports("unwrapKey", "AES-KW", {
+        name: "HMAC",
+        hash: "SHA-256",
+      })
+    ).toBe(true);
+    expect(supports("unwrapKey", "AES-KW", "HMAC")).toBe(false);
+  });
+
+  it("checks shared-key algorithms for key encapsulation", () => {
+    expect(supports("encapsulateKey", "ML-KEM-512")).toBe(true);
+    expect(supports("decapsulateKey", "ML-KEM-512")).toBe(true);
+    expect(
+      supports("encapsulateKey", "ML-KEM-512", {
+        name: "AES-GCM",
+        length: 256,
+      })
+    ).toBe(true);
+    expect(supports("encapsulateKey", "ML-KEM-512", "ECDSA")).toBe(false);
+  });
+
+  it("rejects null BufferSource parameters", () => {
+    expect(supports("encrypt", { name: "RSA-OAEP", label: null })).toBe(false);
+  });
+
+  it("enforces deriveBits length range", () => {
+    expect(() =>
+      supports(
+        "deriveBits",
+        {
+          name: "HKDF",
+          hash: "SHA-256",
+          salt: new Uint8Array(),
+          info: new Uint8Array(),
+        },
+        2 ** 32
+      )
+    ).toThrow(TypeError);
+    expect(() => supports("digest", "SHA-256", 2 ** 32)).toThrow(TypeError);
+  });
+
+  it("reports RustCrypto RSA generation limits", () => {
+    const algorithm = {
+      name: "RSA-PSS",
+      hash: "SHA-256",
+      publicExponent: new Uint8Array([1, 0, 1]),
+    };
+    expect(supports("generateKey", { ...algorithm, modulusLength: 512 })).toBe(
+      false
+    );
+    expect(supports("generateKey", { ...algorithm, modulusLength: 1024 })).toBe(
+      true
+    );
+    expect(
+      supports("generateKey", { name: "HMAC", hash: "SHA-256", length: 1024 })
+    ).toBe(true);
+    for (const length of [1025, 1032]) {
+      expect(
+        supports("generateKey", { name: "HMAC", hash: "SHA-256", length })
+      ).toBe(false);
+    }
+    expect(
+      supports("importKey", { name: "HMAC", hash: "SHA-256", length: 127 })
+    ).toBe(false);
+  });
+
+  it("supports deriving X25519 secrets into HKDF keys", async () => {
+    const alice = await crypto.subtle.generateKey("X25519", false, [
+      "deriveKey",
+    ]);
+    const bob = await crypto.subtle.generateKey("X25519", false, ["deriveKey"]);
+    expect(
+      supports("deriveKey", { name: "X25519", public: bob.publicKey }, "HKDF")
+    ).toBe(true);
+    expect(
+      supports(
+        "deriveBits",
+        { name: "X25519", public: bob.publicKey },
+        "AES-GCM"
+      )
+    ).toBe(true);
+    expect(alice.privateKey.algorithm.name).toBe("X25519");
+  });
+
+  it("rejects incompatible ECDH public keys", async () => {
+    const ecdsa = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["verify"]
+    );
+    const source = { name: "ECDH", public: ecdsa.publicKey };
+    expect(supports("deriveBits", source, 256)).toBe(false);
+    expect(
+      supports("deriveKey", source, { name: "AES-GCM", length: 128 })
+    ).toBe(false);
+  });
+
+  it("checks KDF-derived HMAC length constraints", () => {
+    for (const source of [
+      {
+        name: "HKDF",
+        hash: "SHA-256",
+        salt: new Uint8Array(),
+        info: new Uint8Array(),
+      },
+      {
+        name: "PBKDF2",
+        hash: "SHA-256",
+        salt: new Uint8Array(),
+        iterations: 1,
+      },
+    ]) {
+      expect(
+        supports("deriveKey", source, {
+          name: "HMAC",
+          hash: "SHA-256",
+          length: 512,
+        })
+      ).toBe(true);
+      for (const length of [513, 1096]) {
+        expect(
+          supports("deriveKey", source, {
+            name: "HMAC",
+            hash: "SHA-256",
+            length,
+          })
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("reports zero PBKDF2 iterations as unsupported", () => {
+    expect(
+      supports(
+        "deriveBits",
+        {
+          name: "PBKDF2",
+          hash: "SHA-256",
+          salt: new Uint8Array(),
+          iterations: 0,
+        },
+        8
+      )
+    ).toBe(false);
+  });
+});

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -704,3 +704,111 @@ describe("Modern WebCrypto ML-KEM", () => {
     ).rejects.toHaveProperty("name", "OperationError");
   });
 });
+
+describe("Modern WebCrypto hybrid KEMs", () => {
+  it("encapsulates and decapsulates every hybrid variant", async () => {
+    const variants = [
+      ["MLKEM768-P256", 1249, 1153],
+      ["MLKEM768-X25519", 1216, 1120],
+      ["MLKEM1024-P384", 1665, 1665],
+    ] as const;
+
+    for (const [name, publicKeyLength, ciphertextLength] of variants) {
+      const keyPair = await crypto.subtle.generateKey(name, true, [
+        "encapsulateBits",
+        "decapsulateBits",
+      ]);
+      expect(
+        (await crypto.subtle.exportKey("raw-public", keyPair.publicKey))
+          .byteLength
+      ).toBe(publicKeyLength);
+      expect(
+        (await crypto.subtle.exportKey("raw-seed", keyPair.privateKey))
+          .byteLength
+      ).toBe(32);
+
+      const encapsulated = await crypto.subtle.encapsulateBits(
+        name,
+        keyPair.publicKey
+      );
+      expect(encapsulated.ciphertext.byteLength).toBe(ciphertextLength);
+      expect(
+        await crypto.subtle.decapsulateBits(
+          name,
+          keyPair.privateKey,
+          encapsulated.ciphertext
+        )
+      ).toEqual(encapsulated.sharedKey);
+    }
+  });
+
+  it("imports the actual hybrid shared secret", async () => {
+    const name = "MLKEM768-X25519";
+    const keyPair = await crypto.subtle.generateKey(name, false, [
+      "encapsulateBits",
+      "decapsulateKey",
+    ]);
+
+    const encapsulated = await crypto.subtle.encapsulateBits(
+      name,
+      keyPair.publicKey
+    );
+    let nameReads = 0;
+    const sharedKey = await crypto.subtle.decapsulateKey(
+      name,
+      keyPair.privateKey,
+      encapsulated.ciphertext,
+      {
+        get name() {
+          nameReads++;
+          return nameReads === 1 ? "HMAC" : "not-an-algorithm";
+        },
+        hash: "SHA-256",
+        length: 256,
+      },
+      true,
+      ["sign"]
+    );
+    expect(nameReads).toBe(1);
+    expect(
+      new Uint8Array(await crypto.subtle.exportKey("raw-secret", sharedKey))
+    ).toEqual(new Uint8Array(encapsulated.sharedKey));
+  });
+
+  it("round-trips hybrid raw and JWK keys", async () => {
+    const name = "MLKEM768-X25519";
+    const keyPair = await crypto.subtle.generateKey(name, true, [
+      "encapsulateBits",
+      "decapsulateBits",
+    ]);
+    for (const [key, formats, usages] of [
+      [keyPair.publicKey, ["raw-public", "jwk"], ["encapsulateBits"]],
+      [keyPair.privateKey, ["raw-seed", "jwk"], ["decapsulateBits"]],
+    ] as const) {
+      for (const format of formats) {
+        const encoded = await crypto.subtle.exportKey(format, key);
+        const imported = await crypto.subtle.importKey(
+          format,
+          encoded,
+          name,
+          true,
+          usages
+        );
+        expect(imported.type).toBe(key.type);
+      }
+    }
+  });
+
+  it("rejects DER key formats", async () => {
+    const keyPair = await crypto.subtle.generateKey("MLKEM768-P256", true, [
+      "encapsulateBits",
+      "decapsulateBits",
+    ]);
+    await expect(
+      crypto.subtle.exportKey("spki", keyPair.publicKey)
+    ).rejects.toHaveProperty("name", "NotSupportedError");
+    await expect(
+      crypto.subtle.exportKey("pkcs8", keyPair.privateKey)
+    ).rejects.toHaveProperty("name", "NotSupportedError");
+  });
+});

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import type { webcrypto } from "node:crypto";
 
+const DATA = new TextEncoder().encode("modern WebCrypto");
+
 describe("Modern WebCrypto key formats", () => {
   it("aliases raw public and secret key formats", async () => {
     const hmac = (await crypto.subtle.generateKey(
@@ -187,5 +189,152 @@ describe("Modern WebCrypto XOF digests", () => {
         )
       ).rejects.toThrow(TypeError);
     }
+  });
+});
+
+describe("Modern WebCrypto ChaCha20-Poly1305", () => {
+  it("encrypts, decrypts, and authenticates additional data", async () => {
+    const key = await crypto.subtle.generateKey("ChaCha20-Poly1305", true, [
+      "encrypt",
+      "decrypt",
+    ]);
+    const algorithm = {
+      name: "ChaCha20-Poly1305",
+      iv: new Uint8Array(12),
+      additionalData: new Uint8Array([1, 2, 3]),
+    };
+    const ciphertext = await crypto.subtle.encrypt(algorithm, key, DATA);
+    expect(
+      new Uint8Array(await crypto.subtle.decrypt(algorithm, key, ciphertext))
+    ).toEqual(DATA);
+
+    const tampered = new Uint8Array(ciphertext);
+    tampered[0] ^= 1;
+    await expect(
+      crypto.subtle.decrypt(algorithm, key, tampered)
+    ).rejects.toHaveProperty("name", "OperationError");
+  });
+
+  it("round-trips raw-secret and JWK keys", async () => {
+    const key = await crypto.subtle.generateKey("ChaCha20-Poly1305", true, [
+      "encrypt",
+      "decrypt",
+    ]);
+    const raw = await crypto.subtle.exportKey("raw-secret", key);
+    expect(raw.byteLength).toBe(32);
+    const jwk = await crypto.subtle.exportKey("jwk", key);
+    expect(jwk).toMatchObject({ kty: "oct", alg: "C20P" });
+
+    for (const [format, data] of [
+      ["raw-secret", raw],
+      ["jwk", jwk],
+    ] as const) {
+      const imported = await crypto.subtle.importKey(
+        format,
+        data,
+        "ChaCha20-Poly1305",
+        true,
+        ["encrypt"]
+      );
+      expect(await crypto.subtle.exportKey("raw-secret", imported)).toEqual(
+        raw
+      );
+    }
+  });
+
+  it("derives 256-bit keys", async () => {
+    const baseKey = await crypto.subtle.importKey(
+      "raw-secret",
+      new Uint8Array([1]),
+      "HKDF",
+      false,
+      ["deriveKey"]
+    );
+    const key = await crypto.subtle.deriveKey(
+      {
+        name: "HKDF",
+        hash: "SHA-256",
+        salt: new Uint8Array(),
+        info: new Uint8Array(),
+      },
+      baseKey,
+      "ChaCha20-Poly1305",
+      true,
+      ["encrypt"]
+    );
+
+    expect(key.algorithm).toMatchObject({ name: "ChaCha20-Poly1305" });
+    expect((await crypto.subtle.exportKey("raw-secret", key)).byteLength).toBe(
+      32
+    );
+  });
+
+  it("validates key and AEAD parameters", async () => {
+    await expect(
+      crypto.subtle.importKey(
+        "raw-secret",
+        new Uint8Array(31),
+        "ChaCha20-Poly1305",
+        false,
+        ["encrypt"]
+      )
+    ).rejects.toHaveProperty("name", "DataError");
+
+    const key = await crypto.subtle.generateKey("ChaCha20-Poly1305", false, [
+      "encrypt",
+      "decrypt",
+    ]);
+    for (const algorithm of [
+      { name: "ChaCha20-Poly1305", iv: new Uint8Array(11) },
+      {
+        name: "ChaCha20-Poly1305",
+        iv: new Uint8Array(12),
+        tagLength: 96,
+      },
+      {
+        name: "ChaCha20-Poly1305",
+        iv: new Uint8Array(12),
+        tagLength: null as unknown as number,
+      },
+    ]) {
+      await expect(
+        crypto.subtle.encrypt(algorithm, key, DATA)
+      ).rejects.toHaveProperty("name", "OperationError");
+    }
+  });
+
+  it("wraps and unwraps keys", async () => {
+    const wrappingKey = await crypto.subtle.generateKey(
+      "ChaCha20-Poly1305",
+      false,
+      ["wrapKey", "unwrapKey"]
+    );
+    const target = await crypto.subtle.generateKey(
+      { name: "AES-GCM", length: 128 },
+      true,
+      ["encrypt"]
+    );
+    const algorithm = {
+      name: "ChaCha20-Poly1305",
+      iv: new Uint8Array(12),
+    };
+    const wrapped = await crypto.subtle.wrapKey(
+      "raw-secret",
+      target,
+      wrappingKey,
+      algorithm
+    );
+    const unwrapped = await crypto.subtle.unwrapKey(
+      "raw-secret",
+      wrapped,
+      wrappingKey,
+      algorithm,
+      "AES-GCM",
+      true,
+      ["encrypt"]
+    );
+    expect(await crypto.subtle.exportKey("raw", unwrapped)).toEqual(
+      await crypto.subtle.exportKey("raw", target)
+    );
   });
 });

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { webcrypto } from "node:crypto";
 
 describe("Modern WebCrypto key formats", () => {
@@ -75,5 +76,32 @@ describe("Modern WebCrypto key formats", () => {
         "AES-KW"
       )
     ).rejects.toHaveProperty("name", "InvalidAccessError");
+  });
+});
+
+describe("Modern WebCrypto SHA-3", () => {
+  it("keeps SHA-3 out of Node streaming hash names", () => {
+    expect(() => createHash("SHA3-256")).toThrow();
+  });
+
+  it("calculates fixed SHA-3 digests", async () => {
+    const result = await crypto.subtle.digest("SHA3-256", new Uint8Array());
+    expect(new Uint8Array(result)).toEqual(
+      new Uint8Array([
+        167, 255, 198, 248, 191, 30, 215, 102, 81, 193, 71, 86, 160, 97, 214,
+        98, 245, 128, 255, 77, 228, 59, 73, 250, 130, 216, 10, 75, 128, 248, 67,
+        74,
+      ])
+    );
+  });
+
+  it("keeps SHA-3 out of HMAC", async () => {
+    await expect(
+      crypto.subtle.generateKey(
+        { name: "HMAC", hash: "SHA3-256" },
+        false,
+        ["sign"]
+      )
+    ).rejects.toHaveProperty("name", "NotSupportedError");
   });
 });

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -452,6 +452,42 @@ describe("Modern WebCrypto ML-DSA", () => {
   });
 });
 
+describe("Modern WebCrypto ML private-key formats", () => {
+  it("rejects empty combined private-key sequences", async () => {
+    for (const [name, oidSuffix, usages] of [
+      ["ML-DSA-44", [0x03, 0x11], ["sign"]],
+      ["ML-KEM-512", [0x04, 0x01], ["decapsulateBits"]],
+    ] as const) {
+      const pkcs8 = Uint8Array.of(
+        0x30,
+        0x14,
+        0x02,
+        0x01,
+        0x00,
+        0x30,
+        0x0b,
+        0x06,
+        0x09,
+        0x60,
+        0x86,
+        0x48,
+        0x01,
+        0x65,
+        0x03,
+        0x04,
+        ...oidSuffix,
+        0x04,
+        0x02,
+        0x30,
+        0x00
+      );
+      await expect(
+        crypto.subtle.importKey("pkcs8", pkcs8, name, false, usages)
+      ).rejects.toHaveProperty("name", "DataError");
+    }
+  });
+});
+
 describe("Modern WebCrypto ML-KEM", () => {
   it("encapsulates and decapsulates bits for every parameter set", async () => {
     const variants = [

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -1,0 +1,79 @@
+import type { webcrypto } from "node:crypto";
+
+describe("Modern WebCrypto key formats", () => {
+  it("aliases raw public and secret key formats", async () => {
+    const hmac = (await crypto.subtle.generateKey(
+      { name: "HMAC", hash: "SHA-256" },
+      true,
+      ["sign"]
+    )) as webcrypto.CryptoKey;
+    const secret = await crypto.subtle.exportKey("raw-secret", hmac);
+    const importedSecret = await crypto.subtle.importKey(
+      "raw-secret",
+      secret,
+      { name: "HMAC", hash: "SHA-256" },
+      true,
+      ["sign"]
+    );
+    expect(await crypto.subtle.exportKey("raw", importedSecret)).toEqual(
+      secret
+    );
+
+    const keyPair = await crypto.subtle.generateKey("Ed25519", true, [
+      "verify",
+    ]);
+    const publicKey = await crypto.subtle.exportKey(
+      "raw-public",
+      keyPair.publicKey
+    );
+    const importedPublic = await crypto.subtle.importKey(
+      "raw-public",
+      publicKey,
+      "Ed25519",
+      true,
+      ["verify"]
+    );
+    expect(await crypto.subtle.exportKey("raw", importedPublic)).toEqual(
+      publicKey
+    );
+  });
+
+  it("rejects recognized key formats unsupported by an algorithm", async () => {
+    for (const format of ["raw-private", "raw-seed"] as const) {
+      await expect(
+        crypto.subtle.importKey(
+          format,
+          new Uint8Array([1]),
+          { name: "HMAC", hash: "SHA-256" },
+          false,
+          ["sign"]
+        )
+      ).rejects.toHaveProperty("name", "NotSupportedError");
+    }
+  });
+
+  it("rejects raw-public export of private keys as invalid access", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign", "verify"]
+    );
+    await expect(
+      crypto.subtle.exportKey("raw-public", keyPair.privateKey)
+    ).rejects.toHaveProperty("name", "InvalidAccessError");
+
+    const wrappingKey = await crypto.subtle.generateKey(
+      { name: "AES-KW", length: 128 },
+      false,
+      ["wrapKey"]
+    );
+    await expect(
+      crypto.subtle.wrapKey(
+        "raw-public",
+        keyPair.privateKey,
+        wrappingKey,
+        "AES-KW"
+      )
+    ).rejects.toHaveProperty("name", "InvalidAccessError");
+  });
+});

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -812,3 +812,92 @@ describe("Modern WebCrypto hybrid KEMs", () => {
     ).rejects.toHaveProperty("name", "NotSupportedError");
   });
 });
+
+describe("SubtleCrypto.getPublicKey", () => {
+  it("is a branded prototype method", async () => {
+    const prototype = Object.getPrototypeOf(crypto.subtle);
+    expect(Object.hasOwn(crypto.subtle, "getPublicKey")).toBe(false);
+    expect(Object.hasOwn(prototype, "getPublicKey")).toBe(true);
+
+    const keyPair = await crypto.subtle.generateKey("Ed25519", false, [
+      "sign",
+    ]);
+    expect(() =>
+      Reflect.apply(crypto.subtle.getPublicKey, {}, [keyPair.privateKey, []])
+    ).toThrow(TypeError);
+  });
+
+  it("derives public keys for every asymmetric family", async () => {
+    const cases = [
+      [{ name: "ECDSA", namedCurve: "P-256" }, ["sign", "verify"], ["verify"]],
+      [{ name: "ECDH", namedCurve: "P-256" }, ["deriveBits"], []],
+      ["Ed25519", ["sign", "verify"], ["verify"]],
+      ["X25519", ["deriveBits"], []],
+      [
+        {
+          name: "RSA-PSS",
+          modulusLength: 1024,
+          publicExponent: new Uint8Array([1, 0, 1]),
+          hash: "SHA-256",
+        },
+        ["sign", "verify"],
+        ["verify"],
+      ],
+      ["ML-DSA-44", ["sign", "verify"], ["verify"]],
+      [
+        "ML-KEM-512",
+        ["encapsulateBits", "decapsulateBits"],
+        ["encapsulateBits"],
+      ],
+      [
+        "MLKEM768-X25519",
+        ["encapsulateBits", "decapsulateBits"],
+        ["encapsulateBits"],
+      ],
+    ] as const;
+
+    for (const [algorithm, keyUsages, publicUsages] of cases) {
+      const keyPair = await crypto.subtle.generateKey(
+        algorithm,
+        true,
+        keyUsages
+      );
+      const publicKey = await crypto.subtle.getPublicKey(
+        keyPair.privateKey,
+        publicUsages
+      );
+      expect(publicKey.type).toBe("public");
+      expect(publicKey.extractable).toBe(true);
+      expect(publicKey.usages).toEqual(publicUsages);
+      expect(await crypto.subtle.exportKey("jwk", publicKey)).toEqual(
+        await crypto.subtle.exportKey("jwk", keyPair.publicKey)
+      );
+    }
+  }, 30000);
+
+  it("rejects non-private and symmetric keys", async () => {
+    const keyPair = await crypto.subtle.generateKey("Ed25519", false, [
+      "sign",
+      "verify",
+    ]);
+    await expect(
+      crypto.subtle.getPublicKey(keyPair.publicKey, ["verify"])
+    ).rejects.toHaveProperty("name", "InvalidAccessError");
+    await expect(
+      crypto.subtle.getPublicKey(keyPair.publicKey, ["sign"])
+    ).rejects.toHaveProperty("name", "InvalidAccessError");
+
+    const secret = await crypto.subtle.generateKey(
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    await expect(crypto.subtle.getPublicKey(secret, [])).rejects.toHaveProperty(
+      "name",
+      "NotSupportedError"
+    );
+    await expect(
+      crypto.subtle.getPublicKey(secret, ["encrypt"])
+    ).rejects.toHaveProperty("name", "NotSupportedError");
+  });
+});

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -105,3 +105,87 @@ describe("Modern WebCrypto SHA-3", () => {
     ).rejects.toHaveProperty("name", "NotSupportedError");
   });
 });
+
+describe("Modern WebCrypto XOF digests", () => {
+  it("matches cSHAKE and TurboSHAKE vectors", async () => {
+    const vectors = [
+      [
+        { name: "cSHAKE128", outputLength: 256 },
+        "7f9c2ba4e88f827d616045507605853ed73b8093f6efbc88eb1a6eacfa66ef26",
+      ],
+      [
+        { name: "TurboSHAKE128", outputLength: 256 },
+        "1e415f1c5983aff2169217277d17bb538cd945a397ddec541f1ce41af2c1b74c",
+      ],
+    ] as const;
+
+    for (const [algorithm, expected] of vectors) {
+      const digest = new Uint8Array(
+        await crypto.subtle.digest(algorithm, new Uint8Array())
+      );
+      expect(Buffer.from(digest).toString("hex")).toBe(expected);
+    }
+  });
+
+  it("supports partial-bit cSHAKE output", async () => {
+    const digest = new Uint8Array(
+      await crypto.subtle.digest(
+        { name: "cSHAKE256", outputLength: 9 },
+        new Uint8Array()
+      )
+    );
+    expect(digest.byteLength).toBe(2);
+    expect(digest[1] & 0x7f).toBe(0);
+  });
+
+  it("validates XOF parameters", async () => {
+    expect(
+      await crypto.subtle.digest(
+        { name: "cSHAKE128", outputLength: null as unknown as number },
+        new Uint8Array()
+      )
+    ).toHaveProperty("byteLength", 0);
+
+    await expect(
+      crypto.subtle.digest(
+        { name: "TurboSHAKE128", outputLength: null as unknown as number },
+        new Uint8Array()
+      )
+    ).rejects.toMatchObject({ name: "OperationError" });
+
+    await expect(
+      crypto.subtle.digest(
+        { name: "cSHAKE128", outputLength: 0xffffffff },
+        new Uint8Array()
+      )
+    ).rejects.toMatchObject({ name: "OperationError" });
+
+    for (const domainSeparation of [0, 0x80, null]) {
+      await expect(
+        crypto.subtle.digest(
+          {
+            name: "TurboSHAKE128",
+            outputLength: 256,
+            domainSeparation: domainSeparation as unknown as number,
+          },
+          new Uint8Array()
+        )
+      ).rejects.toMatchObject({ name: "OperationError" });
+    }
+  });
+
+  it("rejects null cSHAKE BufferSource parameters", async () => {
+    for (const parameter of ["functionName", "customization"] as const) {
+      await expect(
+        crypto.subtle.digest(
+          {
+            name: "cSHAKE128",
+            outputLength: 256,
+            [parameter]: null,
+          },
+          new Uint8Array()
+        )
+      ).rejects.toThrow(TypeError);
+    }
+  });
+});

--- a/tests/unit/crypto.subtle.modern.test.ts
+++ b/tests/unit/crypto.subtle.modern.test.ts
@@ -1005,18 +1005,23 @@ describe("SubtleCrypto.supports", () => {
     expect(() => supports("digest", "SHA-256", 2 ** 32)).toThrow(TypeError);
   });
 
-  it("reports RustCrypto RSA generation limits", () => {
+  it("reports provider key generation limits", async () => {
     const algorithm = {
       name: "RSA-PSS",
       hash: "SHA-256",
       publicExponent: new Uint8Array([1, 0, 1]),
     };
-    expect(supports("generateKey", { ...algorithm, modulusLength: 512 })).toBe(
-      false
-    );
-    expect(supports("generateKey", { ...algorithm, modulusLength: 1024 })).toBe(
-      true
-    );
+    const rsa512 = { ...algorithm, modulusLength: 512 };
+    const canGenerateRsa512 = await crypto.subtle
+      .generateKey(rsa512, false, ["sign"])
+      .then(
+        () => true,
+        () => false
+      );
+    expect(supports("generateKey", rsa512)).toBe(canGenerateRsa512);
+    expect(
+      supports("generateKey", { ...algorithm, modulusLength: 1024 })
+    ).toBe(true);
     expect(
       supports("generateKey", { name: "HMAC", hash: "SHA-256", length: 1024 })
     ).toBe(true);

--- a/tests/unit/crypto.subtle.test.ts
+++ b/tests/unit/crypto.subtle.test.ts
@@ -2227,6 +2227,55 @@ fullCrypto("SubtileCrypto import/export", () => {
     }
   }, 30000);
 
+  it("preserves leading zeroes in private EC JWK values", async () => {
+    const keys = [
+      {
+        crv: "P-256",
+        x: "mGriUG8f8QTQQjCGHY9LSY9LxMbQCbMPdUTcEpuC0o0",
+        y: "ADzMwKZGDgrjKKTZfTx7YdhvxiicGJ8lJREMRBuwfpc",
+        d: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACs",
+      },
+      {
+        crv: "P-384",
+        x: "0DqnSPX0jrPgxUtoPyXS4tfX4yASgqlbV6Wf-4-Uz0xDsRB8qUS5IRw1ERLeFu0Y",
+        y: "AAoIxgLcXgAx2tCIwZMF9rJSorw_JF96W4C0hMe5n2mBwyN0xxSnaDJV9TMfZrsG",
+        d: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACw",
+      },
+      {
+        crv: "P-521",
+        x: "AMaFjga3BATpzZ4-y2YjlbRCnGSBOQU_tSH4KK9ga009uqFLXnfv51ko_h3BJ6L_qN4zSLPBhWpCm_l-fjHC5b1m",
+        y: "ARg5KWp4mjvABFyKX7QsfRvZmPVESVebRGgXr70XJz5mLJfucple9CZAxVC5AT-tB2E1PHCGonLCQIi-lHaf0WZQ",
+        d: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB",
+      },
+    ];
+
+    for (const { crv, x, y, d } of keys) {
+      const jwk = {
+        kty: "EC",
+        crv,
+        x,
+        y,
+        d,
+        ext: true,
+        key_ops: ["sign"],
+      };
+      const key = await crypto.subtle.importKey(
+        "jwk",
+        jwk,
+        { name: "ECDSA", namedCurve: crv },
+        true,
+        ["sign"]
+      );
+      const exported = await crypto.subtle.exportKey("jwk", key);
+
+      expect({ x: exported.x, y: exported.y, d: exported.d }).toEqual({
+        x,
+        y,
+        d,
+      });
+    }
+  });
+
   it("should import and export an Ed25519 private JWK", async () => {
     const algorithm = {
       name: "Ed25519",

--- a/tests/wpt/WebCryptoAPI.digest.test.ts
+++ b/tests/wpt/WebCryptoAPI.digest.test.ts
@@ -1,3 +1,9 @@
 import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
 
-runSuite(import.meta.url, runTestDynamic);
+runSuite(import.meta.url, runTestDynamic, [], {
+  tentativeFiles: [
+    "cshake.tentative.https.any.js",
+    "sha3.tentative.https.any.js",
+    "turboshake.tentative.https.any.js",
+  ],
+});

--- a/tests/wpt/WebCryptoAPI.encap_decap.test.ts
+++ b/tests/wpt/WebCryptoAPI.encap_decap.test.ts
@@ -1,5 +1,8 @@
 import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
 
 runSuite(import.meta.url, runTestDynamic, [], {
-  tentativeFiles: ["mldsa.tentative.https.any.js"],
+  tentativeFiles: [
+    "encap_decap_bits.tentative.https.any.js",
+    "encap_decap_keys.tentative.https.any.js",
+  ],
 });

--- a/tests/wpt/WebCryptoAPI.encrypt_decrypt.test.ts
+++ b/tests/wpt/WebCryptoAPI.encrypt_decrypt.test.ts
@@ -1,5 +1,12 @@
 import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
 
-runSuite(import.meta.url, runTestDynamic, [
-  "aes_gcm_256_iv.https.any.js", // NOTICE: Only 96-bit IVs are supported
-]);
+runSuite(
+  import.meta.url,
+  runTestDynamic,
+  [
+    "aes_gcm_256_iv.https.any.js", // Only 96-bit IVs are supported.
+  ],
+  {
+    tentativeFiles: ["chacha20_poly1305.tentative.https.any.js"],
+  }
+);

--- a/tests/wpt/WebCryptoAPI.generateKey.test.ts
+++ b/tests/wpt/WebCryptoAPI.generateKey.test.ts
@@ -1,7 +1,23 @@
 import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
 
-runSuite(import.meta.url, runTestDynamic, [
-  "successes_RSA-OAEP.https.any.js", // Error: Test timed out after 5000ms
-  "successes_RSA-PSS.https.any.js", // Error: Test timed out after 5000ms
-  "successes_RSASSA-PKCS1-v1_5.https.any.js", // Error: Test timed out after 5000ms
-]);
+runSuite(
+  import.meta.url,
+  runTestDynamic,
+  [
+    "successes_RSA-OAEP.https.any.js", // Error: Test timed out after 5000ms
+    "successes_RSA-PSS.https.any.js", // Error: Test timed out after 5000ms
+    "successes_RSASSA-PKCS1-v1_5.https.any.js", // Error: Test timed out after 5000ms
+  ],
+  {
+    tentativeFiles: [
+      "failures_chacha20_poly1305.tentative.https.any.js",
+      "failures_Hybrid-KEM.tentative.https.any.js",
+      "failures_ML-DSA.tentative.https.any.js",
+      "failures_ML-KEM.tentative.https.any.js",
+      "successes_chacha20_poly1305.tentative.https.any.js",
+      "successes_Hybrid-KEM.tentative.https.any.js",
+      "successes_ML-DSA.tentative.https.any.js",
+      "successes_ML-KEM.tentative.https.any.js",
+    ],
+  }
+);

--- a/tests/wpt/WebCryptoAPI.getPublicKey.test.ts
+++ b/tests/wpt/WebCryptoAPI.getPublicKey.test.ts
@@ -1,0 +1,12 @@
+import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
+
+runSuite(
+  import.meta.url,
+  runTestDynamic,
+  [["getPublicKey.tentative.https.any.js", /(?:Ed448|X448)/]],
+  {
+    subDir: "WebCryptoAPI",
+    filePattern: /^getPublicKey\.tentative\.https\.any\.js$/,
+    tentativeFiles: ["getPublicKey.tentative.https.any.js"],
+  }
+);

--- a/tests/wpt/WebCryptoAPI.import_export.test.ts
+++ b/tests/wpt/WebCryptoAPI.import_export.test.ts
@@ -1,3 +1,11 @@
 import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
 
-runSuite(import.meta.url, runTestDynamic);
+runSuite(import.meta.url, runTestDynamic, [], {
+  tentativeFiles: [
+    "ChaCha20-Poly1305_importKey.tentative.https.any.js",
+    "Hybrid-KEM_importKey.tentative.https.any.js",
+    "ML-DSA_importKey.tentative.https.any.js",
+    "ML-KEM_importKey.tentative.https.any.js",
+    "raw_format_aliases.tentative.https.any.js",
+  ],
+});

--- a/tests/wpt/WebCryptoAPI.serialization.test.ts
+++ b/tests/wpt/WebCryptoAPI.serialization.test.ts
@@ -1,3 +1,11 @@
 import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
 
-runSuite(import.meta.url, runTestDynamic);
+runSuite(import.meta.url, runTestDynamic, [], {
+  tentativeFiles: [
+    "chacha20-poly1305.tentative.https.any.js",
+    "hybridkem.tentative.https.window.js",
+    "mldsa.tentative.https.any.js",
+    "mlkem.tentative.https.any.js",
+  ],
+  filePattern: /\.(?:any|window)\.js$/,
+});

--- a/tests/wpt/WebCryptoAPI.supports.test.ts
+++ b/tests/wpt/WebCryptoAPI.supports.test.ts
@@ -1,0 +1,10 @@
+import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
+
+runSuite(import.meta.url, runTestDynamic, [], {
+  subDir: "WebCryptoAPI",
+  filePattern: /^supports(?:-modern)?\.tentative\.https\.any\.js$/,
+  tentativeFiles: [
+    "supports-modern.tentative.https.any.js",
+    "supports.tentative.https.any.js",
+  ],
+});

--- a/tests/wpt/WebCryptoAPI.wrapKey_unwrapKey.test.ts
+++ b/tests/wpt/WebCryptoAPI.wrapKey_unwrapKey.test.ts
@@ -3,9 +3,6 @@ import { runSuite, runTestDynamic } from "./WebCryptoAPI.harness.js";
 runSuite(import.meta.url, runTestDynamic, [
   [
     "wrapKey_unwrapKey.https.any.js",
-    [
-      "[setup] Key import/export format must be 'jwk','raw','spki' or 'pkcs8'", // 'raw-secret' is not supported.
-      /(?:using .* and AES-GCM|AES-GCM.*non-extractable)/, // Upstream vectors use a 128-bit IV; only 96-bit IVs are supported.
-    ],
+    /(?:using .* and AES-GCM|AES-GCM.*non-extractable)/, // Upstream vectors use a 128-bit IV; only 96-bit IVs are supported.
   ],
 ]);

--- a/tests/wpt/_harness-util.js
+++ b/tests/wpt/_harness-util.js
@@ -144,7 +144,7 @@ function baseRunSuite(
   metaUrl,
   harness,
   skipFiles = [],
-  { filePattern, subDir } = {}
+  { filePattern, subDir, tentativeFiles = [] } = {}
 ) {
   const finalSubDir = subDir ?? deriveDefaultSubDir(metaUrl);
   const finalPattern = filePattern ?? /\.any\.js$/;
@@ -156,29 +156,44 @@ function baseRunSuite(
     return false;
   };
 
+  const directoryFiles = fs.readdirSync(targetDir);
+  for (const file of tentativeFiles) {
+    if (!directoryFiles.includes(file)) {
+      throw new Error(`Tentative WPT allowlist entry not found: ${file}`);
+    }
+  }
+  const enabledTentativeFiles = new Set(tentativeFiles);
+
   const skip = (f) =>
-    /\.tentative\./.test(f) ||
+    (/\.tentative\./.test(f) && !enabledTentativeFiles.has(f)) ||
     skipFiles.some((s) => !Array.isArray(s) && matchesFile(f, s));
-  const testFiles = fs
-    .readdirSync(targetDir)
-    .filter((f) => finalPattern.test(f) && !skip(f));
+  const testFiles = directoryFiles.filter(
+    (f) => finalPattern.test(f) && !skip(f)
+  );
 
   describe(finalSubDir, () => {
     for (const file of testFiles) {
-      it(`should pass ${file} tests`, (done) => {
-        const source = fs.readFileSync(path.join(targetDir, file), "utf8");
-        const fileErrorSkipRules = skipFiles.filter(
-          (s) => Array.isArray(s) && matchesFile(file, s[0])
-        );
-        const skipErrors = fileErrorSkipRules.flatMap((s) =>
-          Array.isArray(s[1]) ? s[1] : [s[1]]
-        );
-        harness(source, done, {
-          baseDir: WPT_DIR,
-          testDir: targetDir,
-          ...(skipErrors.length > 0 ? { skipErrors } : {}),
-        });
-      });
+      const source = fs.readFileSync(path.join(targetDir, file), "utf8");
+      const timeout = /^\s*\/\/\s*META:\s*timeout=long\s*$/m.test(source)
+        ? 60_000
+        : undefined;
+      it(
+        `should pass ${file} tests`,
+        (done) => {
+          const fileErrorSkipRules = skipFiles.filter(
+            (s) => Array.isArray(s) && matchesFile(file, s[0])
+          );
+          const skipErrors = fileErrorSkipRules.flatMap((s) =>
+            Array.isArray(s[1]) ? s[1] : [s[1]]
+          );
+          harness(source, done, {
+            baseDir: WPT_DIR,
+            testDir: targetDir,
+            ...(skipErrors.length > 0 ? { skipErrors } : {}),
+          });
+        },
+        timeout
+      );
     }
   });
 }
@@ -195,10 +210,11 @@ export function makeRunnerWPT(config) {
   return baseRunner(config);
 }
 
-export function runSuiteWPT(metaUrl, harness, skipFiles = []) {
+export function runSuiteWPT(metaUrl, harness, skipFiles = [], options = {}) {
   return baseRunSuite(metaUrl, harness, skipFiles, {
-    filePattern: /\.any\.js$/,
-    subDir: deriveSubDir(metaUrl),
+    ...options,
+    filePattern: options.filePattern ?? /\.any\.js$/,
+    subDir: options.subDir ?? deriveSubDir(metaUrl),
   });
 }
 

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -618,6 +618,9 @@ declare module "crypto" {
        * - `'SHA-256'`
        * - `'SHA-384'`
        * - `'SHA-512'`
+       * - `'SHA3-256'`
+       * - `'SHA3-384'`
+       * - `'SHA3-512'`
        *
        * If `algorithm` is provided as an `<Object>`, it must have a `name` property whose value is one of the above.
        */

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -387,6 +387,11 @@ declare module "crypto" {
     interface AesKeyGenParams extends Algorithm {
       length: number;
     }
+    interface CShakeParams extends Algorithm {
+      customization?: BufferSource;
+      functionName?: BufferSource;
+      outputLength: number;
+    }
     interface Algorithm {
       name: string;
     }
@@ -480,6 +485,10 @@ declare module "crypto" {
     }
     interface RsaPssParams extends Algorithm {
       saltLength: number;
+    }
+    interface TurboShakeParams extends Algorithm {
+      domainSeparation?: number;
+      outputLength: number;
     }
 
     interface CryptoKey {
@@ -621,11 +630,15 @@ declare module "crypto" {
        * - `'SHA3-256'`
        * - `'SHA3-384'`
        * - `'SHA3-512'`
+       * - `'cSHAKE128'`
+       * - `'cSHAKE256'`
+       * - `'TurboSHAKE128'`
+       * - `'TurboSHAKE256'`
        *
        * If `algorithm` is provided as an `<Object>`, it must have a `name` property whose value is one of the above.
        */
       digest(
-        algorithm: AlgorithmIdentifier,
+        algorithm: AlgorithmIdentifier | CShakeParams | TurboShakeParams,
         data: BufferSource
       ): Promise<ArrayBuffer>;
       /**

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -411,9 +411,10 @@ declare module "crypto" {
     interface EcdsaParams extends Algorithm {
       hash: HashAlgorithmIdentifier;
     }
-    interface Ed448Params extends Algorithm {
+    interface ContextParams extends Algorithm {
       context?: BufferSource;
     }
+    interface Ed448Params extends ContextParams {}
     interface HkdfParams extends Algorithm {
       hash: HashAlgorithmIdentifier;
       info: BufferSource;
@@ -445,6 +446,8 @@ declare module "crypto" {
       n?: string;
       oth?: RsaOtherPrimesInfo[];
       p?: string;
+      priv?: string;
+      pub?: string;
       q?: string;
       qi?: string;
       use?: string;
@@ -697,6 +700,9 @@ declare module "crypto" {
        * - `'ECDSA'`
        * - `'ECDH'`
        * - `'Ed25519'`
+       * - `'ML-DSA-44'`
+       * - `'ML-DSA-65'`
+       * - `'ML-DSA-87'`
        * The `<CryptoKey>` (secret key) generating algorithms supported include:
        *
        * - `'HMAC'`
@@ -767,13 +773,16 @@ declare module "crypto" {
        * - `'ECDSA'`
        * - `'Ed25519'`
        * - `'HMAC'`
+       * - `'ML-DSA-44'`
+       * - `'ML-DSA-65'`
+       * - `'ML-DSA-87'`
        */
       sign(
         algorithm:
           | AlgorithmIdentifier
           | RsaPssParams
           | EcdsaParams
-          | Ed448Params,
+          | ContextParams,
         key: CryptoKey,
         data: BufferSource
       ): Promise<ArrayBuffer>;
@@ -838,13 +847,16 @@ declare module "crypto" {
        * - `'ECDSA'`
        * - `'Ed25519'`
        * - `'HMAC'`
+       * - `'ML-DSA-44'`
+       * - `'ML-DSA-65'`
+       * - `'ML-DSA-87'`
        */
       verify(
         algorithm:
           | AlgorithmIdentifier
           | RsaPssParams
           | EcdsaParams
-          | Ed448Params,
+          | ContextParams,
         key: CryptoKey,
         signature: BufferSource,
         data: BufferSource

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -354,9 +354,13 @@ declare module "crypto" {
       | "spki";
     type KeyType = "private" | "public" | "secret";
     type KeyUsage =
+      | "decapsulateBits"
+      | "decapsulateKey"
       | "decrypt"
       | "deriveBits"
       | "deriveKey"
+      | "encapsulateBits"
+      | "encapsulateKey"
       | "encrypt"
       | "sign"
       | "unwrapKey"
@@ -520,6 +524,10 @@ declare module "crypto" {
        * - `'deriveBits'` - The key may be used to derive bits.
        * - `'wrapKey'` - The key may be used to wrap another key.
        * - `'unwrapKey'` - The key may be used to unwrap another key.
+       * - `'encapsulateKey'` - The key may be used to encapsulate a shared key.
+       * - `'encapsulateBits'` - The key may be used to encapsulate shared bits.
+       * - `'decapsulateKey'` - The key may be used to decapsulate a shared key.
+       * - `'decapsulateBits'` - The key may be used to decapsulate shared bits.
        *
        * Valid key usages depend on the key algorithm (identified by `cryptokey.algorithm.name`).
        * @since v15.0.0
@@ -538,6 +546,14 @@ declare module "crypto" {
        * A {@link CryptoKey} whose type will be `'public'`.
        */
       publicKey: CryptoKey;
+    }
+    interface EncapsulatedBits {
+      ciphertext: ArrayBuffer;
+      sharedKey: ArrayBuffer;
+    }
+    interface EncapsulatedKey {
+      ciphertext: ArrayBuffer;
+      sharedKey: CryptoKey;
     }
 
     interface SubtleCrypto {
@@ -622,6 +638,19 @@ declare module "crypto" {
         extractable: boolean,
         keyUsages: readonly KeyUsage[]
       ): Promise<CryptoKey>;
+      decapsulateBits(
+        algorithm: AlgorithmIdentifier,
+        decapsulationKey: CryptoKey,
+        ciphertext: BufferSource
+      ): Promise<ArrayBuffer>;
+      decapsulateKey(
+        algorithm: AlgorithmIdentifier,
+        decapsulationKey: CryptoKey,
+        ciphertext: BufferSource,
+        sharedKeyAlgorithm: AlgorithmIdentifier,
+        extractable: boolean,
+        keyUsages: readonly KeyUsage[]
+      ): Promise<CryptoKey>;
       /**
        * Using the method identified by `algorithm`, `subtle.digest()` attempts to generate a digest of `data`.
        * If successful, the returned promise is resolved with an `<ArrayBuffer>` containing the computed digest.
@@ -646,6 +675,17 @@ declare module "crypto" {
         algorithm: AlgorithmIdentifier | CShakeParams | TurboShakeParams,
         data: BufferSource
       ): Promise<ArrayBuffer>;
+      encapsulateBits(
+        algorithm: AlgorithmIdentifier,
+        encapsulationKey: CryptoKey
+      ): Promise<EncapsulatedBits>;
+      encapsulateKey(
+        algorithm: AlgorithmIdentifier,
+        encapsulationKey: CryptoKey,
+        sharedKeyAlgorithm: AlgorithmIdentifier,
+        extractable: boolean,
+        keyUsages: readonly KeyUsage[]
+      ): Promise<EncapsulatedKey>;
       /**
        * Using the method and parameters specified by `algorithm` and the keying material provided by `key`,
        * `subtle.encrypt()` attempts to encipher `data`. If successful,
@@ -703,6 +743,9 @@ declare module "crypto" {
        * - `'ML-DSA-44'`
        * - `'ML-DSA-65'`
        * - `'ML-DSA-87'`
+       * - `'ML-KEM-512'`
+       * - `'ML-KEM-768'`
+       * - `'ML-KEM-1024'`
        * The `<CryptoKey>` (secret key) generating algorithms supported include:
        *
        * - `'HMAC'`

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -774,6 +774,10 @@ declare module "crypto" {
         extractable: boolean,
         keyUsages: KeyUsage[]
       ): Promise<CryptoKeyPair | CryptoKey>;
+      getPublicKey(
+        key: CryptoKey,
+        keyUsages: readonly KeyUsage[]
+      ): Promise<CryptoKey>;
       /**
        * The `subtle.importKey()` method attempts to interpret the provided `keyData` as the given `format`
        * to create a `<CryptoKey>` instance using the provided `algorithm`, `extractable`, and `keyUsages` arguments.

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -343,7 +343,15 @@ declare module "crypto" {
    */
   namespace webcrypto {
     type BufferSource = ArrayBufferView | ArrayBuffer;
-    type KeyFormat = "jwk" | "pkcs8" | "raw" | "spki";
+    type KeyFormat =
+      | "jwk"
+      | "pkcs8"
+      | "raw"
+      | "raw-private"
+      | "raw-public"
+      | "raw-secret"
+      | "raw-seed"
+      | "spki";
     type KeyType = "private" | "public" | "secret";
     type KeyUsage =
       | "decrypt"

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -376,11 +376,12 @@ declare module "crypto" {
     interface AesDerivedKeyParams extends Algorithm {
       length: number;
     }
-    interface AesGcmParams extends Algorithm {
+    interface AeadParams extends Algorithm {
       additionalData?: BufferSource;
       iv: BufferSource;
       tagLength?: number;
     }
+    interface AesGcmParams extends AeadParams {}
     interface AesKeyAlgorithm extends KeyAlgorithm {
       length: number;
     }
@@ -548,6 +549,7 @@ declare module "crypto" {
        * - `'AES-CTR'`
        * - `'AES-CBC'`
        * - `'AES-GCM'`
+       * - `'ChaCha20-Poly1305'`
        */
       decrypt(
         algorithm:
@@ -555,7 +557,7 @@ declare module "crypto" {
           | RsaOaepParams
           | AesCtrParams
           | AesCbcParams
-          | AesGcmParams,
+          | AeadParams,
         key: CryptoKey,
         data: BufferSource
       ): Promise<ArrayBuffer>;
@@ -652,6 +654,7 @@ declare module "crypto" {
        * - `'AES-CTR'`
        * - `'AES-CBC'`
        * - `'AES-GCM'`
+       * - `'ChaCha20-Poly1305'`
        */
       encrypt(
         algorithm:
@@ -659,7 +662,7 @@ declare module "crypto" {
           | RsaOaepParams
           | AesCtrParams
           | AesCbcParams
-          | AesGcmParams,
+          | AeadParams,
         key: CryptoKey,
         data: BufferSource
       ): Promise<ArrayBuffer>;
@@ -701,6 +704,7 @@ declare module "crypto" {
        * - `'AES-CBC'`
        * - `'AES-GCM'`
        * - `'AES-KW'`
+       * - `'ChaCha20-Poly1305'`
        * @param keyUsages See {@link https://nodejs.org/docs/latest/api/webcrypto.html#cryptokeyusages Key usages}.
        */
       generateKey(
@@ -812,7 +816,7 @@ declare module "crypto" {
           | RsaOaepParams
           | AesCtrParams
           | AesCbcParams
-          | AesGcmParams,
+          | AeadParams,
         unwrappedKeyAlgorithm:
           | AlgorithmIdentifier
           | RsaHashedImportParams
@@ -871,7 +875,7 @@ declare module "crypto" {
           | RsaOaepParams
           | AesCtrParams
           | AesCbcParams
-          | AesGcmParams
+          | AeadParams
       ): Promise<ArrayBuffer>;
     }
   }

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -746,6 +746,9 @@ declare module "crypto" {
        * - `'ML-KEM-512'`
        * - `'ML-KEM-768'`
        * - `'ML-KEM-1024'`
+       * - `'MLKEM768-P256'`
+       * - `'MLKEM768-X25519'`
+       * - `'MLKEM1024-P384'`
        * The `<CryptoKey>` (secret key) generating algorithms supported include:
        *
        * - `'HMAC'`

--- a/types/crypto.d.ts
+++ b/types/crypto.d.ts
@@ -555,8 +555,22 @@ declare module "crypto" {
       ciphertext: ArrayBuffer;
       sharedKey: CryptoKey;
     }
+    interface SubtleCryptoConstructor {
+      readonly prototype: SubtleCrypto;
+      supports(
+        operation: string,
+        algorithm: AlgorithmIdentifier,
+        length?: number | null
+      ): boolean;
+      supports(
+        operation: string,
+        algorithm: AlgorithmIdentifier,
+        additionalAlgorithm: AlgorithmIdentifier
+      ): boolean;
+    }
 
     interface SubtleCrypto {
+      readonly constructor: SubtleCryptoConstructor;
       /**
        * Using the method and parameters specified in `algorithm` and the keying material provided by `key`,
        * `subtle.decrypt()` attempts to decipher the provided `data`. If successful,

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -1,4 +1,7 @@
+FileAPI/blob > should pass Blob-constructor-detached-buffer.any.js tests
+FileAPI/blob > should pass Blob-textStream.any.js tests
 WebCryptoAPI > should pass historical.any.js tests
+encoding > should pass single-byte-decoder.any.js tests
 fetch/api/basic > should pass conditional-get.any.js tests
 fetch/api/basic > should pass header-value-combining.any.js tests
 fetch/api/basic > should pass integrity.sub.any.js tests
@@ -7,6 +10,9 @@ fetch/api/basic > should pass mode-same-origin.any.js tests
 fetch/api/basic > should pass referrer.any.js tests
 fetch/api/basic > should pass request-headers-case.any.js tests
 fetch/api/basic > should pass request-referrer.any.js tests
+fetch/api/body > should pass textstream.any.js tests
+streams/readable-byte-streams > should pass tee.any.js tests
+streams/readable-streams > should pass from.any.js tests
 streams/transferable > should pass transform-stream-members.any.js tests
 streams/transform-streams > should pass strategies.any.js tests
 streams/transform-streams > should pass terminate.any.js tests
@@ -20,4 +26,5 @@ third_party/test262/test/intl402/Temporal/ZonedDateTime/compare > should pass in
 third_party/test262/test/intl402/Temporal/ZonedDateTime/compare > should pass sub-minute-offset.js tests
 url > should pass IdnaTestV2.any.js tests
 url > should pass url-constructor.any.js tests
+url > should pass url-origin.any.js tests
 url > should pass url-setters.any.js tests


### PR DESCRIPTION
Followup to #1743 this implements a subset of https://wicg.github.io/webcrypto-modern-algos/ + https://github.com/WICG/webcrypto-modern-algos/pull/67

- `ML-KEM` + encap/decap methods
- Hybrid KEMs
- `ML-DSA`
- `ChaCha20-Poly1305`
- `SHA-3` as digest only
- `cSHAKE` as digest only
- `TurboSHAKE` as digest only
- `SubtleCrypto.supports(operation, algorithm)`
- `SubtleCrypto.prototype.getPublicKey(key, keyUsages)`
- `raw-{secret,public,private,seed}` key formats and `raw` to `raw-secret/raw-public` aliases for existing algorithms

Refs: #1738