### PR TITLE
fix(encoding): correct Windows-1252 and streaming decoder behavior

### DIFF
--- a/libs/llrt_encoding/src/lib.rs
+++ b/libs/llrt_encoding/src/lib.rs
@@ -74,7 +74,8 @@ impl Encoder {
         match self {
             Self::Hex => Ok(bytes_to_hex_string(bytes)),
             Self::Base64 => Ok(bytes_to_b64_string(bytes)),
-            Self::Utf8 | Self::Windows1252 => bytes_to_utf8_string(bytes, lossy),
+            Self::Utf8 => bytes_to_utf8_string(bytes, lossy),
+            Self::Windows1252 => Ok(bytes_to_windows1252_string(bytes)),
             Self::Utf16le => bytes_to_utf16_string(bytes, Endian::Little, lossy),
             Self::Utf16be => bytes_to_utf16_string(bytes, Endian::Big, lossy),
         }
@@ -195,6 +196,44 @@ pub fn bytes_to_utf8_string(bytes: &[u8], lossy: bool) -> Result<String, String>
     }
 }
 
+pub fn bytes_to_windows1252_string(bytes: &[u8]) -> String {
+    bytes.iter().map(|&byte| index_windows_1252(byte)).collect()
+}
+
+// https://encoding.spec.whatwg.org/index-windows-1252.txt
+fn index_windows_1252(byte: u8) -> char {
+    match byte {
+        0x80 => '\u{20AC}',
+        0x82 => '\u{201A}',
+        0x83 => '\u{0192}',
+        0x84 => '\u{201E}',
+        0x85 => '\u{2026}',
+        0x86 => '\u{2020}',
+        0x87 => '\u{2021}',
+        0x88 => '\u{02C6}',
+        0x89 => '\u{2030}',
+        0x8A => '\u{0160}',
+        0x8B => '\u{2039}',
+        0x8C => '\u{0152}',
+        0x8E => '\u{017D}',
+        0x91 => '\u{2018}',
+        0x92 => '\u{2019}',
+        0x93 => '\u{201C}',
+        0x94 => '\u{201D}',
+        0x95 => '\u{2022}',
+        0x96 => '\u{2013}',
+        0x97 => '\u{2014}',
+        0x98 => '\u{02DC}',
+        0x99 => '\u{2122}',
+        0x9A => '\u{0161}',
+        0x9B => '\u{203A}',
+        0x9C => '\u{0153}',
+        0x9E => '\u{017E}',
+        0x9F => '\u{0178}',
+        _ => char::from(byte),
+    }
+}
+
 #[derive(Clone, Copy)]
 pub enum Endian {
     Little,
@@ -231,7 +270,10 @@ pub fn bytes_to_utf16_string(bytes: &[u8], endian: Endian, lossy: bool) -> Resul
 
     // Odd trailing byte in lossy mode produces a replacement character
     if lossy && !bytes.len().is_multiple_of(2) {
-        result.push('\u{FFFD}');
+        let last = data16.last().copied();
+        if !matches!(last, Some(0xD800..=0xDBFF)) {
+            result.push('\u{FFFD}');
+        }
     }
 
     Ok(result)
@@ -249,5 +291,13 @@ mod tests {
         assert!(bytes_from_b64_strict(b"-_8=").is_err());
         assert!(bytes_from_b64_strict(b"SGVs bG8=").is_err());
         assert!(bytes_from_b64_strict(b"SGVsbG8").is_err());
+    }
+
+    #[test]
+    fn windows1252_decodes_special_bytes() {
+        assert_eq!(bytes_to_windows1252_string(&[0x80]), "€");
+        assert_eq!(bytes_to_windows1252_string(&[0x82]), "‚");
+        assert_eq!(bytes_to_windows1252_string(&[0x93]), "“");
+        assert_eq!(bytes_to_windows1252_string(&[0xFF]), "ÿ");
     }
 }

