### PR TITLE
chore(wpt): Normalize test exclusion criteria to uncover previously hidden errors

### DIFF
--- a/tests/wpt/FileAPI.blob.test.ts
+++ b/tests/wpt/FileAPI.blob.test.ts
@@ -1,10 +1,9 @@
 import { runSuite, runTestDynamic } from "./FileAPI.harness.js";
 
 runSuite(import.meta.url, runTestDynamic, [
+  ["Blob-constructor.any.js", [/MessageChannel is not defined/]],
   [
-    "Blob-constructor.any.js",
-    [
-      "[Passing a FrozenArray as the blobParts array should work (FrozenArray<MessagePort>).] MessageChannel is not defined",
-    ],
+    "Blob-constructor-detached-buffer.any.js",
+    [/MessageChannel is not defined/],
   ],
 ]);

--- a/tests/wpt/encoding.test.ts
+++ b/tests/wpt/encoding.test.ts
@@ -2,13 +2,17 @@ import { runSuite, runTestDynamic } from "./encoding.harness.js";
 
 runSuite(import.meta.url, runTestDynamic, [
   "idlharness.any.js", // ReferenceError: idl_test is not defined
-  "iso-2022-jp-decoder.any.js", // The "iso-2022-jp" encoding is not supported
-  "replacement-encodings.any.js", // ReferenceError: promise_test is not defined
-  "unsupported-encodings.any.js", // ReferenceError: promise_test is not defined
-  "textdecoder-eof.any.js", // The "Big5" encoding is not supported
-  "textdecoder-fatal-single-byte.any.js", // The "IBM866" encoding is not supported
-  "textdecoder-labels.any.js", // IBM866 / legacy encodings
-  "textdecoder-mistakes.any.js", // legacy single-byte encodings
-  "textencoder-constructor-non-utf.any.js", // IBM866 / legacy encodings
-  "encodeInto.any.js", // needs MessageChannel for the detached-buffer test
+  ["encodeInto.any.js", [/MessageChannel is not defined/]],
+  ["iso-2022-jp-decoder.any.js", [/encoding is not supported/]],
+  ["replacement-encodings.any.js", [/XMLHttpRequest is not defined/]],
+  [
+    "single-byte-decoder.any.js",
+    [/encoding is not supported/, /XMLHttpRequest is not defined/],
+  ],
+  ["textdecoder-eof.any.js", [/encoding is not supported/]],
+  ["textdecoder-fatal-single-byte.any.js", [/encoding is not supported/]],
+  ["textdecoder-labels.any.js", [/encoding is not supported/]],
+  ["textdecoder-mistakes.any.js", [/encoding is not supported/]],
+  ["textencoder-constructor-non-utf.any.js", [/encoding is not supported/]],
+  ["unsupported-encodings.any.js", [/XMLHttpRequest is not defined/]],
 ]);

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -1,7 +1,8 @@
-FileAPI/blob > should pass Blob-constructor-detached-buffer.any.js tests
 FileAPI/blob > should pass Blob-textStream.any.js tests
 WebCryptoAPI > should pass historical.any.js tests
 encoding > should pass single-byte-decoder.any.js tests
+encoding > should pass textdecoder-fatal-single-byte.any.js tests
+encoding > should pass textdecoder-mistakes.any.js tests
 fetch/api/basic > should pass conditional-get.any.js tests
 fetch/api/basic > should pass header-value-combining.any.js tests
 fetch/api/basic > should pass integrity.sub.any.js tests


### PR DESCRIPTION
### Issue # (if available)

n/a

### Description of changes

- Since regular expressions can now be used for error exclusion criteria, we can leverage this to efficiently skip errors caused by unsupported features.
- This brought to light several errors that need to be verified during encoding.
- However, it has not yet been determined whether these errors should be skipped.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