--- a/modules/llrt_string_decoder/src/string_decoder.rs
+++ b/modules/llrt_string_decoder/src/string_decoder.rs
@@ -192,7 +192,10 @@ impl StringDecoder {
     }
 
     fn flush(&mut self, ctx: &Ctx<'_>) -> Result<String> {
-        if matches!(self.encoder, Encoder::Utf16le) && self.buffered_bytes % 2 == 1 {
+        let odd_utf16_byte =
+            matches!(self.encoder, Encoder::Utf16le) && self.buffered_bytes % 2 == 1;
+
+        if odd_utf16_byte {
             // Ignore a single trailing byte, like the JS decoder does.
             self.missing_bytes -= 1;
             self.buffered_bytes -= 1;
@@ -202,13 +205,23 @@ impl StringDecoder {
             return Ok(String::new());
         }
 
-        let res = self.make_string(ctx, &self.buffer);
+        let decode_len = self.buffer.len() - usize::from(odd_utf16_byte);
+
+        let mut res = self.make_string(ctx, &self.buffer[..decode_len])?;
+
+        if odd_utf16_byte && decode_len >= 2 {
+            let code_unit =
+                u16::from_le_bytes([self.buffer[decode_len - 2], self.buffer[decode_len - 1]]);
+            if (0xD800..=0xDBFF).contains(&code_unit) {
+                res.push('\u{FFFD}');
+            }
+        }
 
         self.missing_bytes = 0;
         self.buffered_bytes = 0;
         self.buffer.clear();
 
-        res
+        Ok(res)
     }
 }
 

--- a/modules/llrt_util/src/text_decoder.rs
+++ b/modules/llrt_util/src/text_decoder.rs
@@ -146,10 +146,6 @@ impl<'js> TextDecoder {
             &combined
         };
 
-        if !stream {
-            self.bom_seen.set(false);
-        }
-
         // Strip BOM if needed (only on first chunk of a decode sequence)
         if !self.ignore_bom && !self.bom_seen.get() {
             let skip = match self.encoder {
@@ -209,8 +205,19 @@ impl<'js> TextDecoder {
             }
         }
 
-        self.encoder
+        let result = self
+            .encoder
             .encode_to_string(&data[..decode_end], !self.fatal)
-            .or_throw_type(&ctx, "")
+            .inspect_err(|_| {
+                pending.clear();
+                self.bom_seen.set(false);
+            })
+            .or_throw_type(&ctx, "")?;
+
+        if !stream {
+            self.bom_seen.set(false);
+        }
+
+        Ok(result)
     }
 }

--- a/wpt_errors.txt
+++ b/wpt_errors.txt
@@ -1,8 +1,5 @@
 FileAPI/blob > should pass Blob-textStream.any.js tests
 WebCryptoAPI > should pass historical.any.js tests
-encoding > should pass single-byte-decoder.any.js tests
-encoding > should pass textdecoder-fatal-single-byte.any.js tests
-encoding > should pass textdecoder-mistakes.any.js tests
 fetch/api/basic > should pass conditional-get.any.js tests
 fetch/api/basic > should pass header-value-combining.any.js tests
 fetch/api/basic > should pass integrity.sub.any.js tests


### PR DESCRIPTION
### Issue # (if available)

Related #1760 

### Description of changes

Fix encoding behavior for single-byte decoders and streaming text decoders.

- Implement WHATWG Windows-1252 byte-to-character decoding.
- Fix `TextDecoder` BOM state handling across non-streaming decodes.
- Reset pending decoder state when a fatal decoding error occurs.
- Correct UTF-16LE trailing-byte and high-surrogate handling in `StringDecoder`.

### Checklist

- [ ] Created unit tests in `tests/unit` and/or in Rust for my feature if needed
- [x] Ran `make fix` to format JS and apply Clippy auto fixes
- [x] Made sure my code didn't add any additional warnings: `make check`
- [ ] Added relevant type info in `types/` directory
- [ ] Updated documentation if needed ([API.md](API.md)/[README.md](README.md)/Other)

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
